### PR TITLE
Buildtree config cmake 46

### DIFF
--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -353,7 +353,7 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_ALL_ST_NoFortran
       "WithSubpackages_INCLUDE_DIRS = .+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran;.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/with_subpackages/b/src;.+/TribitsExampleProject/packages/with_subpackages/b/src;.+/TribitsExampleProject/packages/with_subpackages/a;.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/simple_cxx/src;.+/TribitsExampleProject/packages/simple_cxx/src;.+/tpls/HeaderOnlyTpl;.+/TribitsExampleProject/packages/with_subpackages/c"
       "WithSubpackages_LIBRARY_DIRS = '.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/with_subpackages/b/src;.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/with_subpackages/a;.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/simple_cxx/src;.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/with_subpackages/c'"
       "WithSubpackages_LIBRARIES = 'pws_c.pws_b.pws_a.simplecxx'"
-      "WithSubpackages_TPL_INCLUDE_DIRS = '.+/doc/examples/tpls/HeaderOnlyTpl'"
+      "WithSubpackages_TPL_INCLUDE_DIRS = '.+/tribits/examples/tpls/HeaderOnlyTpl'"
       "WithSubpackages_TPL_LIBRARY_DIRS = ''"
       "WithSubpackages_TPL_LIBRARIES = ''"
       "WithSubpackages_MPI_LIBRARIES = ''"

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -330,7 +330,44 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_ALL_ST_NoFortran
       "WithSubpackagesC_test_of_c_util.* Passed"
       "100% tests passed, 0 tests failed out of 5"
 
-  TEST_3 CMND make ARGS install ${CTEST_BUILD_FLAGS}
+  TEST_3
+    MESSAGE "Create and configure a dummy project that includes WithSubpackagesConfig.cmake"
+      " from the build tree" 
+    CMND ${CMAKE_COMMAND}
+    ARGS
+      -DDUMMY_PROJECT_NAME=DummyProject
+      -DDUMMY_PROJECT_DIR=dummy_client_of_build_WithSubpackages
+      -DEXPORT_VAR_PREFIX=WithSubpackages
+      -DEXPORT_CONFIG_FILE=../packages/with_subpackages/WithSubpackagesConfig.cmake
+      -DCMAKE_COMMAND=${CMAKE_COMMAND}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/RunDummyPackageClientBulid.cmake
+    PASS_REGULAR_EXPRESSION_ALL
+      "WithSubpackages_CXX_FLAGS = '.*'"
+      "WithSubpackages_C_FLAGS = '.*'"
+      "WithSubpackages_FORTRAN_FLAGS = '.*'"
+      "WithSubpackages_EXTRA_LD_FLAGS = '.*'"
+      "WithSubpackages_SHARED_LIB_RPATH_COMMAND = '.*'"
+      "WithSubpackages_BUILD_SHARED_LIBS = '.*'"
+      "WithSubpackages_LINKER = '.+'"
+      "WithSubpackages_AR = '.+'"
+      "WithSubpackages_INCLUDE_DIRS = .+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran;.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/with_subpackages/b/src;.+/TribitsExampleProject/packages/with_subpackages/b/src;.+/TribitsExampleProject/packages/with_subpackages/a;.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/simple_cxx/src;.+/TribitsExampleProject/packages/simple_cxx/src;.+/tpls/HeaderOnlyTpl;.+/TribitsExampleProject/packages/with_subpackages/c"
+      "WithSubpackages_LIBRARY_DIRS = '.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/with_subpackages/b/src;.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/with_subpackages/a;.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/simple_cxx/src;.+/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/packages/with_subpackages/c'"
+      "WithSubpackages_LIBRARIES = 'pws_c.pws_b.pws_a.simplecxx'"
+      "WithSubpackages_TPL_INCLUDE_DIRS = '.+/doc/examples/tpls/HeaderOnlyTpl'"
+      "WithSubpackages_TPL_LIBRARY_DIRS = ''"
+      "WithSubpackages_TPL_LIBRARIES = ''"
+      "WithSubpackages_MPI_LIBRARIES = ''"
+      "WithSubpackages_MPI_LIBRARY_DIRS = ''"
+      "WithSubpackages_MPI_INCLUDE_DIRS = ''"
+      "WithSubpackages_MPI_EXEC = '${MPI_EXEC}'"
+      "WithSubpackages_MPI_EXEC_MAX_NUMPROCS = '${MPI_EXEC_MAX_NUMPROCS}'"
+      "WithSubpackages_MPI_EXEC_NUMPROCS_FLAG = '${MPI_EXEC_NUMPROCS_FLAG}'"
+      "WithSubpackages_PACKAGE_LIST = 'WithSubpackagesC.WithSubpackagesB.WithSubpackagesA.SimpleCxx'"
+      "WithSubpackages_TPL_LIST = 'HeaderOnlyTpl'"
+      "-- Configuring done"
+      "-- Generating done"
+
+  TEST_4 CMND make ARGS install ${CTEST_BUILD_FLAGS}
     MESSAGE "Build 'install' target using raw 'make'"
     PASS_REGULAR_EXPRESSION_ALL
       "Installing: .+/install/include/TribitsExProj_version.h"
@@ -365,7 +402,7 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_ALL_ST_NoFortran
       "Installing: .+/install/lib/cmake/WithSubpackagesC/WithSubpackagesCTargets-release.cmake"
       "Installing: .+/install/include/Makefile.export.WithSubpackagesC"
 
-  TEST_4 CMND ${CMAKE_COMMAND}
+  TEST_5 CMND ${CMAKE_COMMAND}
     ARGS
       -DDUMMY_PROJECT_NAME=DummyProject
       -DDUMMY_PROJECT_DIR=dummy_client_of_WithSubpackages
@@ -412,9 +449,9 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_ALL_ST_NoFortran
       "CPack: - Install directory: .*/examples/TribitsExampleProject"
       "CPack: Create package"
       "CPack: - package: .*/ExamplesUnitTests/TriBITS_TribitsExampleProject_ALL_ST_NoFortran/tribitsexproj-1.1-Source.tar.bz2 generated."
-  TEST_6 CMND tar ARGS -xzf tribitsexproj-1.1-Source.tar.gz
+  TEST_7 CMND tar ARGS -xzf tribitsexproj-1.1-Source.tar.gz
     MESSAGE "Untar the tarball"
-  TEST_7 CMND diff
+  TEST_8 CMND diff
      ARGS -qr
        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
        tribitsexproj-1.1-Source

--- a/tribits/core/package_arch/TribitsWriteClientExportFiles.cmake
+++ b/tribits/core/package_arch/TribitsWriteClientExportFiles.cmake
@@ -411,10 +411,20 @@ INCLUDE(\"${${DEP_PACKAGE}_BINARY_DIR}/${DEP_PACKAGE}Config.cmake\")"
     ENDFOREACH()
 
     # Import build tree targets into applications.
+    #
+    # BMA: Export only the immediate libraries of this project to the
+    # build tree. Should manage more carefully, checking that they are
+    # targets of this project and not other libs.  Also, should
+    # consider more careful recursive management of targets when there
+    # are sub-packages.  We'd like to export per-package, but deps
+    # won't be satisfied, so we export one file for the project for
+    # now...
     IF(${TRIBITS_PACKAGE}_HAS_NATIVE_LIBRARIES)
+      EXPORT(TARGETS ${${PACKAGE_NAME}_LIBRARIES} FILE
+	"${${PROJECT_NAME}_BINARY_DIR}/${PROJECT_NAME}Targets.cmake" APPEND)
       SET(PACKAGE_CONFIG_CODE "${PACKAGE_CONFIG_CODE}
 # Import ${PACKAGE_NAME} targets
-INCLUDE(\"${PROJECT_BINARY_DIR}/${PACKAGE_NAME}Targets.cmake\")"
+INCLUDE(\"${${PROJECT_NAME}_BINARY_DIR}/${PROJECT_NAME}Targets.cmake\")"
       )
     ENDIF()
 

--- a/tribits/core/package_arch/TribitsWriteClientExportFiles.cmake
+++ b/tribits/core/package_arch/TribitsWriteClientExportFiles.cmake
@@ -403,9 +403,11 @@ FUNCTION(TRIBITS_WRITE_FLEXIBLE_PACKAGE_CLIENT_EXPORT_FILES)
 
     # Include configurations of dependent packages
     FOREACH(DEP_PACKAGE ${${PACKAGE_NAME}_FULL_ENABLED_DEP_PACKAGES})
+      # Could use file(RELATIVE_PATH ...), but probably not necessary
+      # since unlike install trees, build trees need not be relocatable
       SET(PACKAGE_CONFIG_CODE "${PACKAGE_CONFIG_CODE}
-INCLUDE(\"\${CMAKE_CURRENT_LIST_DIR}/../${DEP_PACKAGE}/${DEP_PACKAGE}Config.cmake)"
-)
+INCLUDE(\"${${DEP_PACKAGE}_BINARY_DIR}/${DEP_PACKAGE}Config.cmake\")"
+        )
     ENDFOREACH()
 
     # Import build tree targets into applications.


### PR DESCRIPTION
Proposed fix for TriBITS #46

This isn't perfect, but a big step up for build tree ProjectConfig.cmake and PackageConfig.cmake files.  Fixes issue with missing quote in the generated CMake code, properly generates includes from one PackageConfig.cmake to another, and puts all targets in a top-level build tree Targets.cmake.  Ideally these would be in separate PackageTargets.cmake in the build tree as is done for install, but I am not sufficiently TriBITS savvy to do this.

This should not affect install tree *Targets.cmake or *Config.cmake, but further testing is probably warranted. 