### PR TITLE
patch for "regex too big"

### DIFF
--- a/tribits/core/installation/TribitsProjectConfigTemplate.cmake.in
+++ b/tribits/core/installation/TribitsProjectConfigTemplate.cmake.in
@@ -151,6 +151,25 @@ FOREACH(comp ${PDOLLAR}{COMPONENTS_LIST})
    ENDIF()
 ENDFOREACH()
 
+# Resolve absolute paths and remove duplicate paths
+# for LIBRARY_DIRS and INCLUDE_DIRS
+# This reduces stress on regular expressions later
+SET(short_dirs)
+FOREACH(dir ${PDOLLAR}{${PROJECT_NAME}_INCLUDE_DIRS})
+  GET_FILENAME_COMPONENT(dir_abs ${PDOLLAR}{dir} ABSOLUTE)
+  LIST(APPEND short_dirs ${PDOLLAR}{dir_abs})
+ENDFOREACH()
+LIST(REMOVE_DUPLICATES short_dirs)
+SET(${PROJECT_NAME}_INCLUDE_DIRS ${PDOLLAR}{short_dirs})
+
+SET(short_dirs)
+FOREACH(dir ${PDOLLAR}{${PROJECT_NAME}_LIBRARY_DIRS})
+  GET_FILENAME_COMPONENT(dir_abs ${PDOLLAR}{dir} ABSOLUTE)
+  LIST(APPEND short_dirs ${PDOLLAR}{dir_abs})
+ENDFOREACH()
+LIST(REMOVE_DUPLICATES short_dirs)
+SET(${PROJECT_NAME}_LIBRARY_DIRS ${PDOLLAR}{short_dirs})
+
 ## ---------------------------------------------------------------------------
 ## MPI specific variables
 ##   These variables are provided to make it easier to get the mpi libraries


### PR DESCRIPTION
Hi,

I'd like to submit this duplicate path fix for review.
It has resolved a CMake error related to regular
expressions being too big when installing
Trilinos / Albany into a "deep" directory (long path).
I suspect the ideal would be to have a function/macro
that does this and apply it to all relevant paths,
and I leave it to people who know the codebase
to decide on that.

Here is the original description:
Saurabh Tendulkar <saurabh@simmetrix.com> wrote:

We ran into the following error while installing Albany:
"RegularExpression::compile(): Expression too big"
from cmake while setting RPATHs.

From https://tribits.org/doc/TribitsBuildReference.html, the solution seems to be to use a short build directory. This does not really work for us. On looking closer, the rpaths are added together for subproducts in trilinos, where each path is like this:
<install_prefix>/lib/cmake/[subproduct]/../../../lib
i.e. about a hundred different paths (pointing to the same real path), which is why the RegularExpression length is exhausted.

I added a few lines of code to TribitsProjectConfigTemplate.cmake.in to resolve these paths so they are unique (patch attached - there are probably ways to do this better). This has been done for both include and library dirs - only library_dirs was needed for us, but include_dirs was doing the same thing. This fixes the issue.