### PR TITLE
assert that HDF5 is found in its parallel version

### DIFF
--- a/tribits/common_tpls/FindTPLHDF5.cmake
+++ b/tribits/common_tpls/FindTPLHDF5.cmake
@@ -38,9 +38,10 @@ IF (HDF5_ALLOW_PREFIND)
   FIND_PACKAGE(HDF5 COMPONENTS ${HDF5_COMPNENTS})
 
   # Make sure that HDF5 is parallel.
-  IF (NOT HDF5_IS_PARALLEL)
-    MESSAGE(FATAL_ERROR "HDF5 not parallel. Did CMake find the correct libraries?
-    Try setting HDF5_INCLUDE_DIRS and/or HDF5_LIBRARY_DIRS.
+  IF (TPL_ENABLE_MPI AND NOT HDF5_IS_PARALLEL)
+    MESSAGE(FATAL_ERROR "Trilinos is configured for MPI, HDF5 is not.
+    Did CMake find the correct libraries?
+    Try setting HDF5_INCLUDE_DIRS and/or HDF5_LIBRARY_DIRS explicitly.
     ")
   ENDIF()
 

--- a/tribits/common_tpls/FindTPLHDF5.cmake
+++ b/tribits/common_tpls/FindTPLHDF5.cmake
@@ -28,7 +28,7 @@ ENDIF()
 TRIBITS_TPL_ALLOW_PRE_FIND_PACKAGE(HDF5  HDF5_ALLOW_PREFIND)
 IF (HDF5_ALLOW_PREFIND)
 
-  MESSAGE("-- Using FIND_PACKAGE(HDF5 ...) ...") 
+  MESSAGE("-- Using FIND_PACKAGE(HDF5 ...) ...")
 
   SET(HDF5_COMPNENTS C)
   IF (HDF5_REQUIRE_FORTRAN)
@@ -36,6 +36,13 @@ IF (HDF5_ALLOW_PREFIND)
   ENDIF()
 
   FIND_PACKAGE(HDF5 COMPONENTS ${HDF5_COMPNENTS})
+
+  # Make sure that HDF5 is parallel.
+  IF (NOT HDF5_IS_PARALLEL)
+    MESSAGE(FATAL_ERROR "HDF5 not parallel. Did CMake find the correct libraries?
+    Try setting HDF5_INCLUDE_DIRS and/or HDF5_LIBRARY_DIRS.
+    ")
+  ENDIF()
 
   IF (HDF5_FOUND)
     # Tell TriBITS that we found HDF5 and there no need to look any further!


### PR DESCRIPTION
As of recently, Debian supports installing both serial and MPI versions of HDF5
alongside. If both are installed, CMake prefers the serial version, leading to
funny errors further down in the compilation (unknown symbols for EpetraExt).
This commit makes sure that CMake bails out early if the serial version of HDF5
was found.