### PR TITLE
Fixed typos only.

### DIFF
--- a/test/core/TribitsProcessPackagesAndDirsLists_UnitTests.cmake
+++ b/test/core/TribitsProcessPackagesAndDirsLists_UnitTests.cmake
@@ -111,7 +111,7 @@ FUNCTION(UNITTEST_BASIC_PACKAGE_LIST_READ_ABS_PACAKGE_DIR)
   TRIBITS_PROCESS_PACKAGES_AND_DIRS_LISTS(${PROJECT_NAME} ".")
 
   UNITTEST_COMPARE_CONST( MESSAGE_WRAPPER_INPUT
-    "-- ;PROJECT_SOURCE_DIR_BASE_MATCH='/home/me/DummyProject';FATAL_ERROR;Error: The pacakge 'Package2' was given an absolute directory '/home/me/Package2' which is *not* under the project's soruce directory '/home/me/DummyProject/'!;-- ;DummyProject_NUM_PACKAGES='3'"
+    "-- ;PROJECT_SOURCE_DIR_BASE_MATCH='/home/me/DummyProject';FATAL_ERROR;Error: The pacakge 'Package2' was given an absolute directory '/home/me/Package2' which is *not* under the project's source directory '/home/me/DummyProject/'!;-- ;DummyProject_NUM_PACKAGES='3'"
     )
   UNITTEST_COMPARE_CONST( ${PROJECT_NAME}_PACKAGES
     "Package0;Package1;Package2")

--- a/tribits/core/config_tests/FortranMangling.cmake
+++ b/tribits/core/config_tests/FortranMangling.cmake
@@ -159,7 +159,7 @@ ENDFUNCTION()
 
 
 # 2008/10/26: rabartl: Below, these were macros that were also present in the
-# file that I got off of the web but I did not need them so they are disbled
+# file that I got off of the web but I did not need them so they are disabled
 # (for now)
 
 ## - Guess if the Fortran compiler returns REAL in C doubles.

--- a/tribits/core/package_arch/TribitsGlobalMacros.cmake
+++ b/tribits/core/package_arch/TribitsGlobalMacros.cmake
@@ -2352,7 +2352,7 @@ MACRO(TRIBITS_SETUP_PACKAGING_AND_DISTRIBUTION)
   SET(${PROJECT_NAME}_CPACK_SOURCE_GENERATOR
     ${${PROJECT_NAME}_CPACK_SOURCE_GENERATOR_DEFAULT}
     CACHE STRING
-    "The types of soruce generators to use for CPACK_SOURCE_GENERATOR.")
+    "The types of source generators to use for CPACK_SOURCE_GENERATOR.")
   SET(CPACK_SOURCE_GENERATOR ${${PROJECT_NAME}_CPACK_SOURCE_GENERATOR})
 
   # K.6) Loop through the Repositories and run their callback functions.

--- a/tribits/core/package_arch/TribitsProcessPackagesAndDirsLists.cmake
+++ b/tribits/core/package_arch/TribitsProcessPackagesAndDirsLists.cmake
@@ -488,7 +488,7 @@ MACRO(TRIBITS_PROCESS_PACKAGES_AND_DIRS_LISTS  REPOSITORY_NAME  REPOSITORY_DIR)
             REPOSITORY_AND_PACKAGE_DIR)
         ELSE()
           MESSAGE_WRAPPER(FATAL_ERROR
-            "Error: The pacakge '${TRIBITS_PACKAGE}' was given an absolute directory '${PACKAGE_ABS_DIR}' which is *not* under the project's soruce directory '${PROJECT_SOURCE_DIR}/'!")
+            "Error: The pacakge '${TRIBITS_PACKAGE}' was given an absolute directory '${PACKAGE_ABS_DIR}' which is *not* under the project's source directory '${PROJECT_SOURCE_DIR}/'!")
           SET(REPOSITORY_AND_PACKAGE_DIR "ERROR-BAD-PACKAGE-ABS-DIR")
           # ToDo: We could just put in a relative path but that requries
           # knowing the common path between the two directory paths but CMake

--- a/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
+++ b/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
@@ -94,7 +94,7 @@ with::
   $ cd <SOME_BUILD_DIR>
 
 but it is generally recommended to create a build directory parallel from the
-soruce tree.
+source tree.
 
 NOTE: If you mistakenly try to configure for an in-source build (e.g. with
 'cmake .') you will get an error message and instructions on how to resolve
@@ -187,7 +187,7 @@ Selecting the list of packages to enable
 ----------------------------------------
 
 The <Project> project is broken up into a set of packages that can be enabled
-(or disbled).  For details and generic examples, see `Package Dependencies and
+(or disabled).  For details and generic examples, see `Package Dependencies and
 Enable/Disable Logic`_ and `TriBITS Dependency Handling Behaviors`_.
 
 See the following use cases:


### PR DESCRIPTION
Victoria Smith pointed out some typos in the TrilinosBuildReference that originate in TriBITS source code.  I also corrected other identical mis-spellings.