### PR TITLE
If NetCDF is also enabled, may need hdf5_hl library

### DIFF
--- a/tribits/common_tpls/FindTPLHDF5.cmake
+++ b/tribits/common_tpls/FindTPLHDF5.cmake
@@ -21,6 +21,10 @@ IF (TPL_ENABLE_MPI)
   SET(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} z)
 ENDIF()
 
+IF (TPL_ENABLE_Netcdf)
+  SET(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} hdf5_hl)
+ENDIF()
+
 #
 # Second, search for HDF5 components (if allowed) using the standard
 # FIND_PACKAGE(HDF5 ...).


### PR DESCRIPTION
If using the netcdf4-enabled version of NetCDF library, it requires both libhdf5_hl and libhdf5.  

Check whether NetCDF is enabled and if so, add libhdf5_hl to the list of required libs.  This check should possibly also check if netcdf4 enabled in netcdf, but currently assumes that is the case.