### PR TITLE
Trivial amend to 6fe7223 (GCC 5.X deprecated warnings)

### DIFF
--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -265,10 +265,10 @@ IF (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
     )
 ELSE()
   SET(DEPRECATED_WARNING_1_STR
-    ".*/TribitsExampleProject/packages/simple_cxx/src/SimpleCxx_HelloWorld.cpp:.*: warning: ‘int SimpleCxx::HelloWorld::someOldFunc.. const’ is deprecated"
+    ".*/TribitsExampleProject/packages/simple_cxx/src/SimpleCxx_HelloWorld.cpp:.*: warning: .int SimpleCxx::HelloWorld::someOldFunc.. const. is deprecated"
     )
   SET(DEPRECATED_WARNING_2_STR
-    ".*/TribitsExampleProject/packages/simple_cxx/src/SimpleCxx_HelloWorld.cpp:.*: warning: ‘int SimpleCxx::HelloWorld::someOldFunc2.. const’ is deprecated: .Just don't call this function at all please."
+    ".*/TribitsExampleProject/packages/simple_cxx/src/SimpleCxx_HelloWorld.cpp:.*: warning: .int SimpleCxx::HelloWorld::someOldFunc2.. const. is deprecated: .Just don't call this function at all please."
     )
 ENDIF()
 


### PR DESCRIPTION
Regex match in test `TriBITS_TribitsExampleProject_ALL_ST_NoFortran` was
failing. I had a couple apostrophes in place of accute accents. I replaced them
by dots in the pattern string.