### PR TITLE
Gitdist with Python3

### DIFF
--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -771,7 +771,7 @@ def filterWarnings(lines):
 def getCmndOutput(cmnd, rtnCode=False):
   child = subprocess.Popen(cmnd, shell=True, stdout=subprocess.PIPE,
     stderr = subprocess.STDOUT)
-  output = child.stdout.read()
+  output = s(child.stdout.read())
   child.wait()
   if rtnCode:
     return (output, child.returncode)
@@ -786,7 +786,7 @@ def runCmnd(options, cmnd):
     print(cmnd)
   else:
     child = subprocess.Popen(cmnd, stdout=subprocess.PIPE).stdout
-    output = child.read()
+    output = s(child.read())
     sys.stdout.flush()
     print(output)
     sys.stdout.flush()


### PR DESCRIPTION
Outputs from commands run via the shell needed to be wrapped in s() to
decode the byte strings into Unicode strings.

Previously, using gitdist with Python 3.5.2 yielded:
```
Traceback (most recent call last):
  File “./Trilinos/cmake/tribits/python_utils/gitdist”, line 1453, in <module>
    + addColorToRepoDir(options.useColor, repoName) )
  File “./Trilinos/cmake/tribits/python_utils/gitdist”, line 814, in addColorToRepoDir
    return txtbld+txtblu+strIn+txtrst
TypeError: can’t concat bytes to str
```
This fixes the problem.