### PR TITLE
Run gitdist from anywhere in repo

### DIFF
--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -1035,25 +1035,41 @@ def getCommandlineOps():
 
   # Change to top-level git directory (in case of nested git repos)
 
-  drive, currentPath = os.path.splitdrive(os.getcwd())
-  pathList = []
-  while 1:
-    currentPath, currentDir = os.path.split(currentPath)
-    if currentDir != "":
-      pathList.append(currentDir)
-    else:
-      if currentPath != "":
-        pathList.append(currentPath)
-      break
-  pathList.reverse()
-  newDir = drive+pathList[0]
-  for currentDir in pathList:
-    newDir = os.path.join(newDir, currentDir)
-    if os.path.isfile(os.path.join(newDir, ".gitdist")):
-      break
-    if os.path.isfile(os.path.join(newDir, ".gitdist.default")):
-      break
-  os.chdir(newDir)
+  moveToBaseDir = os.environ.get("GITDIST_MOVE_TO_BASE_DIR")
+
+  if moveToBaseDir == None or moveToBaseDir == "":
+    # Run gitdist in the current directory
+    None
+  elif moveToBaseDir == "EXTREME_BASE":
+    # Run gitdist in the most base dir where .gitdist[.default] exists
+    drive, currentPath = os.path.splitdrive(os.getcwd())
+    pathList = []
+    while 1:
+      currentPath, currentDir = os.path.split(currentPath)
+      if currentDir != "":
+        pathList.append(currentDir)
+      else:
+        if currentPath != "":
+          pathList.append(currentPath)
+        break
+    #print("pathList="+str(pathList))
+    pathList.reverse()
+    #print("pathList="+str(pathList))
+    newDir = drive+pathList[0]
+    for currentDir in pathList:
+      #print("currentDir="+str(currentDir))
+      newDir = os.path.join(newDir, currentDir)
+      #print("newDir="+str(newDir))
+      if os.path.isfile(os.path.join(newDir, ".gitdist")):
+        break
+      if os.path.isfile(os.path.join(newDir, ".gitdist.default")):
+        break
+    os.chdir(newDir)
+  else:
+    print(
+      "Error, env var GITDIST_MOVE_TO_BASE_DIR='"+moveToBaseDir+"' is invalid!"+
+      "  Valid choices include empty '', and EXTREME_BASE")
+    sys.exit(1)
 
   # Get list of extra repos
 

--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -1033,6 +1033,28 @@ def getCommandlineOps():
   # E) Get the list of extra repos
   #
 
+  # Change to top-level git directory (in case of nested git repos)
+
+  drive, currentPath = os.path.splitdrive(os.getcwd())
+  pathList = []
+  while 1:
+    currentPath, currentDir = os.path.split(currentPath)
+    if currentDir != "":
+      pathList.append(currentDir)
+    else:
+      if currentPath != "":
+        pathList.append(currentPath)
+      break
+  pathList.reverse()
+  newDir = drive+pathList[0]
+  for currentDir in pathList:
+    newDir = os.path.join(newDir, currentDir)
+    if os.path.isdir(os.path.join(newDir, ".git")):
+      break
+  os.chdir(newDir)
+
+  # Get list of extra repos
+
   if options.repos:
     reposFullList = options.repos.split(",")
   else:

--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -1049,7 +1049,9 @@ def getCommandlineOps():
   newDir = drive+pathList[0]
   for currentDir in pathList:
     newDir = os.path.join(newDir, currentDir)
-    if os.path.isdir(os.path.join(newDir, ".git")):
+    if os.path.isfile(os.path.join(newDir, ".gitdist")):
+      break
+    if os.path.isfile(os.path.join(newDir, ".gitdist.default")):
       break
   os.chdir(newDir)
 

--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -1036,8 +1036,7 @@ def getCommandlineOps():
   # Change to top-level git directory (in case of nested git repos)
 
   moveToBaseDir = os.environ.get("GITDIST_MOVE_TO_BASE_DIR")
-
-  if moveToBaseDir == None or moveToBaseDir == "":
+  if (moveToBaseDir == None) or (moveToBaseDir == ""):
     # Run gitdist in the current directory
     None
   elif moveToBaseDir == "EXTREME_BASE":
@@ -1052,23 +1051,27 @@ def getCommandlineOps():
         if currentPath != "":
           pathList.append(currentPath)
         break
-    #print("pathList="+str(pathList))
     pathList.reverse()
-    #print("pathList="+str(pathList))
-    newDir = drive+pathList[0]
-    for currentDir in pathList:
-      #print("currentDir="+str(currentDir))
-      newDir = os.path.join(newDir, currentDir)
-      #print("newDir="+str(newDir))
-      if os.path.isfile(os.path.join(newDir, ".gitdist")):
+    newPath = drive+pathList[0]
+    for directory in pathList:
+      newPath = os.path.join(newPath, directory)
+      if ((os.path.isfile(os.path.join(newPath, ".gitdist"))) or
+        (os.path.isfile(os.path.join(newPath, ".gitdist.default")))):
         break
-      if os.path.isfile(os.path.join(newDir, ".gitdist.default")):
+    os.chdir(newPath)
+  elif moveToBaseDir == "IMMEDIATE_BASE":
+    # Run gitdist in the immediate base dir where .gitdist[.default] exists
+    currentPath = os.getcwd()
+    while 1:
+      if ((os.path.isfile(os.path.join(currentPath, ".gitdist"))) or
+        (os.path.isfile(os.path.join(currentPath, ".gitdist.default")))):
         break
-    os.chdir(newDir)
+      currentPath, currentDir = os.path.split(currentPath)
+    os.chdir(currentPath)
   else:
     print(
-      "Error, env var GITDIST_MOVE_TO_BASE_DIR='"+moveToBaseDir+"' is invalid!"+
-      "  Valid choices include empty '', and EXTREME_BASE")
+      "Error, env var GITDIST_MOVE_TO_BASE_DIR='"+moveToBaseDir+"' is invalid!"
+      + "  Valid choices include empty '', IMMEDIATE_BASE, and EXTREME_BASE")
     sys.exit(1)
 
   # Get list of extra repos

--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -1030,10 +1030,8 @@ def getCommandlineOps():
     sys.exit(1)
 
   #
-  # E) Get the list of extra repos
+  # E) Change to top-level git directory (in case of nested git repos)
   #
-
-  # Change to top-level git directory (in case of nested git repos)
 
   moveToBaseDir = os.environ.get("GITDIST_MOVE_TO_BASE_DIR")
   if (moveToBaseDir == None) or (moveToBaseDir == ""):
@@ -1074,7 +1072,9 @@ def getCommandlineOps():
       + "  Valid choices include empty '', IMMEDIATE_BASE, and EXTREME_BASE")
     sys.exit(1)
 
-  # Get list of extra repos
+  #
+  # F) Get the list of extra repos
+  #
 
   if options.repos:
     reposFullList = options.repos.split(",")
@@ -1098,7 +1098,7 @@ def getCommandlineOps():
     notReposFullList = []
 
   #
-  # F) Return
+  # G) Return
   #
 
   return (options, nativeCmnd, otherArgs, reposFullList,


### PR DESCRIPTION
Look at the current working directory when `gitdist` is executed, determine the top-level `git` repo in that path, and change to it before continuing.  This allows `gitdist` to be run from anywhere in a `git` repository, including within a nesting of repositories.  For instance, if you have a directory structure like the following
```
/some/path/to/wherever/
  metaRepo/
    .git/
    .gitdist
    repo1/
      .git
    repo2/
      .git
    etc.
```
executing `gitdist` anywhere down in the `metaRepo` directory tree will change you to the `metaRepo` directory, execute `gitdist`, and then leave you back where you started when `gitdist` finishes.

If, for whatever reason, this change is not a good idea, just let me know and I can simply write a shell script to wrap `gitdist` for my own personal use.