### PR TITLE
Colorize git commands run through gitdist

### DIFF
--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -786,6 +786,7 @@ def runCmnd(options, cmnd):
     print(cmnd)
   else:
     subprocess.Popen(cmnd, stdout=sys.stdout, stderr=sys.stderr).communicate()
+    print("")
 
 
 # Determine if a command exists:

--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -785,11 +785,7 @@ def runCmnd(options, cmnd):
   if options.noOpt:
     print(cmnd)
   else:
-    child = subprocess.Popen(cmnd, stdout=subprocess.PIPE).stdout
-    output = child.read()
-    sys.stdout.flush()
-    print(s(output))
-    sys.stdout.flush()
+    subprocess.Popen(cmnd, stdout=sys.stdout, stderr=sys.stderr).communicate()
 
 
 # Determine if a command exists:


### PR DESCRIPTION
It was bugging me that `gitdist` stripped out whatever colors would normally be displayed when running the equivalent `git` commands from the command line.  This is an attempt to fix that problem by tying the `stdout` and `stderr` of the `subprocess` used to execute the `git` command to the `stdout` and `stderr` of the process running `gitdist` itself.  Not sure if that's the best way to do this&mdash;I only have about an hour's worth of experience with Python's `subprocess`.  I haven't seen any unintended side effects of this change yet, though I am by no means a power `gitdist` user.  Let me know if this just isn't a good idea, or if we need to go about it a different way.  Many thanks.