### PR TITLE
Add a workaround to prevent test script from being run twice

### DIFF
--- a/tribits/ctest_driver/TribitsCTestDriverCore.cmake
+++ b/tribits/ctest_driver/TribitsCTestDriverCore.cmake
@@ -1659,18 +1659,13 @@ FUNCTION(TRIBITS_CTEST_DRIVER)
   ENDIF()
 
   #
-  # Write a few variables to the global level to make cmake happy.
-  #
-  # If these don't get set in the base CTest script scope, CTest returns an
-  # error!
+  # This is a workaround to prevent the test script from being run twice. Since
+  # we are declaring tests inside a function, CTEST_RUN_CURRENT_SCRIPT gets set
+  # in the function scope, NOT the global scope. Manually setting it here with
+  # PARENT_SCOPE sets it at the global scope.
   #
 
-  SET(CTEST_SOURCE_DIRECTORY ${CTEST_SOURCE_DIRECTORY} CACHE INTERNAL "")
-  SET(CTEST_BINARY_DIRECTORY ${CTEST_BINARY_DIRECTORY} CACHE INTERNAL "")
-  IF ("${CTEST_COMMAND}" STREQUAL "")
-    SET(CTEST_COMMAND ctest)
-  ENDIF()
-  SET(CTEST_COMMAND ${CTEST_COMMAND} CACHE INTERNAL "")
+  SET(CTEST_RUN_CURRENT_SCRIPT 0 PARENT_SCOPE)
 
   #
   # Empty out the binary directory

--- a/tribits/ctest_driver/experimental_build_test.cmake
+++ b/tribits/ctest_driver/experimental_build_test.cmake
@@ -128,8 +128,3 @@ SET( CTEST_EXPLICITLY_ENABLE_IMPLICITLY_ENABLED_PACKAGES OFF )
 #
 
 TRIBITS_CTEST_DRIVER()
-
-MESSAGE(FATAL_ERROR "Not an error, we just need to abort to avoid running tests again!")
-# Above, we have to abort this Ctest -S script or, for some reason, ctest will
-# run the tests again!  This is the dumbest thing ever but I can't find a way
-# around this.


### PR DESCRIPTION
This also removes the need to set CTEST_COMMAND and friends, since it is no longer attempting to run it.