### PR TITLE
Set CTEST_COMMAND to a no-op

### DIFF
--- a/tribits/ctest_driver/TribitsCTestDriverCore.cmake
+++ b/tribits/ctest_driver/TribitsCTestDriverCore.cmake
@@ -1659,20 +1659,6 @@ FUNCTION(TRIBITS_CTEST_DRIVER)
   ENDIF()
 
   #
-  # Write a few variables to the global level to make cmake happy.
-  #
-  # If these don't get set in the base CTest script scope, CTest returns an
-  # error!
-  #
-
-  SET(CTEST_SOURCE_DIRECTORY ${CTEST_SOURCE_DIRECTORY} CACHE INTERNAL "")
-  SET(CTEST_BINARY_DIRECTORY ${CTEST_BINARY_DIRECTORY} CACHE INTERNAL "")
-  IF ("${CTEST_COMMAND}" STREQUAL "")
-    SET(CTEST_COMMAND ctest)
-  ENDIF()
-  SET(CTEST_COMMAND ${CTEST_COMMAND} CACHE INTERNAL "")
-
-  #
   # This is a workaround to prevent the test script from being run twice. Since
   # we are declaring tests inside a function, CTEST_RUN_CURRENT_SCRIPT gets set
   # in the function scope, NOT the global scope. Manually setting it here with

--- a/tribits/ctest_driver/TribitsCTestDriverCore.cmake
+++ b/tribits/ctest_driver/TribitsCTestDriverCore.cmake
@@ -1659,13 +1659,18 @@ FUNCTION(TRIBITS_CTEST_DRIVER)
   ENDIF()
 
   #
-  # This is a workaround to prevent the test script from being run twice. Since
-  # we are declaring tests inside a function, CTEST_RUN_CURRENT_SCRIPT gets set
-  # in the function scope, NOT the global scope. Manually setting it here with
-  # PARENT_SCOPE sets it at the global scope.
+  # Write a few variables to the global level to make cmake happy.
+  #
+  # If these don't get set in the base CTest script scope, CTest returns an
+  # error!
   #
 
-  SET(CTEST_RUN_CURRENT_SCRIPT 0 PARENT_SCOPE)
+  SET(CTEST_SOURCE_DIRECTORY ${CTEST_SOURCE_DIRECTORY} CACHE INTERNAL "")
+  SET(CTEST_BINARY_DIRECTORY ${CTEST_BINARY_DIRECTORY} CACHE INTERNAL "")
+  IF ("${CTEST_COMMAND}" STREQUAL "")
+    SET(CTEST_COMMAND ctest)
+  ENDIF()
+  SET(CTEST_COMMAND ${CTEST_COMMAND} CACHE INTERNAL "")
 
   #
   # Empty out the binary directory

--- a/tribits/ctest_driver/TribitsCTestDriverCore.cmake
+++ b/tribits/ctest_driver/TribitsCTestDriverCore.cmake
@@ -1659,16 +1659,18 @@ FUNCTION(TRIBITS_CTEST_DRIVER)
   ENDIF()
 
   #
-  # Write a few variables to the global level to make cmake happy.
-  #
-  # If these don't get set in the base CTest script scope, CTest returns an
-  # error!
+  # This hack is a workaround for a bug in CMake. Since we're calling
+  # ctest_start() inside a function scope, CTEST_RUN_CURRENT_SCRIPT doesn't
+  # get set in the root scope, and setting it manually at the root or via
+  # PARENT_SCOPE isn't scalable since ctest_start() is nested inside several
+  # layers of functions in some cases. So, instead, we just turn CTEST_COMMAND
+  # into a no-op.
   #
 
   SET(CTEST_SOURCE_DIRECTORY ${CTEST_SOURCE_DIRECTORY} CACHE INTERNAL "")
   SET(CTEST_BINARY_DIRECTORY ${CTEST_BINARY_DIRECTORY} CACHE INTERNAL "")
   IF ("${CTEST_COMMAND}" STREQUAL "")
-    SET(CTEST_COMMAND ctest)
+    SET(CTEST_COMMAND "${CMAKE_COMMAND} -E echo")
   ENDIF()
   SET(CTEST_COMMAND ${CTEST_COMMAND} CACHE INTERNAL "")
 


### PR DESCRIPTION
As discussed, I have set `CTEST_COMMAND` to a no-op, since this seems to be the most scalable solution to this problem.