### PR TITLE
Update FindNetCDF.cmake with better tests

### DIFF
--- a/tribits/common_tpls/find_modules/FindNetCDF.cmake
+++ b/tribits/common_tpls/find_modules/FindNetCDF.cmake
@@ -44,7 +44,7 @@
 #    Control the search through NetCDF_DIR or setting environment variable
 #    NetCDF_ROOT to the NetCDF installation prefix.
 #
-#    This module does not search default paths! 
+#    This module does not search default paths!
 #
 #    Following variables are set:
 #    NetCDF_FOUND            (BOOL)       Flag indicating if NetCDF was found
@@ -57,7 +57,7 @@
 #    Additional variables set
 #    NetCDF_C_LIBRARY        (FILE)       NetCDF C library
 #    NetCDF_CXX_LIBRARY      (FILE)       NetCDF C++ library
-#    NetCDF_LARGE_DIMS       (BOOL)       Checks the header files for size of 
+#    NetCDF_LARGE_DIMS       (BOOL)       Checks the header files for size of
 #                                          NC_MAX_DIMS and NC_MAX_VARS
 #                                          Returns TRUE if
 #                                          NC_MAX_DIMS >= 655363
@@ -129,7 +129,7 @@ else(NetCDF_LIBRARIES AND NetCDF_INCLUDE_DIRS)
             set(NetCDF_INCLUDE_DIR "NetCDF_INCLUDE_DIR-NOTFOUND")
         endif()
 
-    else() 
+    else()
 
         set(netcdf_inc_suffixes "include")
         if(NetCDF_ROOT)
@@ -145,7 +145,7 @@ else(NetCDF_LIBRARIES AND NetCDF_INCLUDE_DIRS)
             else()
                  message(SEND_ERROR "NetCDF_ROOT=${NetCDF_ROOT} does not exist")
                  set(NetCDF_INCLUDE_DIR "NetCDF_INCLUDE_DIR-NOTFOUND")
-            endif()    
+            endif()
 
 
         else()
@@ -164,47 +164,70 @@ else(NetCDF_LIBRARIES AND NetCDF_INCLUDE_DIRS)
     endif()
 
     # Large dimension and parallel check here
-    if ( NetCDF_INCLUDE_DIR ) 
-       
-        set(netcdf_h "${NetCDF_INCLUDE_DIR}/netcdf.h" )
-        message(STATUS "NetCDF include file ${netcdf_h} will be searched for define values")
+    if ( NetCDF_INCLUDE_DIR )
 
-        file(STRINGS "${netcdf_h}" netcdf_max_dims_string REGEX "^#define NC_MAX_DIMS")
-        string(REGEX REPLACE "[^0-9]" "" netcdf_max_dims "${netcdf_max_dims_string}")
-
-        file(STRINGS "${netcdf_h}" netcdf_max_vars_string REGEX "^#define NC_MAX_VARS")
-        string(REGEX REPLACE "[^0-9]" "" netcdf_max_vars "${netcdf_max_vars_string}")
-
-        if ( 
-             ( (netcdf_max_dims EQUAL 65536)  OR (netcdf_max_dims GREATER 65536) ) AND
-             ( (netcdf_max_vars EQUAL 524288) OR (netcdf_max_vars GREATER 524288) )
-            )
-            set(NetCDF_LARGE_DIMS TRUE)
-        else()
-            message(WARNING "WARNING: The NetCDF found in ${NetCDF_ROOT} does not have the correct NC_MAX_DIMS and NC_MAX_VARS. "
-                             "It may not be compatible with Exodus. See NetCDF-Mapping.md for details\n" )
-            set(NetCDF_LARGE_DIMS FALSE)
-        endif()
-
-	set(NetCDF_PARALLEL False)
         find_path(meta_path
-	          NAMES "netcdf_meta.h"
+                  NAMES "netcdf_meta.h"
                   HINTS ${NetCDF_INCLUDE_DIR}
                   NO_DEFAULT_PATH)
         if(meta_path)
-	   # Search meta for NC_HAS_PARALLEL setting...
-	   file(STRINGS "${meta_path}/netcdf_meta.h" netcdf_par_string REGEX "NC_HAS_PARALLEL")
-	   string(REGEX REPLACE "[^0-9]" "" netcdf_par_val "${netcdf_par_string}")
-	   # NOTE: The line for NC_HAS_PARALLEL has an hdf5 string in it which results
-           #       netcdf_par_val being set to 05 or 15 above...
-	   if (netcdf_par_val EQUAL 15)
-	      set(NetCDF_PARALLEL True)
-           endif()    
+           function(get_meta_setting symbol define)
+              # Search meta for NC_HAS_${symbol} setting...
+              file(STRINGS "${meta_path}/netcdf_meta.h" meta_string REGEX "NC_HAS_${symbol}")
+              # Strip trailing C comment...
+              string(REGEX REPLACE "/\\*.*$" "" meta_string_nc "${meta_string}")
+              string(REGEX REPLACE "[^01]" "" meta_val "${meta_string_nc}")
+              if (meta_val EQUAL 1)
+                 set(${define} True PARENT_SCOPE)
+              else()
+                 set(${define} False PARENT_SCOPE)
+              endif()
+           endfunction()
+
+
+           # Search meta for NC_HAS_{val} settings...
+           get_meta_setting("PARALLEL" "NetCDF_PARALLEL")
+           get_meta_setting("HDF5" "NetCDF_NEEDS_HDF5")
+           get_meta_setting("PNETCDF" "NetCDF_NEEDS_PNetCDF")
+
+           # Search meta for NC_VERSION,  NOTE: Space following VERSION in regex below is important
+           # Otherwise matches NC_VERSION_MAJOR, NC_VERSION_MINOR, NC_VERSION_PATCH, ...
+           file(STRINGS "${meta_path}/netcdf_meta.h" netcdf_version_string REGEX "NC_VERSION ")
+           string(REGEX REPLACE "[^0-9]" "" NetCDF_VERSION "${netcdf_version_string}")
+
+        else()
+           set(NetCDF_VERSION 300)
         endif()
 
-    endif()    
+       if (${NetCDF_VERSION} LESS "450")
+          # For Versions >= 4.5.0, the NC_MAX_DIMS and NC_MAX_VARS is not enforced, so not necessary to
+          # change them to non-default values. In that case, ignore check below.
+          set(netcdf_h "${NetCDF_INCLUDE_DIR}/netcdf.h" )
+          message(STATUS "NetCDF include file ${netcdf_h} will be searched for define values")
 
-    # Search for libraries 
+          file(STRINGS "${netcdf_h}" netcdf_max_dims_string REGEX "^#define NC_MAX_DIMS")
+          # Strip C Comment from end of string (may include numbers)
+          STRING(REGEX REPLACE "/\\*.* \\*/$" "" netcdf_max_dims_tmp "${netcdf_max_dims_string}")
+          string(REGEX REPLACE "[^0-9]" "" netcdf_max_dims "${netcdf_max_dims_tmp}")
+
+          string(REGEX REPLACE "[^0-9]" "" netcdf_max_vars "${netcdf_max_vars_string}")
+          # Strip C Comment from end of string (may include numbers)
+          STRING(REGEX REPLACE "/\\*.* \\*/$" "" netcdf_max_vars_tmp "${netcdf_max_vars_string}")
+          string(REGEX REPLACE "[^0-9]" "" netcdf_max_vars "${netcdf_max_vars_tmp}")
+
+          if ( (netcdf_max_dims GREATER_EQUAL 65536) AND (netcdf_max_vars GREATER_EQUAL 524288) )
+             set(NetCDF_LARGE_DIMS TRUE)
+          else()
+             message(WARNING "WARNING: The NetCDF found in ${NetCDF_ROOT} does not have the correct NC_MAX_DIMS and NC_MAX_VARS. "
+                              "It may not be compatible with Exodus. See NetCDF-Mapping.md for details\n" )
+             set(NetCDF_LARGE_DIMS FALSE)
+          endif()
+       else()
+          set(NetCDF_LARGE_DIMS TRUE)
+       endif()
+    endif()
+
+    # Search for libraries
     # Search order preference:
     #  (1) NetCDF_LIBRARY_DIR - check existence of path AND if the include files exist
     #  (2) NetCDF_ROOT/<lib,Lib>
@@ -223,14 +246,14 @@ else(NetCDF_LIBRARIES AND NetCDF_INCLUDE_DIRS)
 #                         NAMES netcdf_c++
 #                         HINTS ${NetCDF_LIBRARY_DIR}
 #                         NO_DEFAULT_PATH)
-             
+
         else()
             message(SEND_ERROR "NetCDF_LIBRARY_DIR=${NetCDF_LIBRARY_DIR} does not exist")
             set(NetCDF_LIBRARY "NetCDF_C_LIBRARY-NOTFOUND")
 #            set(NetCDF_LIBRARY "NetCDF_CXX_LIBRARY-NOTFOUND")
         endif()
 
-    else() 
+    else()
 
         if(NetCDF_ROOT)
 
@@ -252,7 +275,7 @@ else(NetCDF_LIBRARIES AND NetCDF_INCLUDE_DIRS)
                  message(SEND_ERROR "NetCDF_ROOT=${NetCDF_ROOT} does not exist")
                  set(NetCDF_LIBRARY "NetCDF_C_LIBRARY-NOTFOUND")
 #                 set(NetCDF_LIBRARY "NetCDF_CXX_LIBRARY-NOTFOUND")
-            endif()    
+            endif()
 
 
         else()
@@ -260,7 +283,7 @@ else(NetCDF_LIBRARIES AND NetCDF_INCLUDE_DIRS)
             find_library(NetCDF_C_LIBRARY
                          NAMES netcdf
                          PATH_SUFFIXES ${netcdf_lib_suffixes})
-            
+
 #            find_library(NetCDF_CXX_LIBRARY
 #                         NAMES netcdf_c++
 #                         PATH_SUFFIXES ${netcdf_lib_suffixes})
@@ -272,84 +295,89 @@ else(NetCDF_LIBRARIES AND NetCDF_INCLUDE_DIRS)
 
     if ( NOT NetCDF_C_LIBRARY )
         message(SEND_ERROR "Can not locate NetCDF C library")
-    endif()    
-    
+    endif()
+
 #    if ( NOT NetCDF_CXX_LIBRARY )
 #        message(SEND_ERROR "Can not locate NetCDF CXX library")
-#    endif()    
+#    endif()
 
 
-   
+
     # Define the LIBRARIES and INCLUDE_DORS
     set(NetCDF_INCLUDE_DIRS ${NetCDF_INCLUDE_DIR})
     set(NetCDF_LIBRARIES    ${NetCDF_CXX_LIBRARY} ${NetCDF_C_LIBRARY})
 
-    # Need to find the NetCDF config script to check for HDF5
-    if ( NetCDF_ROOT OR NetCDF_BIN_DIR )
-        MESSAGE(STATUS "\tNetCDF_ROOT is ${NetCDF_ROOT}")
-        find_program(netcdf_config nc-config 
-                       PATHS ${NetCDF_ROOT}/bin ${NetCDF_BIN_DIR}
-		       NO_DEFAULT_PATH
-		       NO_CMAKE_SYSTEM_PATH
-                       DOC "NetCDF configuration script")
+    # If version >= 4.5.0, then the defines were set above from data in the "netcdf_meta.h" file
+    # If not, then we need to use the `nc-config` script to check the settings.
+    if ( NetCDF_VERSION LESS "450" )
+       # Versions of NetCDF prior to 4.5.0 did have some settings in netcdf_meta.h, but
+       # wasn't always reliable.
 
-        if (netcdf_config)
-            message(STATUS "Found NetCDF configuration script: ${netcdf_config}")
-            execute_process(COMMAND "${netcdf_config}" "--has-hdf5"
-                            RESULT_VARIABLE _ret_code
-                            OUTPUT_VARIABLE _stdout
-                            ERROR_VARIABLE  _stderr
-                           )
-            string(REGEX REPLACE "[\n\r ]" "" _hdf5_answer ${_stdout})
-            message(STATUS "${netcdf_config} --has-hdf5 returned '${_hdf5_answer}'")
-            string(COMPARE EQUAL "${_hdf5_answer}" "yes" _has_hdf5)
-            if (${_has_hdf5} ) 
-                set(NetCDF_NEEDS_HDF5 True)
-            else()
-                set(NetCDF_NEEDS_HDF5 False)
-            endif()    
+       # Need to find the NetCDF config script to check for HDF5
+       if ( NetCDF_ROOT OR NetCDF_BIN_DIR )
+           MESSAGE(STATUS "\tNetCDF_ROOT is ${NetCDF_ROOT}")
+           find_program(netcdf_config nc-config
+                          PATHS ${NetCDF_ROOT}/bin ${NetCDF_BIN_DIR}
+                          NO_DEFAULT_PATH
+                          NO_CMAKE_SYSTEM_PATH
+                          DOC "NetCDF configuration script")
 
-            execute_process(COMMAND "${netcdf_config}" "--version"
-                            RESULT_VARIABLE _ret_code
-                            OUTPUT_VARIABLE _stdout
-                            ERROR_VARIABLE  _stderr
-                           )
-            string(REGEX REPLACE "[\n\r]" "" NetCDF_VERSION ${_stdout})
+           if (netcdf_config)
+               message(STATUS "Found NetCDF configuration script: ${netcdf_config}")
+               execute_process(COMMAND "${netcdf_config}" "--has-hdf5"
+                               RESULT_VARIABLE _ret_code
+                               OUTPUT_VARIABLE _stdout
+                               ERROR_VARIABLE  _stderr
+                              )
+               string(REGEX REPLACE "[\n\r ]" "" _hdf5_answer ${_stdout})
+               message(STATUS "${netcdf_config} --has-hdf5 returned '${_hdf5_answer}'")
+               string(COMPARE EQUAL "${_hdf5_answer}" "yes" _has_hdf5)
+               if (${_has_hdf5} )
+                   set(NetCDF_NEEDS_HDF5 True)
+               else()
+                   set(NetCDF_NEEDS_HDF5 False)
+               endif()
 
-# If --has-pnetcdf returns true, then add pnetcdf as dependent library.
-            execute_process(COMMAND "${netcdf_config}" "--has-pnetcdf"
-                            RESULT_VARIABLE _ret_code
-                            OUTPUT_VARIABLE _stdout
-                            ERROR_VARIABLE  _stderr
-                           )
-            string(REGEX REPLACE "[\n\r ]" "" _pnetcdf_answer ${_stdout})
-            message(STATUS "${netcdf_config} --has-pnetcdf returned '${_pnetcdf_answer}'")
-            string(COMPARE EQUAL "${_pnetcdf_answer}" "yes" _has_pnetcdf)
-            if (${_has_pnetcdf} ) 
-                set(NetCDF_NEEDS_PNetCDF True)
-            else()
-                set(NetCDF_NEEDS_PNetCDF False)
-            endif()    
+               execute_process(COMMAND "${netcdf_config}" "--version"
+                               RESULT_VARIABLE _ret_code
+                               OUTPUT_VARIABLE _stdout
+                               ERROR_VARIABLE  _stderr
+                              )
+               string(REGEX REPLACE "[\n\r]" "" NetCDF_VERSION ${_stdout})
 
+               # If --has-pnetcdf returns true, then add pnetcdf as dependent library.
+               execute_process(COMMAND "${netcdf_config}" "--has-pnetcdf"
+                               RESULT_VARIABLE _ret_code
+                               OUTPUT_VARIABLE _stdout
+                               ERROR_VARIABLE  _stderr
+                              )
+               string(REGEX REPLACE "[\n\r ]" "" _pnetcdf_answer ${_stdout})
+               message(STATUS "${netcdf_config} --has-pnetcdf returned '${_pnetcdf_answer}'")
+               string(COMPARE EQUAL "${_pnetcdf_answer}" "yes" _has_pnetcdf)
+               if (${_has_pnetcdf} )
+                   set(NetCDF_NEEDS_PNetCDF True)
+               else()
+                   set(NetCDF_NEEDS_PNetCDF False)
+               endif()
+           endif()
+       endif()
+    endif()
 
-        endif()
-    endif()    
-
-    if(NetCDF_NEEDS_HDF5) 
+    if(NetCDF_NEEDS_HDF5)
         message(STATUS "NetCDF requires HDF5")
         add_package_dependency(NetCDF DEPENDS_ON HDF5)
     else()
         message(STATUS "NetCDF does not require HDF5")
     endif()
 
-    if(NetCDF_NEEDS_PNetCDF) 
+    if(NetCDF_NEEDS_PNetCDF)
         message(STATUS "NetCDF requires PNetCDF")
         add_package_dependency(NetCDF DEPENDS_ON PNetCDF)
     else()
         message(STATUS "NetCDF does not require PNetCDF")
     endif()
 
-endif(NetCDF_LIBRARIES AND NetCDF_INCLUDE_DIRS )    
+endif(NetCDF_LIBRARIES AND NetCDF_INCLUDE_DIRS )
 
 # --- Search for NetCDF tools
 if ( NetCDF_BINARY_DIR )
@@ -378,7 +406,7 @@ else()
             set(NetCDF_BINARY_DIR "NetCDF_BINARY_DIR-NOTFOUND")
         endif()
 
-    else() 
+    else()
 
         set(netcdf_bin_suffixes "bin")
         if(NetCDF_ROOT)
@@ -394,7 +422,7 @@ else()
             else()
                  message(SEND_ERROR "NetCDF_ROOT=${NetCDF_ROOT} does not exist")
                  set(NetCDF_BINARY_DIR "NetCDF_BINARY_DIR-NOTFOUND")
-            endif()    
+            endif()
 
 
         else()


### PR DESCRIPTION
As of NetCDF-4.5.0, the `NC_MAX_VARS` and `NC_MAX_DIMS` limits are no longer enforced, so it isn't necessary to check their values.  While updating the test and whether to perform it or not, I discovered that the current parsing of `NC_MAX_VARS` and `NC_MAX_DIMS` was returning incorrect values.

To fix this, I added a REGEX to strip the C comment from the end of the string.
I also parsed more values from the `netcdf_meta.h` file if it exists instead of parsing some values from it and some from the `nc-config` script.

Tested on several versions of NetCDF and values all look reasonable