### PR TITLE
NETCDF: Fix search of netcdf_meta

### DIFF
--- a/tribits/common_tpls/find_modules/FindNetCDF.cmake
+++ b/tribits/common_tpls/find_modules/FindNetCDF.cmake
@@ -193,7 +193,9 @@ else(NetCDF_LIBRARIES AND NetCDF_INCLUDE_DIRS)
                   NO_DEFAULT_PATH)
         if(meta_path)
 	   # Search meta for NC_HAS_PARALLEL setting...
-	   file(STRINGS "${meta_path}/netcdf_meta.h" netcdf_par_string REGEX "NC_HAS_PARALLEL")
+	   # Note that there is both NC_HAS_PARALLEL4 and NC_HAS_PARALLEL, only want NC_HAS_PARALLEL
+	   # so add a space to end to avoid getting NC_HAS_PARALLEL4
+	   file(STRINGS "${meta_path}/netcdf_meta.h" netcdf_par_string REGEX "NC_HAS_PARALLEL ")
 	   string(REGEX REPLACE "[^0-9]" "" netcdf_par_val "${netcdf_par_string}")
 	   # NOTE: The line for NC_HAS_PARALLEL has an hdf5 string in it which results
            #       netcdf_par_val being set to 05 or 15 above...


### PR DESCRIPTION
To determine whether NetCDF is compiled for parallel, we search the `netcdf_meta.h` file for the setting of `NETCDF_PARALLEL`. The problem is that the NetCDF team recently added another setting which is named `NETCDF_PARALLEL4`.  We want the `NETCDF_PARALLEL` so to make sure we get that one only, we add a space to the end of the symbol `NETCDF_PARALLEL `