### PR TITLE
Changed to use print-function for python 3 compatability.

### DIFF
--- a/tribits/ci_support/filter-packages-list.py
+++ b/tribits/ci_support/filter-packages-list.py
@@ -97,4 +97,4 @@ inputPackagesList = options.inputPackagesList.split(",")
 keepTestTestCategoriesList = options.keepTestTestCategories.split(",")
 outputPackagesList = \
   trilinosDependencies.filterPackageNameList(inputPackagesList, keepTestTestCategoriesList)
-print ','.join(outputPackagesList)
+print(','.join(outputPackagesList))

--- a/tribits/ci_support/get-tribits-packages-from-files-list.py
+++ b/tribits/ci_support/get-tribits-packages-from-files-list.py
@@ -109,4 +109,4 @@ projectCiFileChangeLogic = getProjectCiFileChangeLogic(options.projectDir)
 packagesList = getPackagesListFromFilePathsList(trilinosDependencies, filesList, True,
   projectCiFileChangeLogic)
 
-print ','.join(packagesList)
+print(','.join(packagesList))


### PR DESCRIPTION
These two files were failing in testing for python 3
and the only issue was use of the newer print. This
works under both python 2 and 3.