### PR TITLE
Advanced test: fix doc of STANDARD_PASS_OUTPUT

### DIFF
--- a/tribits/core/package_arch/TribitsAddAdvancedTest.cmake
+++ b/tribits/core/package_arch/TribitsAddAdvancedTest.cmake
@@ -473,7 +473,7 @@ INCLUDE(PrintVar)
 #     If specified, the test command will be assumed to pass if the string
 #     expression "Final Result: PASSED" is found in the output for the test.
 #     This as the result of directly passing in ``PASS_REGULAR_EXPRESSION
-#     "Final Result: PASSED"``.
+#     "End Result: TEST PASSED"``.
 #
 #   ``FAIL_REGULAR_EXPRESSION "<regex>"``
 #


### PR DESCRIPTION
Update the expression to be search for, when STANDARD_PASS_OUTPUT is
used within TRIBITS_ADD_ADVANCED_TEST.

Closes #293.