### PR TITLE
Added howto: globally changing X_ENABLE_Y during package config

### DIFF
--- a/tribits/doc/developers_guide/TribitsDevelopersGuide.rst
+++ b/tribits/doc/developers_guide/TribitsDevelopersGuide.rst
@@ -3665,12 +3665,18 @@ In more detail, these rules/behaviors are:
 
 22) **TriBITS auto-enables/disables done using non-cache local variables**:
     TriBITS setting (or overrides) of enable/disable cache variables are done
-    by setting local non-cache variables at the top project-level scope.  This
-    is done so they don't get set in the cache and so that the same dependency
+    by setting local non-cache variables at the top project-level scope
+    (i.e. the ``<projectDir>/CMakeLists.txt`` file scope).  This is done so
+    they don't get set in the cache and so that the same dependency
     enable/disable logic is redone, from scratch, with each re-configure.
     This results in the same enable/disable logic output as for the initial
     configure.  This is to avoid confusion by the user about why some SE
     packages and TPLs are enabled and some are not on subsequent reconfigures.
+    However, this implementation choice must be understood when one wants to
+    go about tweaking these TriBITS enable/disable variables as described in
+    `How to check for and tweak TriBITS "ENABLE" cache variables`_ and `How to
+    tweak downstream TriBITS "ENABLE" variables during package
+    configuration`_.
 
 TriBITS prints out a lot of information about the enable/disable logic as it
 applies the above rules/behaviors.  For a large TriBITS project with lots of
@@ -6041,22 +6047,50 @@ enable/disable logic is applied.
 How to tweak downstream TriBITS "ENABLE" variables during package configuration
 -------------------------------------------------------------------------------
 
-The internal configuration of a package (``<XXX>/CMakeLists.txt``)
-may determine that an optional feature (``<XXX>_ENABLE_<YYY>``) must be
-enabled or disabled with ``SET(<XXX>_ENABLE_<YYY> <val>)``.
-Changing the value of ``<XXX>_ENABLE_<YYY>`` inside package `<XXX>` using ``SET``
-changes the variable's value inside the package's scope, but all other
-packages will see the old value of ``<XXX>_ENABLE_<YYY>``.
+There are cases where one may need to enable or disable some feature that
+TriBITS may have enabled by default (such as in "Adjust SE package and TPLs
+enables and disables" in `Full Processing of TriBITS Project Files`_) and that
+decision can only be made while processing a package's
+`<packageDir>/CMakeLists.txt`_ file. (And therefore the logic for this disable
+cannot be performed in the ``ProjectDependenciesSetup.cmake`` or
+``RepositoryDependenciesSetup.cmake`` files as described in `How to check for
+and tweak TriBITS "ENABLE" cache variables`_ which are processed before the
+enabled packages are configured.)  Also, there are cases where it is necessary
+to make this change visible to downstream packages such as when
+``<DownstreamPackageB>`` support of some feature depends on
+``<DownstreamPackageA>`` support for that same feature.  Examples include
+optional support of an upstream package in a downstream package
+``<DownstreamPackage>_ENABLE_<UpstreamPackage>`` or for support for an
+optional TPL in a downstream package ``<DownstreamPackage>_ENABLE_<TPL>``.
+But other examples may include variables that are not optional TriBITS package
+and TPL enables (such as support for a given data-type that may impact
+multiple packages).
 
-However, it is sometimes necessary to make this change visible to downstream packages.
-To do this, use ``DUAL_SCOPE_SET(<XXX>_ENABLE_<YYY> <val>)`` instead. This
-sets the value in both the global (project) scope and in the local scope of package `<XXX>`.
-Any downstream package (configured after `<XXX>` chronologically)
-will see the new value: ``${<XXX>_ENABLE_<YYY>} STREQUAL <val>``.
-Caution: packages that don't depend on `<XXX>` may or may not see the change.
-It is also strongly recommended that a message or warning is given when globally
-changing an ENABLE variable. The user may have set it explicitly, and they
-should know exacly why and where their choice is being overridden.
+When the internal configuration of a package (i.e. while processing its
+``<packageDir>/CMakeLists.txt`` file) determines that an optional feature
+``<XXX>_ENABLE_<YYY>`` must be enabled or disabled with and will change the
+value previously set (e.g. during the "Adjust SE package and TPLs enables and
+disables" stage), one cannot use a simple ``SET()`` statement.  Changing the
+value of an ``<XXX>_ENABLE_<YYY>`` variable inside a package's
+``<packageDir>/CMakeLists.txt`` file using a raw ``SET(<XXX>_ENABLE_<YYY>
+<newValue>)`` statement only changes the variable's value inside the package's
+scope, but all other packages will see the old value of
+``<XXX>_ENABLE_<YYY>``.  To correctly change the value of one of these
+variables, instead use `DUAL_SCOPE_SET()`_ from the top-level
+``<packageDir>/CMakeLists.txt`` file.  This sets the value in both the
+base-level (global) project scope and in the local scope of
+``<packageDir>/CMakeLists.txt``.  (But this does **not** change the value of a
+cache variable ``<XXX>_ENABLE_<YYY>`` that may have been set by the user or
+some other means; see `TriBITS auto-enables/disables done using non-cache
+local variables`_.)  Any downstream package (configured after processing
+``<packageDir>/CMakeLists.txt``) will see the new value ``<XXX>_ENABLE_<YYY>
+STREQUAL <val>``.  Caution: packages that don't depend on the package that
+makes these changes may or may not see the change.  It is also strongly
+recommended that a message or warning be printed to CMake STDOUT using
+``MESSAGE(["NOTE: "|WARNING] "<message>")`` when globally changing an ENABLE
+variable. The user may have set it explicitly, and they should know exactly
+why and where their choice is being overridden.
+
 
 How to set up multi-repository support
 --------------------------------------

--- a/tribits/doc/developers_guide/TribitsDevelopersGuide.rst
+++ b/tribits/doc/developers_guide/TribitsDevelopersGuide.rst
@@ -6038,6 +6038,25 @@ Enable/Disable Logic`_).  Also, these files get processed in `Reduced Package
 Dependency Processing`_ as well so they get processed in all contexts where
 enable/disable logic is applied.
 
+How to tweak downstream TriBITS "ENABLE" variables during package configuration
+-------------------------------------------------------------------------------
+
+The internal configuration of a package (``<XXX>/CMakeLists.txt``)
+may determine that an optional feature (``<XXX>_ENABLE_<YYY>``) must be
+enabled or disabled with ``SET(<XXX>_ENABLE_<YYY> <val>)``.
+Changing the value of ``<XXX>_ENABLE_<YYY>`` inside package `<XXX>` using ``SET``
+changes the variable's value inside the package's scope, but all other
+packages will see the old value of ``<XXX>_ENABLE_<YYY>``.
+
+However, it is sometimes necessary to make this change visible to downstream packages.
+To do this, use ``DUAL_SCOPE_SET(<XXX>_ENABLE_<YYY> <val>)`` instead. This
+sets the value in both the global (project) scope and in the local scope of package `<XXX>`.
+Any downstream package (configured after `<XXX>` chronologically)
+will see the new value: ``${<XXX>_ENABLE_<YYY>} STREQUAL <val>``.
+Caution: packages that don't depend on `<XXX>` may or may not see the change.
+It is also strongly recommended that a message or warning is given when globally
+changing an ENABLE variable. The user may have set it explicitly, and they
+should know exacly why and where their choice is being overridden.
 
 How to set up multi-repository support
 --------------------------------------


### PR DESCRIPTION
Following discussion in Trilinos issue 6041, where this was used.

Link to discussion: https://github.com/trilinos/Trilinos/issues/6041