### PR TITLE
Upgrade install-cmake.py to get arbitrary versions from GitHub and other improvements (#167)

### DIFF
--- a/test/devtools_install/InstallProgramDriver_UnitTests.py
+++ b/test/devtools_install/InstallProgramDriver_UnitTests.py
@@ -128,7 +128,7 @@ class test_InstallProgramDriver(unittest.TestCase):
 
   def test_default(self):
     ipd = InstallProgramDriver(DummyInstall())
-    sys.argv = ["scriptName"]
+    sys.argv = ["scriptName", "--install-dir=/some/install/path"]
     self.assertEqual(ipd.runDriver(), None)
 
 

--- a/tribits/devtools_install/InstallProgramDriver.py
+++ b/tribits/devtools_install/InstallProgramDriver.py
@@ -141,10 +141,16 @@ in order to remove the intermediate source and build files.
     defaultVersion = self.installObj.getProductDefaultVersion()
     defaultVersionIdx = findInSequence(supportedVersions, defaultVersion)
 
-    addOptionParserChoiceOption(
-      versionCmndArgName, "version", supportedVersions, defaultVersionIdx,
-      "Version to install for "+productName+".", clp)
-    
+    if supportedVersions:
+      addOptionParserChoiceOption(
+        versionCmndArgName, "version", supportedVersions, defaultVersionIdx,
+        "Version to install for "+productName+".", clp)
+    else:
+      clp.add_option(
+        versionCmndArgName, dest="version", type="string",
+        default=defaultVersion,
+        help="Version to install for "+productName+" (list of versions open-ended).")
+
     clp.add_option(
       "--install-dir", dest="installDir", type="string",
       default="/usr/local",
@@ -335,6 +341,18 @@ def setStdDownloadCmndOption(installObj, clp, version):
     "--download-cmnd", dest="downloadCmnd", type="string",
     default=defaultDownloadCmnd,
     help="Command used to download source for "+productName+"." \
+      +"  (Default ='"+defaultDownloadCmnd+"')  WARNING: This will delete" \
+      +" an existing directory '"+productBaseDirName+"' if it already exists!")
+
+def setStdGithubDownloadCmndOption(installObj, githubOrg, githubRepo, clp, version):
+  productName = installObj.getProductBaseName()+"-"+version
+  productBaseDirName = productName+"-base"
+  defaultDownloadCmnd = \
+    "wget -O "+productName+".tar.gz https://github.com/"+githubOrg+"/"+githubRepo+"/tarball/v"+version
+  clp.add_option(
+    "--download-cmnd", dest="downloadCmnd", type="string",
+    default=defaultDownloadCmnd,
+    help="Command used to download source tarball for "+productName+"." \
       +"  (Default ='"+defaultDownloadCmnd+"')  WARNING: This will delete" \
       +" an existing directory '"+productBaseDirName+"' if it already exists!")
 

--- a/tribits/devtools_install/InstallProgramDriver.py
+++ b/tribits/devtools_install/InstallProgramDriver.py
@@ -82,16 +82,21 @@ class InstallProgramDriver:
     #
     # 1) Set up the help text
     #
+
+    productSupportedVersions = self.installObj.getProductSupportedVersions()
+    if productSupportedVersions:
+      supportedVersionsTxt = "Versions supported include:\n   "+\
+        str(self.installObj.getProductSupportedVersions())
+    else:
+      supportedVersionsTxt = "Arbirary versions are supported."
       
     usageHelp = scriptName+\
 r""" [OPTIONS] [--install-dir=<install-dir> ...]
 
 This script checks out source, untars, configures, builds, and installs
-"""+productName+r""" in one shot.  Versions supported include:
+"""+productName+r""" in one shot.  """+supportedVersionsTxt+r"""
 
-    """+str(self.installObj.getProductSupportedVersions())+r"""
-
-(set with --"""+productBaseName+r"""-version=<version>)
+The version to install is set with --"""+productBaseName+r"""-version=<version>.
 
 By default, if you just type:
 

--- a/tribits/devtools_install/InstallProgramDriver.py
+++ b/tribits/devtools_install/InstallProgramDriver.py
@@ -153,10 +153,17 @@ in order to remove the intermediate source and build files.
 
     clp.add_option(
       "--install-dir", dest="installDir", type="string",
-      default="/usr/local",
+      default="",
       help="The install directory <install-dir> for "+productName+ \
-        " (default = /usr/local).  This can be a relative or absolute path, it can" \
+        " (default = '').  This can be a relative or absolute path, it can" \
         " start with ~/, etc." )
+
+    clp.add_option(
+      "--install-dir-base", dest="installDirBase", type="string",
+      default="",
+      help="The base install directory <install-dir> for "+productName+ \
+        " (default = '').  In this case the subdir "+productName+\
+        " will be created under this directory for the install prefix." )
 
     insertInstallPermissionsOptions(clp)
 
@@ -213,10 +220,12 @@ in order to remove the intermediate source and build files.
     # 3) Echo the command-line options
     #
 
-    cmndLine = "******************************************************************************\n"
+    cmndLine = \
+      "******************************************************************************\n"
     cmndLine += scriptName + " \\\n"
     cmndLine += "  "+versionCmndArgName + "='"+options.version+"' \\\n"
     cmndLine += "  --install-dir='" + options.installDir + "' \\\n"
+    cmndLine += "  --install-dir-base='" + options.installDirBase + "' \\\n"
     cmndLine += echoInsertPermissionsOptions(options)
     cmndLine += "  --parallel='" + str(options.parallel) + "' \\\n"
     cmndLine += "  --make-options='" + options.makeOptions + "'\\\n"
@@ -243,7 +252,10 @@ in order to remove the intermediate source and build files.
 
     # Check the options
 
-    if options.installDir == "":
+    if options.installDirBase != "" and options.installDir == "":
+      options.installDir=options.installDirBase+"/"+productName
+
+    elif options.installDir == "":
       raise Exception("Error, --install-dir=<install-dir> can't be empty!")
     options.installDir = os.path.abspath(os.path.expanduser(options.installDir))
 
@@ -283,17 +295,14 @@ in order to remove the intermediate source and build files.
     else:
       print("Skipping on request ...")
     
-    
     print("")
     print("C) Configure "+productName+" ...")
     print("")
-    
     
     if options.configure:
       self.installObj.doConfigure()
     else:
       print("Skipping on request ...")
-    
     
     print("")
     print("D) Build "+productName+" ...")
@@ -303,7 +312,6 @@ in order to remove the intermediate source and build files.
       self.installObj.doBuild()
     else:
       print("Skipping on request ...")
-    
     
     print("")
     print("E) Install "+productName+" ...")

--- a/tribits/devtools_install/install-cmake.py
+++ b/tribits/devtools_install/install-cmake.py
@@ -111,7 +111,7 @@ version of CMake by default.
         +"  Note: This does not override the hard-coded configure options." )
     addOptionParserChoiceOption(
       "--use-native-cmake-config", "cmakeNativeConfig",
-      ["on", "off", "auto"], 2,
+      ["on", "off", "auto"], 1,
       "Use an already installed version of CMake for configuring " \
       +self.getProductName(version)+".", clp)
     addOptionParserChoiceOption(

--- a/tribits/devtools_install/install-cmake.py
+++ b/tribits/devtools_install/install-cmake.py
@@ -119,12 +119,6 @@ version of CMake by default.
       ["on", "off"], 1,
       "Build in support for OpenSSL to submit to CDash via HTTPS for " \
       +self.getProductName(version)+".", clp)
-    clp.add_option(
-      "--cxx-compiler", dest="cxxCompiler", type="string", \
-      default="g++", \
-      help="C++ compiler to use to build "\
-        +self.getProductName(version)+"." \
-        +"  [default = g++]." )
 
   def echoExtraCmndLineOptions(self, inOptions):
     cmndLine = ""
@@ -185,9 +179,9 @@ version of CMake by default.
         " "+self.inOptions.extraConfigureOptions+\
         " -DCMAKE_BUILD_TYPE=Release"+\
         openSSLCachVarStr+\
-        " -DCMAKE_CXX_COMPILER="+self.inOptions.cxxCompiler+\
         " -DCMAKE_INSTALL_PREFIX="+self.inOptions.installDir
         )
+
     elif self.inOptions.cmakeNativeConfig is "on":
       # Configuring CMake with CMake was explicitly requested but
       # the CMake executable was not found in PATH
@@ -199,7 +193,7 @@ version of CMake by default.
         " "+self.inOptions.extraConfigureOptions+\
         getParallelOpt(self.inOptions, "--parallel=")+\
         " --prefix="+self.inOptions.installDir,
-        extraEnv={"CXX":self.inOptions.cxxCompiler,"CXXFLAGS":"-O3", "CFLAGS":"-O3"},
+        extraEnv={"CXXFLAGS":"-O3", "CFLAGS":"-O3"},
         )
 
   def doBuild(self):

--- a/tribits/devtools_install/install-cmake.py
+++ b/tribits/devtools_install/install-cmake.py
@@ -94,7 +94,7 @@ class CMakeInstall:
 This script builds """+self.getProductName(version)+""" from source compiled with the
 configured C/C++ compilers in your path.
 
-This downloads tarballs from github by default for the given cmake version.
+This downloads tarballs from GitHub by default for the given cmake version.
 
 This build script sets the environment vars CXXFLAGS=-O3 AND CFLAGS=-O3
 when doing the configure.  Therefore, this builds and installs an optimized

--- a/tribits/devtools_install/install-cmake.py
+++ b/tribits/devtools_install/install-cmake.py
@@ -123,8 +123,9 @@ version of CMake by default.
   def echoExtraCmndLineOptions(self, inOptions):
     cmndLine = ""
     cmndLine += "  --download-cmnd='"+inOptions.downloadCmnd+"' \\\n"
-    cmndLine += "  --use-native-cmake-config='"+inOptions.cmakeNativeConfig+"' \\\n"
     cmndLine += "  --extra-configure-options='"+inOptions.extraConfigureOptions+"' \\\n"
+    cmndLine += "  --use-native-cmake-config='"+inOptions.cmakeNativeConfig+"' \\\n"
+    cmndLine += "  --use-openssl='"+inOptions.useOpenSSL+"' \\\n"
     return cmndLine
 
   #

--- a/tribits/devtools_install/install-cmake.py
+++ b/tribits/devtools_install/install-cmake.py
@@ -92,7 +92,10 @@ class CMakeInstall:
   def getExtraHelpStr(self, version):
     return """
 This script builds """+self.getProductName(version)+""" from source compiled with the
-configured C/C++ compilers in your path.
+configured C/C++ compilers in your path.  To select a C and C++ compiler which is not
+the default in your path, run with:
+
+  env CC=<path-to-c-compiler> CXX=<path-to-cxx-compiler> install-cmake.py [other options]
 
 This downloads tarballs from GitHub by default for the given cmake version.
 
@@ -190,10 +193,11 @@ version of CMake by default.
     else:
       # CMake is not already installed on system, so use configure
       echoRunSysCmnd(
-        "../"+self.cmakeSrcDir+"/configure "+\
+        "../"+self.cmakeSrcDir+"/bootstrap "+\
         " "+self.inOptions.extraConfigureOptions+\
         getParallelOpt(self.inOptions, "--parallel=")+\
-        " --prefix="+self.inOptions.installDir,
+        " --prefix="+self.inOptions.installDir+\
+        " -- "+openSSLCachVarStr,
         extraEnv={"CXXFLAGS":"-O3", "CFLAGS":"-O3"},
         )
 

--- a/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
+++ b/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
@@ -39,19 +39,19 @@ snapshot of TriBITS), then install CMake with::
   $ cd <some-scratch-space>/
   $ export TRIBITS_BASE_DIR=<project-base-dir>/cmake/tribits
   $ $TRIBITS_BASE_DIR/devtools_install/install-cmake.py \
-     --install-dir=<INSTALL_BASE_DIR> \
+     --install-dir-base=<INSTALL_BASE_DIR> --cmake-version=X.Y.Z \
      --do-all
 
 This will result in cmake and related CMake tools being installed in
-``<INSTALL_BASE_DIR>/bin/`` (see the instructions printed at the end on how to
-update your ``PATH`` env var).
+``<INSTALL_BASE_DIR>/cmake-X.Y.Z/bin/`` (see the instructions printed at the
+end on how to update your ``PATH`` env var).
 
 To get help for installing CMake with this script use::
 
   $ $TRIBITS_BASE_DIR/devtools_install/install-cmake.py --help
 
-NOTE: you will want to read the help message about how to use sudo to
-install in a privileged location (like the default ``/usr/local/bin``).
+NOTE: you will want to read the help message about how to install CMake to
+share with other users and maintainers and how to install with sudo if needed.
 
 
 Installing Ninja from Source


### PR DESCRIPTION
This updates the install-cmake.py scirpt to allow downloading and installing arbitrary versions off of the GitHub site.  This is part of #167.

I also merged in the branch from PR #225 and made some adjustments to make it robust by default (which does not have OpenSSL support by default).
