### PR TITLE
Resolve "Make SnapshotDir Python 3 Compatible"

### DIFF
--- a/tribits/python_utils/SnapshotDir.py
+++ b/tribits/python_utils/SnapshotDir.py
@@ -52,6 +52,35 @@ pp = pprint.PrettyPrinter(indent=4)
 from GeneralScriptSupport import *
 
 
+
+#
+# Byte array / string / unicode support across Python 2 & 3
+#
+# Note that the str class in Python 2 is an ASCII string (byte) array and in
+# Python 3 it is a Unicode object. For Python 3 code that is backward compatible
+# with Python 2, we sometimes need version-specific conversion functions to give
+# us the data type we desire. These functions are:
+#
+#     b(x)    return a byte array of str x, much like b'<string const>' in
+#             Python 3
+#     s(x)    return a version-specific str object equivalent to x
+#
+if sys.version_info < (3,):
+  # Python 2
+  def b(x): return x
+  def s(x): return x
+else:
+  # Python 3
+  import codecs
+  def b(x): return codecs.latin_1_encode(x)[0]
+  def s(x):
+    try:
+      return x.decode("utf-8")
+    except AttributeError:
+      return x
+
+
+
 #
 # Class for defining default options
 #
@@ -456,10 +485,10 @@ def snapshotDir(inOptions):
 
 def assertCleanGitDir(dirPath, dirName, explanation):
 
-  changedFiles = getCmndOutput(
+  changedFiles = s(getCmndOutput(
     "git diff --name-status HEAD -- .",
     stripTrailingSpaces = True,
-    workingDir = dirPath )
+    workingDir = dirPath ))
 
   if changedFiles:
     raise Exception(
@@ -491,7 +520,7 @@ def cleanIgnoredFilesFromGitDir(dirPath, dirName):
 
 
 def getCommitSha1(gitDir):
-  return getCmndOutput("git log -1 --pretty=format:'%h' -- .", workingDir=gitDir).strip()
+  return s(getCmndOutput("git log -1 --pretty=format:'%h' -- .", workingDir=gitDir)).strip()
 
 
 def getGitRepoUrl(gitDir):
@@ -501,13 +530,13 @@ def getGitRepoUrl(gitDir):
   remoteRepoUrl = ""
 
   # Get the remote tracking branch
-  trackingBranchStr = getCmndOutput(
-     "git rev-parse --abbrev-ref --symbolic-full-name @{u}", workingDir=gitDir)
+  trackingBranchStr = s(getCmndOutput(
+     "git rev-parse --abbrev-ref --symbolic-full-name @{u}", workingDir=gitDir))
 
   (remoteRepoName, remoteBranch) = trackingBranchStr.strip().split("/")
 
   # Get the list of remote repos
-  remoteReposListStr = getCmndOutput("git remote -v", workingDir=gitDir)
+  remoteReposListStr = s(getCmndOutput("git remote -v", workingDir=gitDir))
   #print("remoteReposListStr = " + remoteReposListStr)
 
   # Loop through looking for remoteRepoName
@@ -544,9 +573,9 @@ def getGitRepoUrl(gitDir):
 
 
 def getLastCommitMsg(gitDir):
-  return getCmndOutput(
+  return s(getCmndOutput(
     "git log " \
     +" --pretty=format:'commit %H%nAuthor:  %an <%ae>%nDate:    %ad%nSummary: %s%n'" \
     +" -1 -- .",
     workingDir=gitDir
-    )
+    ))


### PR DESCRIPTION
Wrap `getCmndOutput()` in `s()` to decode bytestrings in Python 3.

Closes #310.

@bartlettroscoe, I think this is all that's needed for this particular script.