### PR TITLE
Remove warning when a component isn't found in an installed Config.cmake 

### DIFF
--- a/test/ctest_driver/TribitsExampleProject/CMakeLists.txt
+++ b/test/ctest_driver/TribitsExampleProject/CMakeLists.txt
@@ -2215,7 +2215,6 @@ FUNCTION(GENERATE_AAO_TESTS  USE_NEW_AAO_CTEST_CDASH_FEATURES)
       "DUMMY_PROJECT_DIR = 'dummy_client_of_TribitsExProj'"
       "EXPORT_CONFIG_FILE = '../BUILD/install/lib/cmake/TribitsExProj/TribitsExProjConfig.cmake'"
       "TribitsExProj_FIND_COMPONENTS = 'SimpleCxx[;]WithSubpackagesA[;]WrapExternal'"
-      "Component .WrapExternal. NOT found"
       "TribitsExProj_LIBRARIES = 'pws_a[;]simplecxx'"
       "TribitsExProj_TPL_INCLUDE_DIRS = '.*/examples/tpls/HeaderOnlyTpl'"
       "TribitsExProj_PACKAGE_LIST = 'WithSubpackages[;]WithSubpackagesC[;]WithSubpackagesB[;]WithSubpackagesA[;]MixedLang[;]SimpleCxx'"

--- a/tribits/core/installation/TribitsProjectConfigTemplate.cmake.in
+++ b/tribits/core/installation/TribitsProjectConfigTemplate.cmake.in
@@ -124,8 +124,6 @@ FOREACH(comp ${PDOLLAR}{COMPONENTS_LIST})
    LIST(APPEND ${PROJECT_NAME}_TPL_LIBRARY_DIRS ${PDOLLAR}{${PDOLLAR}{comp}_TPL_LIBRARY_DIRS})
    LIST(APPEND ${PROJECT_NAME}_TPL_LIBRARIES ${PDOLLAR}{${PDOLLAR}{comp}_TPL_LIBRARIES})
  ELSE()
-   # Component not found.
-   MESSAGE(WARNING "Component \"${PDOLLAR}{comp}\" NOT found.")
    # Set ${PROJECT_NAME}_<component>_FOUND to FALSE.
    SET(${PROJECT_NAME}_${PDOLLAR}{comp}_FOUND FALSE)
    # Set ${PROJECT_NAME}_FOUND to FALSE if component is not optional.


### PR DESCRIPTION
This isn't necessary as `find_package` will warn the first time optional components are missing and error out if they're required. It's intrusive if they're optional and not found, because this warning shows up at every reconfigure.