### PR TITLE
WIP: Fix install perms mods and tests to work on MacOSX for real (trilinos/Trilinos#7881)

### DIFF
--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -607,7 +607,7 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsHelloWorld_install_perms
     CMND make ARGS ${CTEST_BUILD_FLAGS} install
     PASS_REGULAR_EXPRESSION_ALL
       "Installing: .*/TriBITS_TribitsHelloWorld_install_perms/install/bin/hello_world.exe"
-      "0: Running: chmod o[+]rX -R /.*/TriBITS_TribitsHelloWorld_install_perms/install"
+      "0: Running: chmod -R o[+]rX /.*/TriBITS_TribitsHelloWorld_install_perms/install"
     ALWAYS_FAIL_ON_NONZERO_RETURN
 
   TEST_10
@@ -1611,7 +1611,7 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_install_perms
   TEST_1
     MESSAGE "Make TribitsExampleProject source dir user rwX only!"
     CMND chmod
-    ARGS g-rwx,o-rwx -R TribitsExampleProject
+    ARGS -R g-rwx,o-rwx TribitsExampleProject
 
   TEST_2
     MESSAGE "Do initial configure with just libs not tests with default install settings"
@@ -1644,8 +1644,8 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_install_perms
       ".*/install_base/install/lib/libpws_c.a"
       "0: Running: chgrp ${TribitsExProj_INSTALL_OWNING_GROUP} /.*/TriBITS_TribitsExampleProject_install_perms/install_base"
       "0: Running: chmod g[+]rwX,o[+]rX /.*/TriBITS_TribitsExampleProject_install_perms/install_base"
-      "1: Running: chgrp ${TribitsExProj_INSTALL_OWNING_GROUP} -R /.*/TriBITS_TribitsExampleProject_install_perms/install_base/install"
-      "1: Running: chmod g[+]rwX,o[+]rX -R /.*/TriBITS_TribitsExampleProject_install_perms/install_base/install"
+      "1: Running: chgrp -R ${TribitsExProj_INSTALL_OWNING_GROUP} /.*/TriBITS_TribitsExampleProject_install_perms/install_base/install"
+      "1: Running: chmod -R g[+]rwX,o[+]rX /.*/TriBITS_TribitsExampleProject_install_perms/install_base/install"
     ALWAYS_FAIL_ON_NONZERO_RETURN
 
   TEST_5
@@ -1658,12 +1658,12 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_install_perms
       install_base/install/lib
       install_base/install/share/WithSubpackagesB/stuff
     PASS_REGULAR_EXPRESSION_ALL
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base"
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/install"
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/install/bin"
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/install/include"
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/install/lib"
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/install/share/WithSubpackagesB/stuff"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/install"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/install/bin"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/install/include"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/install/lib"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/install/share/WithSubpackagesB/stuff"
     ALWAYS_FAIL_ON_NONZERO_RETURN
 
   TEST_6
@@ -1676,13 +1676,13 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_install_perms
       install_base/install/bin
       install_base/install/share/WithSubpackagesB/stuff
     PASS_REGULAR_EXPRESSION_ALL
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* MixedLang.hpp"
-      "[d]rwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* wsp_c"
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* C.hpp"
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* Makefile.export.WithSubpackagesC"
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* libpws_c.a"
-      "[-]rwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* exec_script.sh"
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* regular_file.txt"
+      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* MixedLang.hpp"
+      "[d]rwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* wsp_c"
+      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* C.hpp"
+      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* Makefile.export.WithSubpackagesC"
+      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* libpws_c.a"
+      "[-]rwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* exec_script.sh"
+      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* regular_file.txt"
     ALWAYS_FAIL_ON_NONZERO_RETURN
     # NOTE: Above, the file Makefile.export.WithSubpackagesC seems to be the
     # last file installed and therefore if it has the right permissions, then
@@ -1732,7 +1732,7 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_install_package_by_package_perm
   TEST_2
     MESSAGE "Make TribitsExampleProject source dir user rwX only!"
     CMND chmod
-    ARGS g-rwx,o-rwx -R TribitsExampleProject
+    ARGS -R g-rwx,o-rwx TribitsExampleProject
 
   TEST_3
     MESSAGE "Do initial configure with just libs not tests with default install settings"
@@ -1771,8 +1771,8 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_install_package_by_package_perm
       "0: Running: chmod g[+]rwX,o[+]rX /.*/TriBITS_TribitsExampleProject_install_package_by_package_perms/install_base"
       "1: Running: chgrp ${TribitsExProj_INSTALL_OWNING_GROUP} /.*/TriBITS_TribitsExampleProject_install_package_by_package_perms/install_base/subdir"
       "1: Running: chmod g[+]rwX,o[+]rX /.*/TriBITS_TribitsExampleProject_install_package_by_package_perms/install_base/subdir"
-      "2: Running: chgrp ${TribitsExProj_INSTALL_OWNING_GROUP} -R /.*/TriBITS_TribitsExampleProject_install_package_by_package_perms/install_base/subdir/install"
-      "2: Running: chmod g[+]rwX,o[+]rX -R /.*/TriBITS_TribitsExampleProject_install_package_by_package_perms/install_base/subdir/install"
+      "2: Running: chgrp -R ${TribitsExProj_INSTALL_OWNING_GROUP} /.*/TriBITS_TribitsExampleProject_install_package_by_package_perms/install_base/subdir/install"
+      "2: Running: chmod -R g[+]rwX,o[+]rX /.*/TriBITS_TribitsExampleProject_install_package_by_package_perms/install_base/subdir/install"
     ALWAYS_FAIL_ON_ZERO_RETURN
 
   TEST_6
@@ -1786,13 +1786,13 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_install_package_by_package_perm
       install_base/subdir/install/lib
       install_base/subdir/install/share/WithSubpackagesB/stuff
     PASS_REGULAR_EXPRESSION_ALL
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base"
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir"
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir/install"
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir/install/bin"
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir/install/include"
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir/install/lib"
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir/install/share/WithSubpackagesB/stuff"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir/install"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir/install/bin"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir/install/include"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir/install/lib"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* install_base/subdir/install/share/WithSubpackagesB/stuff"
     ALWAYS_FAIL_ON_NONZERO_RETURN
 
   TEST_7
@@ -1804,12 +1804,12 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_install_package_by_package_perm
       install_base/subdir/install/bin
       install_base/subdir/install/share/WithSubpackagesB/stuff
     PASS_REGULAR_EXPRESSION_ALL
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* MixedLang.hpp"
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* B.hpp"
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* Makefile.export.WithSubpackagesB"
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* libpws_b.a"
-      "[-]rwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* exec_script.sh"
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* regular_file.txt"
+      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* MixedLang.hpp"
+      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* B.hpp"
+      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* Makefile.export.WithSubpackagesB"
+      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* libpws_b.a"
+      "[-]rwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* exec_script.sh"
+      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* regular_file.txt"
     ALWAYS_FAIL_ON_NONZERO_RETURN
 
   TEST_8
@@ -1861,7 +1861,7 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_install_perms_nonowning_base_di
   TEST_1
     MESSAGE "Make TribitsExampleProject source dir user rwX only!"
     CMND chmod
-    ARGS g-rwx,o-rwx -R TribitsExampleProject
+    ARGS -R g-rwx,o-rwx TribitsExampleProject
 
   TEST_2
     MESSAGE "Remove existing intermediate base install if exists"
@@ -1900,8 +1900,8 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_install_perms_nonowning_base_di
       "0: NOTE: Not calling chgrp and chmod on ${installBaseDir} since owner '${TribitsExProj_INSTALL_BASE_OWNING_USER}' != current owner '${TribitsExProj_INSTALL_OWNING_USER}'!"
       "1: Running: chgrp ${TribitsExProj_INSTALL_OWNING_GROUP} ${installPrefixBaseDir}"
       "1: Running: chmod g[+]rwX,o[+]rX ${installPrefixBaseDir}"
-      "2: Running: chgrp ${TribitsExProj_INSTALL_OWNING_GROUP} -R ${installPrefix}"
-      "2: Running: chmod g[+]rwX,o[+]rX -R ${installPrefix}"
+      "2: Running: chgrp -R ${TribitsExProj_INSTALL_OWNING_GROUP} ${installPrefix}"
+      "2: Running: chmod -R g[+]rwX,o[+]rX ${installPrefix}"
     ALWAYS_FAIL_ON_NONZERO_RETURN
 
   TEST_6
@@ -1915,7 +1915,7 @@ TRIBITS_ADD_ADVANCED_TEST( TribitsExampleProject_install_perms_nonowning_base_di
       ${installPrefix}/lib
       ${installPrefix}/share/WithSubpackagesB/stuff
     PASS_REGULAR_EXPRESSION_ALL
-      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_BASE_OWNING_USER} ${TribitsExProj_INSTALL_OWNING_GROUP} .* ${installBaseDir}"
+      "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_BASE_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* ${installBaseDir}"
       "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} +${TribitsExProj_INSTALL_OWNING_GROUP} .* ${installPrefixBaseDir}"
       "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} +${TribitsExProj_INSTALL_OWNING_GROUP} .* ${installPrefix}"
       "drwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} +${TribitsExProj_INSTALL_OWNING_GROUP} .* ${installPrefix}/bin"

--- a/tribits/core/installation/set_installed_group_and_permissions.cmake.in
+++ b/tribits/core/installation/set_installed_group_and_permissions.cmake.in
@@ -34,8 +34,13 @@ FUNCTION(SET_DIR_OWNER_AND_PERMS  dirPath  recurseFlag)
   IF (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
     SET(STAT_ARGS "-f%Su")  # MacOSX stat
   ELSE()
-    SET(STAT_ARGS "-c %U")  # BinUtils stat
+    SET(STAT_ARGS "-c%U")  # BinUtils stat
   ENDIF()
+  # NOTE: Above, we can't have a space between the '-f' and '%Su' strings or
+  # the '-c' and '%U' strings.  If you do, then you get a single space at the
+  # beginning of the returned owner name as ' <dirOwner>' instead of
+  # '<dirOwner>'.  The automated tests on Linux and MacOSX don't pass if you
+  # don't have it this way.
 
   EXECUTE_PROCESS(COMMAND stat ${STAT_ARGS} "${dirPath}"
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/tribits/core/installation/set_installed_group_and_permissions.cmake.in
+++ b/tribits/core/installation/set_installed_group_and_permissions.cmake.in
@@ -15,7 +15,9 @@ SET(PROJECT_MAKE_INSTALL_PERMS_CHANGE "@PROJECT_MAKE_INSTALL_PERMS_CHANGE@")
 # Helper functions
 #
 
+
 SET(CHMOD_CHGRP_IDX 0)
+
 
 FUNCTION(ECHO_AND_RUN_CMND)
   STRING(REPLACE ";" " " CMND_STR "${ARGN}")
@@ -26,15 +28,16 @@ FUNCTION(ECHO_AND_RUN_CMND)
   ENDIF()
 ENDFUNCTION()
 
+
 FUNCTION(SET_DIR_OWNER_AND_PERMS  dirPath  recurseFlag)
 
-  IF (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    SET(STAT_ARG "-f")  # MacOSX stat
+  IF (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+    SET(STAT_ARGS "-f%Su")  # MacOSX stat
   ELSE()
-    SET(STAT_ARG "-c")  # BinUtils stat
+    SET(STAT_ARGS "-c %U")  # BinUtils stat
   ENDIF()
 
-  EXECUTE_PROCESS(COMMAND stat ${STAT_ARG} %U "${dirPath}"
+  EXECUTE_PROCESS(COMMAND stat ${STAT_ARGS} "${dirPath}"
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE  dirOwner)
 
@@ -46,12 +49,12 @@ FUNCTION(SET_DIR_OWNER_AND_PERMS  dirPath  recurseFlag)
 
     IF (NOT "${PROJECT_MAKE_INSTALL_GROUP}" STREQUAL "")
       ECHO_AND_RUN_CMND(
-        chgrp ${PROJECT_MAKE_INSTALL_GROUP} ${recurseFlag} "${dirPath}")
+        chgrp ${recurseFlag} ${PROJECT_MAKE_INSTALL_GROUP} "${dirPath}")
     ENDIF()
 
     IF (NOT "${PROJECT_MAKE_INSTALL_PERMS_CHANGE}" STREQUAL "")
       ECHO_AND_RUN_CMND(
-        chmod ${PROJECT_MAKE_INSTALL_PERMS_CHANGE} ${recurseFlag} "${dirPath}")
+        chmod ${recurseFlag} ${PROJECT_MAKE_INSTALL_PERMS_CHANGE} "${dirPath}")
     ENDIF()
 
   ENDIF()
@@ -61,9 +64,11 @@ FUNCTION(SET_DIR_OWNER_AND_PERMS  dirPath  recurseFlag)
 
 ENDFUNCTION()
 
+
 #
 # Executable script
 #
+
 
 IF (EXISTS "${projectInstallBaseDir}")
 


### PR DESCRIPTION
In my last set of commits in PR #327 (toward trilinos/Trilinos#7881), I was not not able to actually test this on a MacOSX machine and it needed a few tweaks.  I also updated the automated tests for this in TriBITS to 100% pass on MacOSX.  Therefore, I am pretty sure this is doing what it is supposed to do.

## How was this tested?

I ran the TriBITS test suite for serial-debug on a MacOSX machine and they 100% passed showing:

```
100% tests passed, 0 tests failed out of 309

Subproject Time Summary:
TriBITS    = 2101.74 sec*proc (309 tests)

Total Test time (real) = 376.57 sec
```

I also ran the TriBITS test suite on my RHEL6 machine 'crf450' and got:

```
100% tests passed, 0 tests failed out of 381

Subproject Time Summary:
TriBITS    = 1767.85 sec*proc (381 tests)

Total Test time (real) = 125.32 sec
```

