### PR TITLE
Change the default for EXPLICIT_TEMPLATE_INSTANTIATION to ON

### DIFF
--- a/tribits/ReleaseNotes.txt
+++ b/tribits/ReleaseNotes.txt
@@ -2,6 +2,16 @@
 Release Notes for TriBITS
 ----------------------------------------
 
+2020/11/12:
+
+*) MAJOR: The default for `<Project>_ENABLE_EXPLICIT_INSTANTIATION` (ETI) was
+ changed from `OFF` to `ON`.  This was turned on in practice for almost all
+ users of Trilinos so while this change technically breaks backward
+ compatibility of TriBITS, in practice, this will likely not impact any
+ important customers.  (And new customers of Trilinos and related TriBITS
+ projects will enjoy the benefits of ETI by default.  See
+ trilinos/Trilinos#8130.)
+
 2020/10/08:
 
 *) MAJOR: Tests defined with `TRIBITS_ADD_TEST()` and
@@ -9,8 +19,8 @@ Release Notes for TriBITS
  for non-MPI TPL_ENABLE_MPI=OFF configurations.  Before, the test would get
  added and basically ignore the value of `NUM_MPI_PROCS`.  This change
  together with the change to move to using `add_test(NAME <name> COMMAND
- <command>)` mostly restores backward compatbility for projects using TriBITS.
- For more details, see trilinos/Trilinos#8110.
+ <command>)` mostly restores backward compatibility for projects using
+ TriBITS.  For more details, see trilinos/Trilinos#8110.
 
 2020/09/28:
 

--- a/tribits/core/package_arch/TribitsGlobalMacros.cmake
+++ b/tribits/core/package_arch/TribitsGlobalMacros.cmake
@@ -482,7 +482,7 @@ MACRO(TRIBITS_DEFINE_GLOBAL_OPTIONS_AND_DEFINE_EXTRA_REPOS)
     "Print out when all of the various files get processed."
     )
 
-  ADVANCED_SET(${PROJECT_NAME}_ENABLE_EXPLICIT_INSTANTIATION OFF
+  ADVANCED_SET(${PROJECT_NAME}_ENABLE_EXPLICIT_INSTANTIATION ON
     CACHE BOOL
     "Enable explicit template instantiation in all packages that support it"
     )

--- a/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
+++ b/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
@@ -991,30 +991,30 @@ NOTE: These options are ignored when using Makefiles or other CMake
 generators.  They only work for the Ninja generator.
 
 
-Enabling explicit template instantiation for C++
-------------------------------------------------
+Disabling explicit template instantiation for C++
+-------------------------------------------------
 
-To enable explicit template instantiation for C++ code for packages that
-support it, configure with::
+By default, support for optional explicit template instantiation (ETI) for C++
+code is enabled.  To disable support for optional ETI, configure with::
 
-  -D <Project>_ENABLE_EXPLICIT_INSTANTIATION=ON
+  -D <Project>_ENABLE_EXPLICIT_INSTANTIATION=OFF
 
 When ``OFF``, all packages that have templated C++ code will use implicit
-template instantiation.
+template instantiation (unless they have hard-coded usage of ETI).
 
-Explicit template instantiation can be enabled (``ON``) or disabled (``OFF``)
-for individual packages with::
-
+ETI can be enabled (``ON``) or disabled (``OFF``) for individual packages
+with::
 
   -D <TRIBITS_PACKAGE>_ENABLE_EXPLICIT_INSTANTIATION=[ON|OFF]
 
 The default value for ``<TRIBITS_PACKAGE>_ENABLE_EXPLICIT_INSTANTIATION`` is
 set by ``<Project>_ENABLE_EXPLICIT_INSTANTIATION``.
 
-For packages that support it, explicit template instantation can massively
-reduce the compile times for the C++ code involved.  To see what packages
-support explicit instantation just search the CMakeCache.txt file for
-variables with ``ENABLE_EXPLICIT_INSTANTIATION`` in the name.
+For packages that support it, explicit template instantiation can massively
+reduce the compile times for the C++ code involved and can even avoid compiler
+crashes in some cases.  To see what packages support explicit template
+instantiation, just search the CMakeCache.txt file for variables with
+``ENABLE_EXPLICIT_INSTANTIATION`` in the name.
 
 
 Disabling the Fortran compiler and all Fortran code
@@ -3916,3 +3916,5 @@ original configure state.  Even with the all-at-once mode, if one kills the
 with an invalid configuration of the project.  In these cases, one may need to
 configure from scratch to get back to the original state before calling ``make
 dashboard``.
+
+..  LocalWords:  templated instantiation Makefiles CMake


### PR DESCRIPTION
This was motivated by Trilinos as it improves the
build and link time somewhat.