### PR TITLE
Update --expected-builds-file to accept a list (#350)

### DIFF
--- a/test/ci_support/CDashQueryAnalyzeReportUnitTestHelpers.py
+++ b/test/ci_support/CDashQueryAnalyzeReportUnitTestHelpers.py
@@ -6,6 +6,14 @@
 ################################################################################
 
 import re
+import shutil
+
+
+# Copy a list of files from one directory to another
+def copyFilesListSrcToDestDir(origDir, filenameList, destDir):
+  for filename in filenameList:
+    shutil.copyfile(origDir+"/"+filename, destDir+"/"+filename)
+
 
 # Find the index of a test in a list of test dicts
 def getIdxOfTestInTestLOD(testsLOD, site, buildName, testname):

--- a/test/ci_support/CDashQueryAnalyzeReport_UnitTests.py
+++ b/test/ci_support/CDashQueryAnalyzeReport_UnitTests.py
@@ -740,22 +740,22 @@ class test_writeCsvFileStructureToStr(unittest.TestCase):
 
 #############################################################################
 #
-# Test CDashQueryAnalyzeReport.getExpectedBuildsListfromCsvFile()
+# Test CDashQueryAnalyzeReport.getExpectedBuildsListOfDictsfromCsvFile()
 #
 #############################################################################
 
-class test_getExpectedBuildsListfromCsvFile(unittest.TestCase):
+class test_getExpectedBuildsListOfDictsfromCsvFile(unittest.TestCase):
 
-  def test_getExpectedBuildsListfromCsvFile(self):
+  def test_getExpectedBuildsListOfDictsfromCsvFile(self):
     expectedBuildsCsvFileStr=\
         "group, site, buildname\n"+\
         "group1, site1, buildname1\n"+\
         "group1, site1, buildname2\n"+\
         "group2, site2, buildname2\n\n\n\n"
-    csvFileName = "test_getExpectedBuildsListfromCsvFile.csv"
+    csvFileName = "test_getExpectedBuildsListOfDictsfromCsvFile.csv"
     with open(csvFileName, 'w') as csvFileToWrite:
       csvFileToWrite.write(expectedBuildsCsvFileStr)
-    expectedBuildsList = getExpectedBuildsListfromCsvFile(csvFileName)
+    expectedBuildsList = getExpectedBuildsListOfDictsfromCsvFile(csvFileName)
     expectedBuildsList_expected = \
       [
         { 'group' : 'group1', 'site' : 'site1', 'buildname' : 'buildname1' },

--- a/test/ci_support/cdash_analyze_and_report/twip_2_twim_2/expectedBuilds1.csv
+++ b/test/ci_support/cdash_analyze_and_report/twip_2_twim_2/expectedBuilds1.csv
@@ -1,0 +1,4 @@
+group, site, buildname
+Specialized, cee-rhel6, Trilinos-atdm-cee-rhel6-clang-opt-serial
+Specialized, cee-rhel6, Trilinos-atdm-cee-rhel6-gnu-4.9.3-opt-serial
+Specialized, cee-rhel6, Trilinos-atdm-cee-rhel6-intel-opt-serial

--- a/test/ci_support/cdash_analyze_and_report/twip_2_twim_2/expectedBuilds2.csv
+++ b/test/ci_support/cdash_analyze_and_report/twip_2_twim_2/expectedBuilds2.csv
@@ -1,0 +1,4 @@
+group, site, buildname
+Specialized, mutrino, Trilinos-atdm-mutrino-intel-opt-openmp-KNL
+Specialized, waterman, Trilinos-atdm-waterman-cuda-9.2-release-debug
+Specialized, waterman, Trilinos-atdm-waterman-gnu-release-debug-openmp

--- a/test/ci_support/cdash_analyze_and_report_UnitTests.py
+++ b/test/ci_support/cdash_analyze_and_report_UnitTests.py
@@ -1519,6 +1519,9 @@ class test_cdash_analyze_and_report(unittest.TestCase):
   # them to be passing and missing tests, then write then back to the file
   # fullCDashNonpassingTests.json
   #
+  # Also, this tests passing in the expected builds as two different files to
+  # test that feature.
+  #
   def test_twip_2_twim_2(self):
 
     testCaseName = "twip_2_twim_2"
@@ -1611,11 +1614,19 @@ cee-rhel6, Trilinos-atdm-cee-rhel6-gnu-4.9.3-opt-serial, PanzerAdaptersIOSS_tIOS
     # missing days.  (This will need to be done once we tablulate "Consecutive
     # Pass Days" and "Consecutive Missing Days".)
 
+    # Set up two expected builds files instead of just one
+    os.remove(testOutputDir+"/expectedBuilds.csv")
+    testCaseSrcDir = testCiSupportDir+"/"+g_baseTestDir+"/"+testCaseName
+    copyFilesListSrcToDestDir(
+      testCaseSrcDir, ("expectedBuilds1.csv", "expectedBuilds2.csv"),
+      testOutputDir)
+
     # Run the script and make sure it outputs the right stuff
     cdash_analyze_and_report_run_case(
       self,
       testCaseName,
       [ "--limit-test-history-days=30",  # Test that you can set this as int
+        "--expected-builds-file=expectedBuilds1.csv,expectedBuilds2.csv",
         "--write-test-data-to-file=test_data.json",
         ],
       0,

--- a/tribits/ci_support/CDashQueryAnalyzeReport.py
+++ b/tribits/ci_support/CDashQueryAnalyzeReport.py
@@ -565,9 +565,19 @@ g_expectedBuildsCsvFileHeadersRequired = \
   ('group', 'site', 'buildname')
 
 
-def getExpectedBuildsListfromCsvFile(expectedBuildsFileName):
+def getExpectedBuildsListOfDictsfromCsvFile(expectedBuildsFileName):
   return readCsvFileIntoListOfDicts(expectedBuildsFileName,
     g_expectedBuildsCsvFileHeadersRequired)
+
+
+def getExpectedBuildsListOfDictsFromCsvFileArg(expectedBuildsFileArg):
+  expectedBuildsLOD = []
+  if expectedBuildsFileArg:
+    expectedBuildsFilenameList = expectedBuildsFileArg.split(",")
+    for expectedBuildsFilename in expectedBuildsFilenameList:
+      expectedBuildsLOD.extend(
+        getExpectedBuildsListOfDictsfromCsvFile(expectedBuildsFilename))
+  return expectedBuildsLOD
 
 
 # Write list of builds from a builds LOD to a CSV file structure meant to

--- a/tribits/ci_support/cdash_analyze_and_report.py
+++ b/tribits/ci_support/cdash_analyze_and_report.py
@@ -125,9 +125,10 @@ def injectCmndLineOptionsInParser(clp, gitoliteRootDefault=""):
   clp.add_option(
     "--expected-builds-file", dest="expectedBuildsFile", type="string",
     default="",
-    help="Path to CSV file that lists the expected builds.  Each of these builds"+\
+    help="Path to a CSV file that lists the expected builds.  Each of these builds"+\
       " must have unique 'site' and 'buildname' field pairs or an error will be"+\
-      " raised and the tool will abort.  [default = '']" )
+      " raised and the tool will abort.  A list of files is also allowed that are"+\
+      " separated with ',' as <file1>,<file2>,... [default = '']" )
 
   clp.add_option(
     "--tests-with-issue-trackers-file", dest="testsWithIssueTrackersFile",
@@ -454,11 +455,8 @@ if __name__ == '__main__':
     #
 
     # Get list of expected builds from input CSV file
-    if inOptions.expectedBuildsFile:
-      expectedBuildsLOD = \
-        CDQAR.getExpectedBuildsListfromCsvFile(inOptions.expectedBuildsFile)
-    else:
-      expectedBuildsLOD = []
+    expectedBuildsLOD = CDQAR.getExpectedBuildsListOfDictsFromCsvFileArg(
+      inOptions.expectedBuildsFile)
     print("\nNum expected builds = "+str(len(expectedBuildsLOD)))
 
     # Create a SearchableListOfDict object to help look up expected builds


### PR DESCRIPTION
This is needed to eliminate duplication in the listing of expected builds in the [TrilinosATDMStatus](https://gitlab-ex.sandia.gov/atdm/TrilinosATDMStatus) driver scripts.  Also, this will make it clear if any new unexpected builds show up on CDash for the full driver script.
