### PR TITLE
tribits/ci_support: Remove soft hyphens

### DIFF
--- a/tribits/ci_support/CDashQueryAnalyzeReport.py
+++ b/tribits/ci_support/CDashQueryAnalyzeReport.py
@@ -3022,6 +3022,10 @@ def createHtmlMimeEmail(fromAddress, toAddress, subject, textBody, htmlBody):
   # through the gateway when html text lines are longer than 1000 characters.
   msg['Content-Transfer-Encoding'] = "quoted-printable"
 
+  # Remove hidden soft hyphens from htmlBody so triagers can easily copy paste
+  # long build and test names into CDash queries.
+  htmlBody = htmlBody.replace('&shy;','')
+
   # Record the MIME types of both parts - text/plain and text/html.
   part1 = MIMEText(textBody.encode('utf-8'), 'plain', 'utf-8')
   part2 = MIMEText(htmlBody.encode('utf-8'), 'html', 'utf-8')

--- a/tribits/ci_support/CDashQueryAnalyzeReport.py
+++ b/tribits/ci_support/CDashQueryAnalyzeReport.py
@@ -3005,7 +3005,8 @@ import email.message
 
 # Create MINE formatted email object (but don't send it)
 #
-def createHtmlMimeEmail(fromAddress, toAddress, subject, textBody, htmlBody):
+def createHtmlMimeEmail(fromAddress, toAddress, subject, textBody, htmlBody,
+                        doRemoveSoftHyphens='off'):
 
   # Create message container - the correct MIME type is multipart/alternative.
   msg = MIMEMultipart('alternative')
@@ -3024,7 +3025,8 @@ def createHtmlMimeEmail(fromAddress, toAddress, subject, textBody, htmlBody):
 
   # Remove hidden soft hyphens from htmlBody so triagers can easily copy paste
   # long build and test names into CDash queries.
-  htmlBody = htmlBody.replace('&shy;','')
+  if doRemoveSoftHyphens == 'on':
+    htmlBody = htmlBody.replace('&shy;', '')
 
   # Record the MIME types of both parts - text/plain and text/html.
   part1 = MIMEText(textBody.encode('utf-8'), 'plain', 'utf-8')

--- a/tribits/ci_support/cdash_analyze_and_report.py
+++ b/tribits/ci_support/cdash_analyze_and_report.py
@@ -265,6 +265,13 @@ def injectCmndLineOptionsInParser(clp, gitoliteRootDefault=""):
     "--send-email-to=", dest="sendEmailTo", type="string", default="",
     help="Send email to 'address1, address2, ...'.  [default '']" )
 
+  addOptionParserChoiceOption(
+    "--email-without-soft-hyphens",
+    "emailWithoutSoftHyphens",
+    ("on", "off"), 1,
+    "Remove soft hyphens from emails.",
+    clp )
+
 
 def validateAndConvertCmndLineOptions(inOptions):
 
@@ -969,7 +976,8 @@ if __name__ == '__main__':
       emailAddress = emailAddress.strip()
       print("\nSending email to '"+emailAddress+"' ...")
       msg=CDQAR.createHtmlMimeEmail(
-        inOptions.emailFromAddress, emailAddress, summaryLine, "", htmlEmailBodyStr)
+        inOptions.emailFromAddress, emailAddress, summaryLine, "",
+        htmlEmailBodyStr, inOptions.emailWithoutSoftHyphens)
       CDQAR.sendMineEmail(msg)
 
   #


### PR DESCRIPTION
  - Remove soft hyphens from htmlBody in createHtmlMimeEmail.

During triaging we often want to copy long build names or test names from the email bodies into CDash queries but run into issues. It turns out that our browsers don't render these soft hyphens but these hidden formatting characters cause the CDash queries to fail.

CC: @ZUUL42, @prwolfe, @jwillenbring, @william76  