### PR TITLE
Remove spaces in include of < time.h > (trilinos/Trilinos#9104)

### DIFF
--- a/tribits/win_interface/include/gettimeofday.c
+++ b/tribits/win_interface/include/gettimeofday.c
@@ -1,4 +1,4 @@
-#include < time.h >
+#include <time.h>
 #include <Winsock2.h> /* to get timeval struct */
 
 struct timezone 


### PR DESCRIPTION
As described in PR trilinos/Trilinos#9104, removing these spaces in:

```
  #included < time.h >
```

fixes the build of Trilinos on Windows using Clang.
