### PR TITLE
#377: Fixing typos

### DIFF
--- a/tribits/core/package_arch/TribitsReadAllProjectDepsFilesCreateDepsGraph.cmake
+++ b/tribits/core/package_arch/TribitsReadAllProjectDepsFilesCreateDepsGraph.cmake
@@ -74,7 +74,7 @@ macro(tribits_read_all_project_deps_files_create_deps_graph)
 
   tribits_config_code_start_timer(SET_UP_DEPENDENCIES_TIME_START_SECONDS)
 
-  tribits_read_defined_external_and_intenral_toplevel_packages_lists()
+  tribits_read_defined_external_and_internal_toplevel_packages_lists()
 
   tribits_read_deps_files_create_deps_graph()
 
@@ -84,11 +84,11 @@ macro(tribits_read_all_project_deps_files_create_deps_graph)
 endmacro()
 
 
-# @MACRO: tribits_read_defined_external_and_intenral_toplevel_packages_lists()
+# @MACRO: tribits_read_defined_external_and_internal_toplevel_packages_lists()
 #
 # Usage::
 #
-#   tribits_read_defined_external_and_intenral_toplevel_packages_lists()
+#   tribits_read_defined_external_and_internal_toplevel_packages_lists()
 #
 # Macro run at the top project-level scope that reads in the contents of all
 # of the `<repoDir>/TPLsList.cmake`_ and `<repoDir>/PackagesList.cmake`_ files
@@ -124,7 +124,7 @@ endmacro()
 #
 # See `Function call tree for constructing package dependency graph`_
 #
-macro(tribits_read_defined_external_and_intenral_toplevel_packages_lists)
+macro(tribits_read_defined_external_and_internal_toplevel_packages_lists)
 
   tribits_set_all_extra_repositories()
 
@@ -272,7 +272,7 @@ endfunction()
 #
 macro(tribits_set_all_extra_repositories)
   if ("${${PROJECT_NAME}_ALL_EXTRA_REPOSITORIES}"   STREQUAL  "")
-    # Allow list to be seprated by ',' instead of just by ';'.  This is needed
+    # Allow list to be separated by ',' instead of just by ';'.  This is needed
     # by the unit test driver code
     split("${${PROJECT_NAME}_PRE_REPOSITORIES}"  ","
       ${PROJECT_NAME}_PRE_REPOSITORIES)

--- a/tribits/core/package_arch/TribitsReadAllProjectDepsFilesCreateDepsGraph.cmake
+++ b/tribits/core/package_arch/TribitsReadAllProjectDepsFilesCreateDepsGraph.cmake
@@ -95,7 +95,7 @@ endmacro()
 # to get the list of defined external packages (TPLs) and internal top-level
 # (TriBITS) packages.
 #
-# On output, this produces the list varaibles::
+# On output, this produces the list variables::
 #
 #   ${PROJECT_NAME}_DEFINED_TPLS
 #   ${PROJECT_NAME}_DEFINED_INTERNAL_PACKAGES
@@ -108,7 +108,7 @@ endmacro()
 #   ${PROJECT_NAME}_PACKAGES (old)
 #   ${PROJECT_NAME}_TPLS (old)
 #
-# and related varaibles.
+# and related variables.
 #
 # This includes the files:
 #
@@ -120,7 +120,7 @@ endmacro()
 #  * `tribits_process_tpls_lists()`_
 #  * `tribits_process_packages_and_dirs_lists()`_
 #
-# which set their varaibles.
+# which set their variables.
 #
 # See `Function call tree for constructing package dependency graph`_
 #
@@ -245,7 +245,7 @@ endmacro()
 #
 #   tribits_write_xml_dependency_files_if_supported()
 #
-# Function that writes XML dependnecy files if support for that exists in this
+# Function that writes XML dependency files if support for that exists in this
 # instance of TriBITs.
 #
 # See `Function call tree for constructing package dependency graph`_
@@ -264,7 +264,7 @@ endfunction()
 
 # Macro that sets ${PROJECT_NAME}_ALL_REPOSITORIES from
 # ${PROJECT_NAME}_PRE_REPOSITORIES and ${PROJECT_NAME}_EXTRA_REPOSITORIES if
-# it is not alrady set.  Also, it replaces ',' with ';' in the latter.
+# it is not already set.  Also, it replaces ',' with ';' in the latter.
 #
 # This function is needed in use cases where extra repos are used where the
 # extra repos are not read in through an ExtraRepositoriesList.cmake file and

--- a/tribits/core/package_arch/TribitsReadDepsFilesCreateDepsGraph.cmake
+++ b/tribits/core/package_arch/TribitsReadDepsFilesCreateDepsGraph.cmake
@@ -53,7 +53,7 @@ include(DualScopeSet)
 # and `<projectDir>/cmake/ProjectDependenciesSetup.cmake`_ and then reads in
 # all of the `<packageDir>/cmake/Dependencies.cmake`_ and
 # `<packageDir>/<spkgDir>/cmake/Dependencies.cmake`_ files and builds the
-# package depenency graph varibles.
+# package dependency graph variables.
 #
 # This macro reads from the variables::
 #
@@ -64,9 +64,9 @@ include(DualScopeSet)
 #
 #   ${PROJECT_NAME}_SE_PACKAGES (old)
 #
-# as well creates the package dependency varaibles described in `List
+# as well creates the package dependency variables described in `List
 # variables defining the package dependencies graph`_ that defines the
-# directed acyclic depenency (DAG) package dependency graph (with navigation
+# directed acyclic dependency (DAG) package dependency graph (with navigation
 # up and down the graph).
 #
 # See `Function call tree for constructing package dependency graph`_
@@ -220,7 +220,7 @@ endmacro()
 #   ${PACKAGE_NAME}_FORWARD_TEST_REQUIRED_DEP_PACKAGES
 #   ${PACKAGE_NAME}_FORWARD_TEST_OPTIONAL_DEP_PACKAGES
 #
-# It also appends the list varaible::
+# It also appends the list variable::
 #
 #   ${PROJECT_NAME}_SE_PACKAGES (old)
 #
@@ -236,7 +236,7 @@ macro(tribits_read_toplevel_package_deps_files_add_to_graph  PACKAGE_NAME)
 
   tribits_prep_to_read_dependencies(${PACKAGE_NAME})
 
-  # Listing of subpakages
+  # Listing of subpackages
   set(SUBPACKAGES_DIRS_CLASSIFICATIONS_OPTREQS) # Allow to be empty
 
   # B) Read in this package's Dependencies file and save off read dependency vars.
@@ -366,7 +366,7 @@ endmacro()
 #
 #   tribits_save_off_dependencies_vars(<postfix>)
 #
-# Saves off package depeneency varaibles with variable suffix ``_<postfix>``.
+# Saves off package dependency variables with variable suffix ``_<postfix>``.
 #
 # See `Function call tree for constructing package dependency graph`_
 #
@@ -417,11 +417,11 @@ endmacro()
 #
 #   tribits_process_package_dependencies_lists(<packageName>)
 #
-# Sets up the upstsream and downstream/forward package dependency list
-# varaibles for ``<packageName>`` descrdibed in `List variables defining the
+# Sets up the upstream and downstream/forward package dependency list
+# variables for ``<packageName>`` described in `List variables defining the
 # package dependencies graph`_.  Note that the downstream/forward dependencies
 # of upstream packages on this package ``<packageName>`` are built up
-# incrimentally.
+# incrementally.
 #
 # See `Function call tree for constructing package dependency graph`_
 # 
@@ -711,7 +711,7 @@ endfunction()
 #   <subpackageFullName>_PARENT_PACKAGE
 #   <subpackageFullName>_PARENT_REPOSITORY
 #
-# And it appends for each subpackage to varaible::
+# And it appends for each subpackage to variable::
 #
 #   ${PROJECT_NAME}_SE_PACKAGES (old)
 #
@@ -876,7 +876,7 @@ macro(tribits_read_subpackage_deps_file_add_to_graph  PACKAGE_NAME
   set(SUBPACKAGE_FULLNAME ${PACKAGE_NAME}${SUBPACKAGE_NAME})
 
   #
-  # A) Get ready to read in the contents of this this subpakages's
+  # A) Get ready to read in the contents of this this subpackage's
   # Dependencies.cmake file
   #
 
@@ -924,7 +924,7 @@ endmacro()
 #
 
 
-# Function that sets a varaible to DECLARED-UNDEFINED
+# Function that sets a variable to DECLARED-UNDEFINED
 #
 function(tribits_declare_undefined  VAR_NAME)
   set(${VAR_NAME}  DECLARED-UNDEFINED  PARENT_SCOPE)

--- a/tribits/core/package_arch/TribitsReadDepsFilesCreateDepsGraph.cmake
+++ b/tribits/core/package_arch/TribitsReadDepsFilesCreateDepsGraph.cmake
@@ -254,7 +254,7 @@ macro(tribits_read_toplevel_package_deps_files_add_to_graph  PACKAGE_NAME)
   # B.1) Set up the mail addresses (one regression email list for the package
   # and all subpackages)
 
-  tribits_set_pacakge_regression_email_list(${PACKAGE_NAME})
+  tribits_set_package_regression_email_list(${PACKAGE_NAME})
 
   # B.2) Process this package's subpackages first *before* finishing this packages!
 
@@ -587,18 +587,18 @@ function(tribits_append_forward_dep_packages PACKAGE_NAME LIST_TYPE)
 endfunction()
 
 
-# @MACRO: tribits_set_pacakge_regression_email_list()
+# @MACRO: tribits_set_package_regression_email_list()
 #
 # Usage::
 #
-#  tribits_set_pacakge_regression_email_list(<packageName>)
+#  tribits_set_package_regression_email_list(<packageName>)
 #
 # Macro that sets a pacakge's regression email address
 # ``${PACKAGE_NAME}_REGRESSION_EMAIL_LIST`` as described in ???.
 #
 # See `Function call tree for constructing package dependency graph`_
 #
-macro(tribits_set_pacakge_regression_email_list PACKAGE_NAME)
+macro(tribits_set_package_regression_email_list PACKAGE_NAME)
 
   # Lower-case package name To be used with auto email naming based on base email address
   string(TOLOWER "${PACKAGE_NAME}" LPACKAGE)
@@ -698,7 +698,7 @@ endfunction()
 # `tribits_package_define_dependencies()`_ , add subpackages to the list of
 # defined packages, and define user cache var options for those subpackages.
 #
-# This sets the list varaibles for the parent package ``<toplevelPackageName>``::
+# This sets the list variables for the parent package ``<toplevelPackageName>``::
 #
 #   <parentPackageName>_SUBPACKAGES
 #   <parentPackageName>_SUBPACKAGE_DIRS

--- a/tribits/core/package_arch/TribitsReadDepsFilesCreateDepsGraph.cmake
+++ b/tribits/core/package_arch/TribitsReadDepsFilesCreateDepsGraph.cmake
@@ -249,7 +249,7 @@ macro(tribits_read_toplevel_package_deps_files_add_to_graph  PACKAGE_NAME)
 
   tribits_assert_read_dependency_vars(${PACKAGE_NAME})
 
-  tribits_save_off_dependencies_vars(PARENTPACK)
+  tribits_save_off_dependency_vars(PARENTPACK)
 
   # B.1) Set up the mail addresses (one regression email list for the package
   # and all subpackages)
@@ -360,17 +360,17 @@ macro(tribits_assert_read_dependency_vars  PACKAGE_NAME)
 endmacro()
 
 
-# @MACRO: tribits_save_off_dependencies_vars()
+# @MACRO: tribits_save_off_dependency_vars()
 #
 # Usage::
 #
-#   tribits_save_off_dependencies_vars(<postfix>)
+#   tribits_save_off_dependency_vars(<postfix>)
 #
 # Saves off package dependency variables with variable suffix ``_<postfix>``.
 #
 # See `Function call tree for constructing package dependency graph`_
 #
-macro(tribits_save_off_dependencies_vars  POSTFIX)
+macro(tribits_save_off_dependency_vars  POSTFIX)
 
   set(LIB_REQUIRED_DEP_PACKAGES_${POSTFIX} ${LIB_REQUIRED_DEP_PACKAGES})
   set(LIB_OPTIONAL_DEP_PACKAGES_${POSTFIX} ${LIB_OPTIONAL_DEP_PACKAGES})

--- a/tribits/core/package_arch/TribitsSystemDataStructuresMacrosFunctions.rst
+++ b/tribits/core/package_arch/TribitsSystemDataStructuresMacrosFunctions.rst
@@ -446,7 +446,7 @@ lists and dependency data-structures described above.
 |           `tribits_prep_to_read_dependencies()`_
 |           ``include(`` `<packageDir>/cmake/Dependencies.cmake`_ ``)``
 |           `tribits_assert_read_dependency_vars()`_
-|           `tribits_save_off_dependencies_vars()`_
+|           `tribits_save_off_dependency_vars()`_
 |           `tribits_parse_subpackages_append_se_packages_add_options()`_
 |           `tribits_read_package_subpackage_deps_files_add_to_graph()`_
 |             Foreach ``SUBPACKAGE``:

--- a/tribits/core/package_arch/TribitsSystemDataStructuresMacrosFunctions.rst
+++ b/tribits/core/package_arch/TribitsSystemDataStructuresMacrosFunctions.rst
@@ -69,7 +69,7 @@ is treated as an internal or external package is determined by the variable::
   ${PACKAGE_NAME}_PACKAGE_STATUS=[INTERNAL|EXTERNAL]
 
 which gets set variouscriteria as described in section `Determining if a
-package is internal or external`_.  This varaible determines what
+package is internal or external`_.  This variable determines what
 pre-built/pre-installed packages must be found out on the system if enabled
 and what internal packages need to be built if enabled.
 
@@ -80,7 +80,7 @@ is used with an adjective, it is usually meant in this more general context.
 ToDo: Describe the data-structures of all "Packages" which includes
 subpackages as well and the lists of enabled packages.
 
-These data-stractures as well as the package dependencies graph is built up in
+These data-structures as well as the package dependencies graph is built up in
 the macro `tribits_read_all_project_deps_files_create_deps_graph()`_ with the
 call graph described in the section `Function call tree for constructing
 package dependency graph`_.
@@ -141,7 +141,7 @@ files for the top-level packages read and processed in the macro
   TribitsAdjustPackageEnables.cmake
 
 One can determine if a package in this list is a top-level parent package or a
-sub-subpackage based on the value of the varaible
+sub-subpackage based on the value of the variable
 `${PACKAGE_NAME}_PARENT_PACKAGE`_.  If the value is non empty, then
 ``${PACKAGE_NAME}`` is a subpackage.  If the value is empty "", then
 ``${PACKAGE_NAME}`` is a parent package.

--- a/tribits/core/package_arch/TribitsSystemDataStructuresMacrosFunctions.rst
+++ b/tribits/core/package_arch/TribitsSystemDataStructuresMacrosFunctions.rst
@@ -68,7 +68,7 @@ is treated as an internal or external package is determined by the variable::
 
   ${PACKAGE_NAME}_PACKAGE_STATUS=[INTERNAL|EXTERNAL]
 
-which gets set variouscriteria as described in section `Determining if a
+which gets set various criteria as described in section `Determining if a
 package is internal or external`_.  This variable determines what
 pre-built/pre-installed packages must be found out on the system if enabled
 and what internal packages need to be built if enabled.
@@ -168,7 +168,6 @@ The full list of defined TPLs is stored in the variable::
 This list is created from the `<repoDir>/TPLsList.cmake`_ files from each
 defined TriBITS Repository.  Along with this, the following variables for each
 of these TriBITS TPLs are defined::
-
 * `${TPL_NAME}_FINDMOD`_
 * `${TPL_NAME}_TESTGROUP`_
 
@@ -429,7 +428,7 @@ Below is the CMake macro and function call graph for constructing the packages
 lists and dependency data-structures described above.
 
 | `tribits_read_all_project_deps_files_create_deps_graph()`_
-|   `tribits_read_defined_external_and_intenral_toplevel_packages_lists()`_
+|   `tribits_read_defined_external_and_internal_toplevel_packages_lists()`_
 |     Foreach ``<repoDir>`` in ``${PROJECT_NAME}_ALL_REPOSITORIES``:
 |       ``include(`` `<repoDir>/TPLsList.cmake`_ ``)``
 |       `tribits_process_tpls_lists()`_

--- a/tribits/doc/guides/TribitsSystemMacroFunctionDocTemplate.rst
+++ b/tribits/doc/guides/TribitsSystemMacroFunctionDocTemplate.rst
@@ -33,7 +33,7 @@ understand the internals of TriBITS.
 @MACRO:    tribits_prep_to_read_dependencies() +
 @MACRO:    tribits_process_package_dependencies_lists() +
 @MACRO:    tribits_read_deps_files_create_deps_graph() +
-@MACRO:    tribits_save_off_dependencies_vars() +
+@MACRO:    tribits_save_off_dependency_vars() +
 @FUNCTION: tribits_set_dep_packages() +
 @MACRO:    tribits_write_xml_dependency_files() +
 @FUNCTION: tribits_write_xml_dependency_files_if_supported() +

--- a/tribits/doc/guides/TribitsSystemMacroFunctionDocTemplate.rst
+++ b/tribits/doc/guides/TribitsSystemMacroFunctionDocTemplate.rst
@@ -25,7 +25,7 @@ understand the internals of TriBITS.
 @MACRO:    tribits_read_all_package_deps_files_create_deps_graph() +
 @MACRO:    tribits_read_package_subpackage_deps_files_add_to_graph() +
 @MACRO:    tribits_read_back_dependencies_vars() +
-@MACRO:    tribits_read_defined_external_and_intenral_toplevel_packages_lists() +
+@MACRO:    tribits_read_defined_external_and_internal_toplevel_packages_lists() +
 @MACRO:    tribits_read_all_project_deps_files_create_deps_graph() +
 @MACRO:    tribits_read_toplevel_package_deps_files_add_to_graph() +
 @MACRO:    tribits_read_subpackage_deps_file_add_to_graph() +


### PR DESCRIPTION
Addresses #377

### This PR:
- fixes text typos in:
  - tribits/core/package_arch/TribitsReadAllProjectDepsFilesCreateDepsGraph.cmake
  - tribits/core/package_arch/TribitsReadDepsFilesCreateDepsGraph.cmake
  - tribits/core/package_arch/TribitsSystemDataStructuresMacrosFunctions.rst
- there are still typos in functions and variables names, but I would leave that to @bartlettroscoe 