### PR TITLE
Fix broken tests for non-Fortran and CMake 3.21 builds (#363)

### DIFF
--- a/dev_testing/crf450/mpi-debug/do-configure
+++ b/dev_testing/crf450/mpi-debug/do-configure
@@ -14,6 +14,7 @@ if [ "$TRIBITS_BASE_DIR" == "" ] ; then
 fi
 
 ${TRIBITS_BASE_DIR}/dev_testing/generic/do-configure-mpi-debug \
+-DDART_TESTING_TIMEOUT=60 \
 -DCTEST_PARALLEL_LEVEL=16 \
 -DTriBITS_CTEST_DRIVER_COVERAGE_TESTS=TRUE \
 -DTriBITS_CTEST_DRIVER_MEMORY_TESTS=TRUE \
@@ -22,7 +23,7 @@ ${TRIBITS_BASE_DIR}/dev_testing/generic/do-configure-mpi-debug \
 -DTribitsExProj_INSTALL_BASE_DIR=/tmp/tribits_install_tests \
 -DTribitsExProj_INSTALL_OWNING_GROUP=wg-sems-users-son \
 -DTriBITS_ENABLE_REAL_GIT_CLONE_TESTS=ON \
--DDART_TESTING_TIMEOUT=60 \
+-DTriBITS_SHOW_TEST_START_END_DATE_TIME=ON \
 "$@"
 
 #-DTriBITS_CTEST_DRIVER_COVERAGE_TESTS=TRUE \

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -444,7 +444,7 @@ tribits_add_advanced_test( TribitsHelloWorld_CONFIGURE_OPTIONS_FILE
     ARGS -DTribitsHelloWorld_CONFIGURE_OPTIONS_FILE=ConfigOptions1.cmake
       .
     PASS_REGULAR_EXPRESSION_ALL
-      "(include|INCLUDE) could not find load file"
+      "(include|INCLUDE) could not find (load|requested) file"
       "TriBITS_TribitsHelloWorld_CONFIGURE_OPTIONS_FILE/ConfigOptions1.cmake"
     # NOTE: Above shows that FILEPATH type causes relative paths to be
     # evaluated w.r.t. the current working directory.

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -599,7 +599,7 @@ tribits_add_advanced_test( TribitsHelloWorld_install_perms
     CMND make ARGS ${CTEST_BUILD_FLAGS} install
     PASS_REGULAR_EXPRESSION_ALL
       "Installing: .*/TriBITS_TribitsHelloWorld_install_perms/install/bin/hello_world.exe"
-      "0: Running: chmod -R o[+]rX /.*/TriBITS_TribitsHelloWorld_install_perms/install"
+      "0: Running: chmod -R g[+]rX,o[+]rX /.*/TriBITS_TribitsHelloWorld_install_perms/install"
     ALWAYS_FAIL_ON_NONZERO_RETURN
 
   TEST_10

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -1600,6 +1600,13 @@ if (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
 endif()
 
 
+if ( ${PROJECT_NAME}_ENABLE_Fortran )
+  set(mixedLangHeaderRegex
+    "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* MixedLang.hpp")
+else()
+  set(mixedLangHeaderRegex "")
+endif()
+
 tribits_add_advanced_test( TribitsExampleProject_install_perms
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
@@ -1678,7 +1685,7 @@ tribits_add_advanced_test( TribitsExampleProject_install_perms
       install_base/install/bin
       install_base/install/share/WithSubpackagesB/stuff
     PASS_REGULAR_EXPRESSION_ALL
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* MixedLang.hpp"
+      "${mixedLangHeaderRegex}"
       "[d]rwxrwxr-x.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* wsp_c"
       "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* C.hpp"
       "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* Makefile.export.WithSubpackagesC"
@@ -1714,6 +1721,13 @@ tribits_add_advanced_test( TribitsExampleProject_install_perms
   #   install(DIRECTORY ... USE_SOURCE_PERMISSIONS) will actually have the
   #   correct group and other permissions set.
 
+if ( ${PROJECT_NAME}_ENABLE_Fortran )
+  set(mixedLangHeaderRegex
+    "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* MixedLang.hpp")
+
+else()
+  set(mixedLangHeaderRegex "")
+endif()
 
 tribits_add_advanced_test( TribitsExampleProject_install_package_by_package_perms
   OVERALL_WORKING_DIRECTORY TEST_NAME
@@ -1806,7 +1820,7 @@ tribits_add_advanced_test( TribitsExampleProject_install_package_by_package_perm
       install_base/subdir/install/bin
       install_base/subdir/install/share/WithSubpackagesB/stuff
     PASS_REGULAR_EXPRESSION_ALL
-      "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* MixedLang.hpp"
+      "${mixedLangHeaderRegex}"
       "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* B.hpp"
       "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* Makefile.export.WithSubpackagesB"
       "[-]rw-rw-r--.* .* ${TribitsExProj_INSTALL_OWNING_USER} *${TribitsExProj_INSTALL_OWNING_GROUP} .* libpws_b.a"

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -2126,6 +2126,11 @@ tribits_add_advanced_test( TribitsExampleProject_ALL_ST_NoFortran_enable_install
 # Find ninja so we can test TriBITS using ninja as well
 find_program(NINJA_EXE ninja)
 
+if ( CMAKE_VERSION VERSION_LESS 3.18.0 )
+  set(rulesNinjaFilePath "rules.ninja")
+else()
+  set(rulesNinjaFilePath "CMakeFiles/rules.ninja")
+endif()
 
 tribits_add_advanced_test( TribitsExampleProject_ALL_ST_NoFortran_Ninja
   OVERALL_WORKING_DIRECTORY TEST_NAME
@@ -2159,14 +2164,14 @@ tribits_add_advanced_test( TribitsExampleProject_ALL_ST_NoFortran_Ninja
 
   TEST_1
     MESSAGE "Verify TribitsExProj_PARALLEL_COMPILE_JOBS_LIMIT=3 has correct effect"
-    CMND grep ARGS -A 1 compile_job_pool rules.ninja
+    CMND grep ARGS -A 1 compile_job_pool ${rulesNinjaFilePath}
     PASS_REGULAR_EXPRESSION
       "depth *= *3"
     ALWAYS_FAIL_ON_NONZERO_RETURN
 
   TEST_2
     MESSAGE "Verify TribitsExProj_PARALLEL_LINK_JOBS_LIMIT=2 has correct effect"
-    CMND grep ARGS -A 1 link_job_pool rules.ninja
+    CMND grep ARGS -A 1 link_job_pool ${rulesNinjaFilePath}
     PASS_REGULAR_EXPRESSION
       "depth *= *2"
     ALWAYS_FAIL_ON_NONZERO_RETURN

--- a/test/ctest_driver/TribitsExampleMetaProject/CMakeLists.txt
+++ b/test/ctest_driver/TribitsExampleMetaProject/CMakeLists.txt
@@ -101,6 +101,7 @@ set(TribitsExampleMetaProject_COMMON_CONFIG_ARGS
 tribits_add_advanced_test( CTestDriver_TribitsExMetaProj_clone_default_branch_remote
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
 
   TEST_0
     MESSAGE "Run ctest driver with intial clone of the repos on the default branch 'master' and remote 'origin'"
@@ -326,6 +327,7 @@ tribits_add_advanced_test( CTestDriver_TribitsExMetaProj_clone_default_branch_re
 tribits_add_advanced_test( CTestDriver_TribitsExMetaProj_clone_custom_branch_remote
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
 
   TEST_0
     MESSAGE "Run ctest driver with intial clone of the repos on the default branch 'master' and remote 'origin'"
@@ -531,9 +533,9 @@ set(FULL_TEST_BINARY_DIR
   "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_CTestDriver_TribitsExMetaProj_version_date")
 
 tribits_add_advanced_test( CTestDriver_TribitsExMetaProj_version_date
-  OVERALL_WORKING_DIRECTORY TEST_NAME
-  OVERALL_NUM_MPI_PROCS 1
-  EXCLUDE_IF_NOT_TRUE GIT_SUPPORTS_VERSION_DATE
+  OVERALL_WORKING_DIRECTORY  TEST_NAME
+  OVERALL_NUM_MPI_PROCS  1
+  EXCLUDE_IF_NOT_TRUE  GIT_SUPPORTS_VERSION_DATE  ${PROJECT_NAME}_ENABLE_Fortran
 
   TEST_0
     MESSAGE "Run ctest driver with intial clone and generate version date files and install"

--- a/test/ctest_driver/TribitsExampleProject/CMakeLists.txt
+++ b/test/ctest_driver/TribitsExampleProject/CMakeLists.txt
@@ -226,6 +226,7 @@ set(TribitsExampleProject_COMMON_CONFIG_ARGS
 tribits_add_advanced_test( CTestDriver_PBP_ST_ALL_PASS
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
   TEST_0
     MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
     CMND ln
@@ -311,6 +312,7 @@ tribits_add_advanced_test( CTestDriver_PBP_GlobalConfigureFail
 tribits_add_advanced_test( CTestDriver_PBP_ST_BreakConfigureOptionalPkg
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
   TEST_0
     MESSAGE "Copy the project dir so I can break it!"
     CMND cp
@@ -354,6 +356,7 @@ tribits_add_advanced_test( CTestDriver_PBP_ST_BreakConfigureOptionalPkg
 tribits_add_advanced_test( CTestDriver_PBP_ST_BreakBuildLibOptionalPkg
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
   TEST_0
     MESSAGE "Copy the project dir so I can break it!"
     CMND cp
@@ -399,6 +402,7 @@ tribits_add_advanced_test( CTestDriver_PBP_ST_BreakBuildLibOptionalPkg
 tribits_add_advanced_test( CTestDriver_PBP_ST_BreakBuildAllOptionalPkg
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
   TEST_0
     MESSAGE "Copy the project dir so I can break it!"
     CMND cp
@@ -446,6 +450,7 @@ tribits_add_advanced_test( CTestDriver_PBP_ST_BreakBuildAllOptionalPkg
 tribits_add_advanced_test( CTestDriver_PBP_ST_BreakTestPkg
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
   TEST_0
     MESSAGE "Copy the project dir so I can break it!"
     CMND cp
@@ -494,6 +499,7 @@ tribits_add_advanced_test( CTestDriver_PBP_ST_BreakTestPkg
 tribits_add_advanced_test( CTestDriver_PBP_ST_BreakConfigureRequiredPkg
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
   TEST_0
     MESSAGE "Copy the project dir so I can break it!"
     CMND cp
@@ -542,6 +548,7 @@ tribits_add_advanced_test( CTestDriver_PBP_ST_BreakConfigureRequiredPkg
 tribits_add_advanced_test( CTestDriver_PBP_ST_ALL_COVERAGE
   OVERALL_WORKING_DIRECTORY TEST_NAME
   EXCLUDE_IF_NOT_TRUE  ${PACKAGE_NAME}_CTEST_DRIVER_COVERAGE_TESTS
+    ${PROJECT_NAME}_ENABLE_Fortran
   OVERALL_NUM_MPI_PROCS 1
   TEST_0
     MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
@@ -575,6 +582,7 @@ tribits_add_advanced_test( CTestDriver_PBP_ST_ALL_COVERAGE
 tribits_add_advanced_test( CTestDriver_PBP_ST_ALL_MEMORY
   OVERALL_WORKING_DIRECTORY TEST_NAME
   EXCLUDE_IF_NOT_TRUE  ${PACKAGE_NAME}_CTEST_DRIVER_MEMORY_TESTS
+    ${PROJECT_NAME}_ENABLE_Fortran
   OVERALL_NUM_MPI_PROCS 1
   TEST_0
     MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
@@ -865,6 +873,7 @@ tribits_add_advanced_test( CTestDriver_PBP_PT_ALL_PASS_CALLS_2
 
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
 
   TEST_0
     MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
@@ -963,6 +972,7 @@ tribits_add_advanced_test( CTestDriver_PBP_PT_ALL_PASS_CALLS_4
 
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
 
   TEST_0
     MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
@@ -1144,6 +1154,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( CTestDriver_AAO${AAO_POSTFIX}_ST_ALL_PASS
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
     TEST_0
       MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
       CMND ln
@@ -1200,6 +1211,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( CTestDriver_AAO${AAO_POSTFIX}_ST_SKIP_CTEST_ADD_TEST
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
 
     TEST_0
       MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
@@ -1238,6 +1250,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( CTestDriver_AAO${AAO_POSTFIX}_ST_INNER_ENABLE_TESTS
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
 
     TEST_0
       MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
@@ -1273,6 +1286,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( CTestDriver_AAO${AAO_POSTFIX}_ST_SimpleCxx_PASS
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
     TEST_0
       MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
       CMND ln
@@ -1338,6 +1352,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( CTestDriver_AAO${AAO_POSTFIX}_ST_PackagesSubset_PASS
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
     TEST_0
       MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
       CMND ln
@@ -1464,6 +1479,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( CTestDriver_AAO${AAO_POSTFIX}_ST_ALL_BreakWithSubpackagesALib
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
     TEST_0
       MESSAGE "Copy the project dir so I can break it!"
       CMND cp
@@ -1524,6 +1540,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( CTestDriver_AAO${AAO_POSTFIX}_ST_PackagesSubset_BreakWithSubpackagesALib
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
     TEST_0
       MESSAGE "Copy the project dir so I can break it!"
       CMND cp
@@ -1568,6 +1585,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( CTestDriver_AAO${AAO_POSTFIX}_ST_ALL_BreakSimpleCxxTestBuild
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
     TEST_0
       MESSAGE "Copy the project dir so I can break it!"
       CMND cp
@@ -1612,6 +1630,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( CTestDriver_AAO${AAO_POSTFIX}_ST_ALL_BreakSimpleCxxTestRun
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
     TEST_0
       MESSAGE "Copy the project dir so I can break it!"
       CMND cp
@@ -1655,6 +1674,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( CTestDriver_AAO${AAO_POSTFIX}_ST_ALL_COVERAGE
     OVERALL_WORKING_DIRECTORY TEST_NAME
     EXCLUDE_IF_NOT_TRUE  ${PACKAGE_NAME}_CTEST_DRIVER_COVERAGE_TESTS
+      ${PROJECT_NAME}_ENABLE_Fortran
     OVERALL_NUM_MPI_PROCS 1
     TEST_0
       MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
@@ -1689,6 +1709,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( CTestDriver_AAO${AAO_POSTFIX}_ST_ALL_MEMORY
     OVERALL_WORKING_DIRECTORY TEST_NAME
     EXCLUDE_IF_NOT_TRUE  ${PACKAGE_NAME}_CTEST_DRIVER_MEMORY_TESTS
+      ${PROJECT_NAME}_ENABLE_Fortran
     OVERALL_NUM_MPI_PROCS 1
     TEST_0
       MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
@@ -1878,6 +1899,7 @@ function(generate_aao_tests)
 
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
 
     TEST_0
       MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
@@ -2077,6 +2099,7 @@ function(generate_aao_tests)
 
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
 
     TEST_0
       MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
@@ -2201,6 +2224,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( ${TEST_NAME_BODY}
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
     TEST_0
       MESSAGE "Symlink TribitsExampleProject so no need to clone (which would not work)."
       CMND ln
@@ -2261,6 +2285,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( ${TEST_NAME_BODY}
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
 
     TEST_0
       MESSAGE "Copy TribitsExampleProject in so we can break it the install."
@@ -2381,6 +2406,7 @@ function(generate_aao_tests)
   tribits_add_advanced_test( ${TEST_NAME_BODY}
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
 
     TEST_0
       MESSAGE "Copy TribitsExampleProject in so we can break it the install."

--- a/test/ctest_driver/TribitsExampleProject/CMakeLists.txt
+++ b/test/ctest_driver/TribitsExampleProject/CMakeLists.txt
@@ -668,6 +668,14 @@ tribits_add_advanced_test( CTestDriver_PBP_Dashboard_ST_ALL_PASS
   # Follow-on tests will not check so much output.
 
 
+if ( ${PROJECT_NAME}_ENABLE_Fortran )
+  set(TribitsExProj_PACKAGES_list
+    "SimpleCxx[;]MixedLang[;]WithSubpackagesA[;]WithSubpackages")
+else()
+  set(TribitsExProj_PACKAGES_list
+    "SimpleCxx[;]WithSubpackagesA[;]WithSubpackages")
+endif()
+
 tribits_add_advanced_test( CTestDriver_AAO_Dashboard_ForwardArgs
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
@@ -712,7 +720,7 @@ tribits_add_advanced_test( CTestDriver_AAO_Dashboard_ForwardArgs
       CTEST_DASHBOARD_ROOT=
       make dashboard
     PASS_REGULAR_EXPRESSION_ALL
-      "Running: env TRIBITS_PROJECT_ROOT=.*/tribits/examples/TribitsExampleProject TribitsExProj_TRIBITS_DIR=.*/tribits TribitsExProj_WARNINGS_AS_ERRORS_FLAGS='' TribitsExProj_ENABLE_SECONDARY_TESTED_CODE=OFF TribitsExProj_CTEST_DO_ALL_AT_ONCE=TRUE CTEST_BUILD_NAME=MyCustomBuildName CTEST_DO_COVERAGE_TESTING=FALSE CTEST_BUILD_FLAGS='-j6' CTEST_PARALLEL_LEVEL=10 CTEST_DO_SUBMIT=FALSE CTEST_DROP_METHOD=OFF CTEST_DROP_SITE=OFF CTEST_DROP_LOCATION=OFF CTEST_DROP_SITE_COVERAGE=FALSE CTEST_DROP_LOCATION_COVERAGE=FALSE TRIBITS_2ND_CTEST_DROP_LOCATION=FALSE TRIBITS_2ND_CTEST_DROP_SITE=FALSE TribitsExProj_EXTRAREPOS_FILE=FALSE TribitsExProj_ENABLE_KNOWN_EXTERNAL_REPOS_TYPE=NONE TribitsExProj_IGNORE_MISSING_EXTRA_REPOSITORIES=TRUE TribitsExProj_EXTRA_REPOSITORIES=DummyRepo1,DummyRepo2,DummyRepo3 TribitsExProj_PACKAGES=SimpleCxx[;]MixedLang[;]WithSubpackagesA[;]WithSubpackages PROJECT_SOURCE_DIR=.*/tribits/examples/TribitsExampleProject .*/ctest -VV -S .*/tribits/ctest_driver/experimental_build_test.cmake"
+      "Running: env TRIBITS_PROJECT_ROOT=.*/tribits/examples/TribitsExampleProject TribitsExProj_TRIBITS_DIR=.*/tribits TribitsExProj_WARNINGS_AS_ERRORS_FLAGS='' TribitsExProj_ENABLE_SECONDARY_TESTED_CODE=OFF TribitsExProj_CTEST_DO_ALL_AT_ONCE=TRUE CTEST_BUILD_NAME=MyCustomBuildName CTEST_DO_COVERAGE_TESTING=FALSE CTEST_BUILD_FLAGS='-j6' CTEST_PARALLEL_LEVEL=10 CTEST_DO_SUBMIT=FALSE CTEST_DROP_METHOD=OFF CTEST_DROP_SITE=OFF CTEST_DROP_LOCATION=OFF CTEST_DROP_SITE_COVERAGE=FALSE CTEST_DROP_LOCATION_COVERAGE=FALSE TRIBITS_2ND_CTEST_DROP_LOCATION=FALSE TRIBITS_2ND_CTEST_DROP_SITE=FALSE TribitsExProj_EXTRAREPOS_FILE=FALSE TribitsExProj_ENABLE_KNOWN_EXTERNAL_REPOS_TYPE=NONE TribitsExProj_IGNORE_MISSING_EXTRA_REPOSITORIES=TRUE TribitsExProj_EXTRA_REPOSITORIES=DummyRepo1,DummyRepo2,DummyRepo3 TribitsExProj_PACKAGES=${TribitsExProj_PACKAGES_list} PROJECT_SOURCE_DIR=.*/tribits/examples/TribitsExampleProject .*/ctest -VV -S .*/tribits/ctest_driver/experimental_build_test.cmake"
 
       "ENV_PROJECT_SOURCE_DIR='.*/tribits/examples/TribitsExampleProject'"
       "ENV_CTEST_BUILD_NAME='MyCustomBuildName'"
@@ -723,7 +731,7 @@ tribits_add_advanced_test( CTestDriver_AAO_Dashboard_ForwardArgs
       "ENV_CTEST_DO_COVERAGE_TESTING='FALSE'"
       "ENV_CTEST_DO_SUBMIT='FALSE'"
       "ENV_TribitsExProj_ENABLE_SECONDARY_TESTED_CODE='OFF'"
-      "ENV_TribitsExProj_PACKAGES='SimpleCxx[;]MixedLang[;]WithSubpackagesA[;]WithSubpackages'"
+      "ENV_TribitsExProj_PACKAGES='${TribitsExProj_PACKAGES_list}'"
       "ENV_TribitsExProj_EXTRAREPOS_FILE='FALSE'"
       "ENV_TribitsExProj_ENABLE_KNOWN_EXTERNAL_REPOS_TYPE='NONE'"
       "ENV_TribitsExProj_EXTRA_REPOSITORIES='DummyRepo1,DummyRepo2,DummyRepo3'"

--- a/test/ctest_driver/TribitsExampleProject/CMakeLists.txt
+++ b/test/ctest_driver/TribitsExampleProject/CMakeLists.txt
@@ -2322,7 +2322,7 @@ function(generate_aao_tests)
         "CONFIGURE_OPTIONS = '.*[;]-DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON[;].*[;]-DCMAKE_INSTALL_PREFIX=install[;]-DTribitsExProj_ENABLE_INSTALL_CMAKE_CONFIG_FILES=ON'"
         "Build PASSED!"
         "Installing [(]i.e. building target 'install_package_by_package'[)] [.][.][.]"
-        "Build install output: BUILD_INSTALL_NUM_ERRORS='1',BUILD_INSTALL_RETURN_VAL='2'"
+        "Build install output: BUILD_INSTALL_NUM_ERRORS='(1|2)',BUILD_INSTALL_RETURN_VAL='2'"
 	"Install FAILED!"
         "File '' does NOT exist so all tests passed!"
         "TRIBITS_CTEST_DRIVER: OVERALL: ALL FAILED"

--- a/tribits/core/config_tests/fmangle/CMakeLists.txt
+++ b/tribits/core/config_tests/fmangle/CMakeLists.txt
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.17)
 project(fmangle C Fortran)
 add_definitions(${COMMON_DEFS})
 set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/tribits/core/package_arch/TribitsAddInstallGroupAndPermsFixups.cmake
+++ b/tribits/core/package_arch/TribitsAddInstallGroupAndPermsFixups.cmake
@@ -76,7 +76,9 @@ function(tribits_configure_set_installed_group_and_perms_file  TARGET_FILE)
   set(group_perms "")
   if (${PROJECT_NAME}_MAKE_INSTALL_GROUP_WRITABLE)
     set(group_perms "g+rwX")
-  elseif (${PROJECT_NAME}_MAKE_INSTALL_GROUP_READABLE)
+  elseif (${PROJECT_NAME}_MAKE_INSTALL_GROUP_READABLE
+    OR ${PROJECT_NAME}_MAKE_INSTALL_WORLD_READABLE
+    )
     set(group_perms "g+rX")
   endif()
 


### PR DESCRIPTION
Related to #363

This fixes all of the tests for the no-Fortran (`TriBITS_ENABLE_Fortran=OFF`) builds mostly be disabling them and updates a few tests for changes in behavior of CMake 3.21 vs. CMake 3.17.  But there are still 10 failing tests for CMake 3.21 due to changes in behavior that may be regressions of some type (but we need to understand more).

This cleans up most of the failures to enable GitHub Actions testing for #363.  The remaining CMake 3.21 tests will likely need to be disabled in the GHA testing builds.

See the individual commits for more details.

