### PR TITLE
Deal with pr null in not preprending build name (#363)

### DIFF
--- a/cmake/ctest/github_actions/run_github_actions_ctest_driver.sh
+++ b/cmake/ctest/github_actions/run_github_actions_ctest_driver.sh
@@ -171,7 +171,9 @@ echo "CTEST_BUILD_NAME = '${CTEST_BUILD_NAME}'"
 if [[ "${GITHUB_EVENT_PATH}" != "" ]] ; then
   pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
   echo "pull_number = '${pull_number}'"
-  export CTEST_BUILD_NAME="pr-${pull_number}_${CTEST_BUILD_NAME}${CTEST_BUILD_NAME_SUFFIX}"
+  if [[ "${pull_number}" != "null" ]] ; then
+    export CTEST_BUILD_NAME="pr-${pull_number}_${CTEST_BUILD_NAME}${CTEST_BUILD_NAME_SUFFIX}"
+  fi
 fi
 echo "CTEST_BUILD_NAME = '${CTEST_BUILD_NAME}'"
 


### PR DESCRIPTION
Where there is not an active PR, the 'pull_number' comes back 'null'.  In this case, we don't want to append the build name.

Related to #363.  Follow up from PR #396 which did not quite get the logic correct (because I did not know about 'null').
