### PR TITLE
Fix tribits_ctest_driver() package-by-package mode for CMake 3.19+ (#363, #394)

### DIFF
--- a/cmake/ctest/github_actions/tribits_cmake-3.21.0_makefiles_python-3.8_g++-9_tweaks.cmake
+++ b/cmake/ctest/github_actions/tribits_cmake-3.21.0_makefiles_python-3.8_g++-9_tweaks.cmake
@@ -15,6 +15,5 @@ set_test_disables(
   TriBITS_CTestDriver_PBP_ST_BreakBuildAllOptionalPkg
   TriBITS_CTestDriver_PBP_ST_BreakBuildLibOptionalPkg
   TriBITS_CTestDriver_PBP_ST_BreakConfigureOptionalPkg
-  TriBITS_CTestDriver_PBP_ST_BreakConfigureRequiredPkg
   TriBITS_CTestDriver_PBP_ST_BreakTestPkg
   )

--- a/test/ctest_driver/MockCTestDriver/CMakeLists.txt
+++ b/test/ctest_driver/MockCTestDriver/CMakeLists.txt
@@ -190,7 +190,7 @@ create_ctest_dependency_handling_test_case(
     "Final set of enabled packages:  Teuchos 1"
     "Final set of non-enabled packages:  TrilinosFramework RTOp Epetra Zoltan Shards Triutils Tpetra EpetraExt Stokhos Sacado Thyra Isorropia AztecOO Galeri Amesos Intrepid Ifpack ML Belos Stratimikos RBGen Phalanx Panzer 23"
     "Processing current package Teuchos: libs='ON', tests='ON'"
-    "CONFIGURE_OPTIONS = '-DTrilinos_TRIBITS_DIR=.+.-DCTEST_USE_LAUNCHERS:BOOL=1.-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON.-DTrilinos_WARNINGS_AS_ERRORS_FLAGS:STRING=-DummyErrFlags.-DTrilinos_ALLOW_NO_PACKAGES:BOOL=ON.-DTrilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON.-DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF.-DTrilinos_EXTRAREPOS_FILE:STRING=.*./MockTrilinos/cmake.ExtraRepositoriesList.cmake.-DTrilinos_IGNORE_MISSING_EXTRA_REPOSITORIES:BOOL=ON.-DTrilinos_ENABLE_KNOWN_EXTERNAL_REPOS_TYPE:STRING=Experimental.-DTrilinos_ENABLE_TESTS:BOOL=ON.-DTrilinos_ENABLE_Teuchos:BOOL=ON'"
+    "CONFIGURE_OPTIONS = '-DTrilinos_TRIBITS_DIR=.+[;]-DCTEST_USE_LAUNCHERS:BOOL=1[;]-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON[;]-DTrilinos_WARNINGS_AS_ERRORS_FLAGS:STRING=-DummyErrFlags[;]-DTrilinos_ALLOW_NO_PACKAGES:BOOL=ON[;]-DTrilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON[;]-DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF[;]-DTrilinos_EXTRAREPOS_FILE:STRING=.*./MockTrilinos/cmake.ExtraRepositoriesList.cmake[;]-DTrilinos_IGNORE_MISSING_EXTRA_REPOSITORIES:BOOL=ON[;]-DTrilinos_ENABLE_KNOWN_EXTERNAL_REPOS_TYPE:STRING=Experimental[;]-DTrilinos_ENABLE_TESTS:BOOL=ON[;]-DTrilinos_DEFINE_MISSING_PACKAGE_LIBS_TARGETS=ON[;]-DTrilinos_ENABLE_Teuchos:BOOL=ON'"
   )
 # NOTE: The above test pins down the form of the configure options passed to
 # different package configures to make sure everything in there.
@@ -245,10 +245,10 @@ create_ctest_dependency_handling_test_case(
     "Final set of enabled packages:  Teuchos RTOp Epetra Zoltan Triutils Tpetra EpetraExt Thyra 8"
     "Final set of non-enabled packages:  TrilinosFramework Shards Stokhos Sacado Isorropia AztecOO Galeri Amesos Intrepid Ifpack ML Belos Stratimikos RBGen Phalanx Panzer 16"
     "Processing current package Teuchos: libs='ON', tests=''"
-    "CONFIGURE_OPTIONS = '-DTrilinos_TRIBITS_DIR=.+-DCTEST_USE_LAUNCHERS:BOOL=1.-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON.-DTrilinos_WARNINGS_AS_ERRORS_FLAGS:STRING=-DummyErrFlags.-DTrilinos_ALLOW_NO_PACKAGES:BOOL=ON.-DTrilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON.-DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF.-DTrilinos_EXTRAREPOS_FILE:STRING=.+/examples/MockTrilinos/cmake/ExtraRepositoriesList.cmake.-DTrilinos_IGNORE_MISSING_EXTRA_REPOSITORIES:BOOL=ON.-DTrilinos_ENABLE_KNOWN_EXTERNAL_REPOS_TYPE:STRING=Experimental.-DTrilinos_ENABLE_TESTS:BOOL=.-DTrilinos_ENABLE_Teuchos:BOOL=ON'"
+    "CONFIGURE_OPTIONS = '-DTrilinos_TRIBITS_DIR=.+-DCTEST_USE_LAUNCHERS:BOOL=1[;]-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON[;]-DTrilinos_WARNINGS_AS_ERRORS_FLAGS:STRING=-DummyErrFlags[;]-DTrilinos_ALLOW_NO_PACKAGES:BOOL=ON[;]-DTrilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON[;]-DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF[;]-DTrilinos_EXTRAREPOS_FILE:STRING=.+/examples/MockTrilinos/cmake/ExtraRepositoriesList.cmake[;]-DTrilinos_IGNORE_MISSING_EXTRA_REPOSITORIES:BOOL=ON[;]-DTrilinos_ENABLE_KNOWN_EXTERNAL_REPOS_TYPE:STRING=Experimental[;]-DTrilinos_ENABLE_TESTS:BOOL=[;]-DTrilinos_DEFINE_MISSING_PACKAGE_LIBS_TARGETS=ON[;]-DTrilinos_ENABLE_Teuchos:BOOL=ON'"
     "Processing current package Epetra: libs='ON', tests=''"
     "Processing current package Thyra: libs='ON', tests='ON'"
-    "CONFIGURE_OPTIONS = '-DTrilinos_TRIBITS_DIR=.+-DCTEST_USE_LAUNCHERS:BOOL=1.-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON.-DTrilinos_WARNINGS_AS_ERRORS_FLAGS:STRING=-DummyErrFlags.-DTrilinos_ALLOW_NO_PACKAGES:BOOL=ON.-DTrilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON.-DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF.-DTrilinos_EXTRAREPOS_FILE:STRING=.+/examples/MockTrilinos/cmake/ExtraRepositoriesList.cmake.-DTrilinos_IGNORE_MISSING_EXTRA_REPOSITORIES:BOOL=ON.-DTrilinos_ENABLE_KNOWN_EXTERNAL_REPOS_TYPE:STRING=Experimental.-DTrilinos_ENABLE_TESTS:BOOL=ON.-DTrilinos_ENABLE_EpetraExt:BOOL=.-DTrilinos_ENABLE_Thyra:BOOL=ON'"
+    "CONFIGURE_OPTIONS = '-DTrilinos_TRIBITS_DIR=.+-DCTEST_USE_LAUNCHERS:BOOL=1[;]-DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON[;]-DTrilinos_WARNINGS_AS_ERRORS_FLAGS:STRING=-DummyErrFlags[;]-DTrilinos_ALLOW_NO_PACKAGES:BOOL=ON[;]-DTrilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON[;]-DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF[;]-DTrilinos_EXTRAREPOS_FILE:STRING=.+/examples/MockTrilinos/cmake/ExtraRepositoriesList.cmake[;]-DTrilinos_IGNORE_MISSING_EXTRA_REPOSITORIES:BOOL=ON[;]-DTrilinos_ENABLE_KNOWN_EXTERNAL_REPOS_TYPE:STRING=Experimental[;]-DTrilinos_ENABLE_TESTS:BOOL=ON[;]-DTrilinos_ENABLE_EpetraExt:BOOL=[;]-DTrilinos_DEFINE_MISSING_PACKAGE_LIBS_TARGETS=ON[;]-DTrilinos_ENABLE_Thyra:BOOL=ON'"
   )
 # NOTE: The above test pins down the form of the configure options passed to
 # different package configures to make sure everything in there.
@@ -1162,5 +1162,3 @@ tribits_add_advanced_test( CTestDriver_tribits_ctest_update_commands_wrapper_def
       "Git Update PASSED!"
 
    )
-
-

--- a/test/ctest_driver/TribitsExampleProject/CMakeLists.txt
+++ b/test/ctest_driver/TribitsExampleProject/CMakeLists.txt
@@ -505,7 +505,7 @@ tribits_add_advanced_test( CTestDriver_PBP_ST_BreakConfigureRequiredPkg
     CMND cp
     ARGS -r ${TribitsExProj_DIR} .
   TEST_1
-    MESSAGE "Break the confgiure for just the required SimpleCxx package"
+    MESSAGE "Break the configure for just the required SimpleCxx package"
     CMND ${CMAKE_CURRENT_SOURCE_DIR}/append_file_with_line.sh
     ARGS TribitsExampleProject/packages/simple_cxx/CMakeLists.txt
       "Configure of SimpleCxx is broken!"
@@ -542,7 +542,64 @@ tribits_add_advanced_test( CTestDriver_PBP_ST_BreakConfigureRequiredPkg
   # NOTE: The above test ensures that the configure failure of an upstream
   # optional package does not break the configure, build, or tests of
   # downstream packages.  It only disables the broken upstream package in
-  # downstream packages.
+  # downstream packages.  This provides a robust package-by-package mode where
+  # configure errors in required upstream packages result in the graceful
+  # disable of downstream packages so that they don't report errors for those
+  # packages when the problem is really in upstream packages.  See the var
+  # ${PROJECT_NAME}_DISABLE_ENABLED_FORWARD_DEP_PACKAGES that is passed
+  # through in package-by-package mode and GitHub PR TriBITSPub/TriBITS#394.
+
+
+tribits_add_advanced_test( CTestDriver_PBP_ST_BreakBuildLibRequiredPkg
+  OVERALL_WORKING_DIRECTORY TEST_NAME
+  OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
+  TEST_0
+    MESSAGE "Copy the project dir so I can break it!"
+    CMND cp
+    ARGS -r ${TribitsExProj_DIR} .
+  TEST_1
+    MESSAGE "Break the build of a lib for the required SimpleCxx package"
+    CMND ${CMAKE_CURRENT_SOURCE_DIR}/append_file_with_line.sh
+    ARGS TribitsExampleProject/packages/simple_cxx/src/SimpleCxx_HelloWorld.cpp
+      "Build of the SimpleCxx library is broken!"
+  TEST_2
+    MESSAGE "Run ctest driver which should show a failed lib build for just the SimpleCxx package!"
+    CMND env
+    ARGS
+      CTEST_DASHBOARD_ROOT=PWD
+      ${PBP_COMMON_ENV_ARGS}
+      TribitsExProj_ENABLE_SECONDARY_TESTED_CODE=TRUE
+      ${CTEST_DROP_SITE_ENV_ARGS}
+      CTEST_BUILD_NAME=${PACKAGE_NAME}_CTestDriver_PBP_ST_BreakBuildLibRequiredPkg
+      ${CTEST_S_SCRIPT_ARGS}
+    PASS_REGULAR_EXPRESSION_ALL
+      "Final set of enabled SE packages:  SimpleCxx MixedLang WithSubpackagesA WithSubpackagesB WithSubpackagesC WithSubpackages WrapExternal 7"
+      "SimpleCxx: Configure passed"
+      "FAILED library build for package 'SimpleCxx'"
+      "SimpleCxx: Skipping tests since libray build failed"
+      "CONFIGURE_OPTIONS = '.*[;]-DTribitsExProj_ENABLE_SimpleCxx:BOOL=OFF[;].*[;]-DTribitsExProj_ENABLE_MixedLang:BOOL=ON'"
+      "MixedLang: Configure passed"
+      "MixedLang: Libs build passed"
+      "MixedLang_RayTracerTests [.]+ +Passed"
+      "CONFIGURE_OPTIONS = '.*[;]-DTribitsExProj_ENABLE_SimpleCxx:BOOL=OFF[;].*[;]-DTribitsExProj_ENABLE_WithSubpackages:BOOL=ON'"
+      "WithSubpackages: Configure passed"
+      "WithSubpackages: Libs build passed"
+      "WithSubpackages: All build passed"
+      "No tests were found"  # Can't tell which package :-(
+      "CONFIGURE_OPTIONS = '.*[;]-DTribitsExProj_ENABLE_SimpleCxx:BOOL=OFF[;].*[;]-DTribitsExProj_ENABLE_WrapExternal:BOOL=ON'"
+      "WrapExternal: Configure passed"
+      "WrapExternal: All build passed"
+      "Final set packages that failed to configure or have the libraries build: 'SimpleCxx'"
+      "Final set of packages that had any failures: 'SimpleCxx'"
+      "TRIBITS_CTEST_DRIVER: OVERALL: ALL FAILED"
+    ALWAYS_FAIL_ON_ZERO_RETURN
+  )
+  # NOTE: The above test is similar to the test
+  # CTestDriver_PBP_ST_BreakConfigureRequiredPkg except the above test is for
+  # the case where a library in a required upstream package does not build and
+  # we want those downstream packages with a required dependency on that
+  # package to be gracefully disabled.
 
 
 tribits_add_advanced_test( CTestDriver_PBP_ST_ALL_COVERAGE

--- a/tribits/core/package_arch/TribitsGlobalMacros.cmake
+++ b/tribits/core/package_arch/TribitsGlobalMacros.cmake
@@ -2403,6 +2403,21 @@ macro(tribits_configure_enabled_packages)
       add_dependencies(libs ${ENABLED_PACKAGE_LIBS_TARGETS})
     endif()
 
+    # Add empty <PackageName>_libs targets for top-level packages if asked
+    if (${PROJECT_NAME}_DEFINE_MISSING_PACKAGE_LIBS_TARGETS)
+      foreach(TRIBITS_PACKAGE ${${PROJECT_NAME}_PACKAGES})
+        if (NOT TARGET ${TRIBITS_PACKAGE}_libs)
+          add_custom_target(${TRIBITS_PACKAGE}_libs
+            COMMENT "Dummy target for ${TRIBITS_PACKAGE}_libs that builds nothing!")
+        endif()
+      endforeach()
+    endif()
+    # NOTE: For motivation for above, see the comment about the setting of
+    # ${PROJECT_NAME}_DEFINE_MISSING_PACKAGE_LIBS_TARGETS=ON in
+    # package-by-package mode in tribits_ctest_driver().  This option is
+    # purposefully not documented and not defined as a cache variable since it
+    # is an internal TriBITS implementation detail.
+
   endif()
 
   tribits_config_code_stop_timer(CONFIGURE_PACKAGES_TIME_START_SECONDS
@@ -2702,3 +2717,12 @@ macro(tribits_exclude_autotools_files) # PACKAGE_NAME LIST_RETURN)
   tribits_exclude_files(${FILES_TO_EXCLUDE})
 
 endmacro()
+
+#  LocalWords:
+#  LocalWords: Sandia SANDIA Redistributions
+#  LocalWords: tribits TriBITS TRIBITS
+#  LocalWords: cmake CMake CMAKE CMakeCache CMakeFiles
+#  LocalWords: ctest CPACK
+#  LocalWords: foreach endforeach endif endmacro
+#  LocalWords: BOOL
+#  LocalWords: libs LIBS config PackageName SUBPACKAGES nonenabled

--- a/tribits/core/package_arch/TribitsGlobalMacros.cmake
+++ b/tribits/core/package_arch/TribitsGlobalMacros.cmake
@@ -80,8 +80,7 @@ include(TribitsTplDeclareLibraries) # Deprecated
 # projects stop using it.
 
 
-#
-# Assert and setup project binary directory and other project variables.
+# Assert and setup project binary directory and other project variables
 #
 macro(tribits_assert_and_setup_project_and_static_system_vars)
 
@@ -136,8 +135,7 @@ macro(tribits_assert_and_setup_project_and_static_system_vars)
 endmacro()
 
 
-#
-# Set up some really basic system variables.
+# Set up some really basic system variables
 #
 # This macro needs to be called *before* the user *.cmake option files are
 # read in so that there is an opportunity to override these.
@@ -159,11 +157,9 @@ macro(tribits_setup_basic_system_vars)
 endmacro()
 
 
+# Define an option to include a file that reads in a bunch of options and read
+# those files
 #
-# Define an option to include a file that reads in a bunch of options
-#
-#
-
 macro(tribits_read_in_options_from_file)
 
   set( ${PROJECT_NAME}_CONFIGURE_OPTIONS_FILE "" CACHE FILEPATH
@@ -187,11 +183,9 @@ macro(tribits_read_in_options_from_file)
 endmacro()
 
 
-#
 # Assert ${PROJECT_NAME}_SET_GROUP_AND_PERMISSIONS_ON_INSTALL_BASE_DIR set
 # correctly
 #
-
 function(assert_project_set_group_and_permissions_on_install_base_dir)
 
   if (
@@ -225,10 +219,8 @@ function(assert_project_set_group_and_permissions_on_install_base_dir)
 endfunction()
 
 
-#
 # Define all of the standard global package architecture options.
 #
-
 macro(tribits_define_global_options_and_define_extra_repos)
 
   set( ${PROJECT_NAME}_ENABLE_ALL_PACKAGES OFF CACHE BOOL
@@ -427,7 +419,7 @@ macro(tribits_define_global_options_and_define_extra_repos)
   advanced_set(${PROJECT_NAME}_CHECK_FOR_UNPARSED_ARGUMENTS
     ${${PROJECT_NAME}_CHECK_FOR_UNPARSED_ARGUMENTS_DEFAULT}
     CACHE STRING
-    "Determins how unparsed arguments for TriBITS functions that use cmake_parase_aruments() internally are handled.  Valid choices are 'WARNING', 'SEND_ERROR', and 'FATAL_ERROR'.  The default is 'SEND_ERROR'."
+    "Determines how unparsed arguments for TriBITS functions that use cmake_parase_aruments() internally are handled.  Valid choices are 'WARNING', 'SEND_ERROR', and 'FATAL_ERROR'.  The default is 'SEND_ERROR'."
     )
   if (
     (NOT ${PROJECT_NAME}_CHECK_FOR_UNPARSED_ARGUMENTS STREQUAL "WARNING")
@@ -1084,7 +1076,7 @@ endmacro()
 
 
 #
-# Repository specializaiton call-back functions
+# Macros to process repository specializaiton call-back functions
 #
 # NOTE: The Tribits system promises to only include these call-back files once
 # (in order) and to only the call call-back macros they provide once (in
@@ -1257,6 +1249,7 @@ macro(tribits_copy_installer_resource _varname _source _destination)
     COPYONLY)
 endmacro()
 
+
 # Run the git log command to get the verison info for a git rep
 #
 function(tribits_generate_single_repo_version_string  GIT_REPO_DIR
@@ -1327,10 +1320,8 @@ function(tribits_generate_single_repo_version_string  GIT_REPO_DIR
 endfunction()
 
 
-#
 # Get the versions of all the git repos
 #
-
 function(tribits_generate_repo_version_file_string  PROJECT_REPO_VERSION_FILE_STRING_OUT)
 
   set(REPO_VERSION_FILE_STR "")
@@ -1377,13 +1368,11 @@ function(tribits_generate_repo_version_file_string  PROJECT_REPO_VERSION_FILE_ST
 endfunction()
 
 
-#
 # Generate the project repos version file and print to stdout
 #
 # This function is designed so that it can be unit tested from inside of a
 # cmake -P script.
 #
-
 function(tribits_generate_repo_version_output_and_file)
   # Get the repos versions
   tribits_generate_repo_version_file_string(PROJECT_REPO_VERSION_FILE_STRING)
@@ -1400,17 +1389,15 @@ function(tribits_generate_repo_version_output_and_file)
 endfunction()
 
 
-#
-# Create project dependencies file and create install target
+# Create project dependencies file and create install target for these
 #
 # NOTE: Before calling this function, the extra repos datastructure must be
 # filled out!
 #
-# NOTE: This function can not be called in a cmake -P script because it has a
+# NOTE: This function cannot be called in a cmake -P script because it has a
 # call to install()!  That is why this function is seprated out from
 # tribits_generate_repo_version_output_and_file().
 #
-
 function(tribits_generate_repo_version_output_and_file_and_install)
 
   #
@@ -1449,11 +1436,9 @@ function(tribits_generate_repo_version_output_and_file_and_install)
 
   endif()
 
-
 endfunction()
 
 
-#
 # Print out a list with white-space separators with an initial doc string
 #
 function(tribits_print_prefix_string_and_list  DOCSTRING   LIST_TO_PRINT)
@@ -1467,9 +1452,8 @@ function(tribits_print_prefix_string_and_list  DOCSTRING   LIST_TO_PRINT)
 endfunction()
 
 
-#
-# Function that prints the current set of enabled/disabled packages given
-# input list of packages.
+# Print the current set of enabled/disabled packages given input list of
+# packages
 #
 function(tribits_print_enabled_packages_list_from_var  PACKAGES_LIST_VAR
   DOCSTRING  ENABLED_FLAG  INCLUDE_EMPTY
@@ -1491,8 +1475,7 @@ function(tribits_print_enabled_packages_list_from_var  PACKAGES_LIST_VAR
 endfunction()
 
 
-#
-# Function that prints the current set of enabled/disabled packages
+# Prints the current set of enabled/disabled packages
 #
 function(tribits_print_enabled_package_list  DOCSTRING  ENABLED_FLAG  INCLUDE_EMPTY)
   tribits_print_enabled_packages_list_from_var( ${PROJECT_NAME}_PACKAGES
@@ -1500,8 +1483,7 @@ function(tribits_print_enabled_package_list  DOCSTRING  ENABLED_FLAG  INCLUDE_EM
 endfunction()
 
 
-#
-# Function that prints the current set of enabled/disabled SE packages
+# Prints the current set of enabled/disabled SE packages
 #
 function(tribits_print_enabled_se_package_list  DOCSTRING  ENABLED_FLAG  INCLUDE_EMPTY)
   if (ENABLED_FLAG AND NOT INCLUDE_EMPTY)
@@ -1521,8 +1503,7 @@ function(tribits_print_enabled_se_package_list  DOCSTRING  ENABLED_FLAG  INCLUDE
 endfunction()
 
 
-#
-# Function that prints the current set of enabled/disabled TPLs
+# Print the current set of enabled/disabled TPLs
 #
 function(tribits_print_enabled_tpl_list  DOCSTRING  ENABLED_FLAG  INCLUDE_EMPTY)
   if (ENABLED_FLAG AND NOT INCLUDE_EMPTY)
@@ -1542,7 +1523,6 @@ function(tribits_print_enabled_tpl_list  DOCSTRING  ENABLED_FLAG  INCLUDE_EMPTY)
 endfunction()
 
 
-#
 # Adjust package enable logic and print out before and after state
 #
 # On output sets:
@@ -1591,10 +1571,8 @@ macro(tribits_adjust_and_print_package_dependencies)
 endmacro()
 
 
+# Gather information from enabled TPLs
 #
-# Macro that gathers information from enabled TPLs
-#
-
 macro(tribits_process_enabled_tpls)
 
   tribits_config_code_start_timer(CONFIGURE_TPLS_TIME_START_SECONDS)
@@ -1926,9 +1904,8 @@ macro(tribits_set_openmp_flags  LANG)
 endmacro()
 
 
-#
 # Set mapping of labels to subprojects (i.e. TriBITS packages) for local CTest
-# only.
+# only
 #
 # NOTE: This macro is only used define mapping of labels to subprojects for
 # running ctest locally.  This results in summarizing the tests run for each
@@ -1936,16 +1913,13 @@ endmacro()
 # harmless to define the mapping for every TriBITS package.  Only TriBITS
 # packages will be listed in the summary if they had one or more tests run.
 #
-
 macro(tribits_set_labels_to_subprojects_mapping)
   set(CTEST_LABELS_FOR_SUBPROJECTS ${${PROJECT_NAME}_PACKAGES})
 endmacro()
 
 
-#
 # Macro to turn on CTest support
 #
-
 macro(tribits_include_ctest_support)
 
   set(DART_TESTING_TIMEOUT_IN ${DART_TESTING_TIMEOUT})
@@ -1995,10 +1969,8 @@ endmacro()
 # that with a set( ... CACHE ...) statement in an input *.cmake file.
 
 
+# Determines if a package should be processed
 #
-# Function that determines if a package should be processed
-#
-
 function(tribits_determine_if_process_package  PACKAGE_NAME
   PROCESS_PACKAGE_OUT  PACKAGE_ENABLE_STR_OUT
   )
@@ -2007,7 +1979,7 @@ function(tribits_determine_if_process_package  PACKAGE_NAME
   set(PACKAGE_ENABLE_STR "")
 
   if (${PACKAGE_NAME}_SUBPACKAGES)
-    # Process the package if any of the the subpackages are enable
+    # Process the package if any of the subpackages are enable
     foreach(TRIBITS_SUBPACKAGE ${${PACKAGE_NAME}_SUBPACKAGES})
       set(SUBPACKAGE_FULLNAME ${PACKAGE_NAME}${TRIBITS_SUBPACKAGE})
       if (${PROJECT_NAME}_ENABLE_${SUBPACKAGE_FULLNAME})
@@ -2039,10 +2011,8 @@ function(tribits_determine_if_process_package  PACKAGE_NAME
 endfunction()
 
 
+# Reads in the project's version file into the current scope
 #
-# Macro that reads in the project's version file into the current scope
-#
-
 macro(tribits_project_read_version_file  PROJECT_SOURCE_DIR_IN)
   set(PROJECT_VERSION_FILE ${PROJECT_SOURCE_DIR_IN}/Version.cmake)
   if (EXISTS ${PROJECT_VERSION_FILE})
@@ -2054,9 +2024,8 @@ macro(tribits_project_read_version_file  PROJECT_SOURCE_DIR_IN)
 endmacro()
 
 
-#
-# Function that reads in and the Repository's specific Version.cmake file and
-# then configures its ${REPO_NAME}_version.h file.
+# Read in and the Repository's specific Version.cmake file and then configure
+# its ${REPO_NAME}_version.h file.
 #
 # The file ${REPO_NAME}_version.h is only configured if the repository contains
 # the files Version.cmake and Copyright.txt
@@ -2115,10 +2084,8 @@ function(tribits_repository_configure_version_header_file
 endfunction()
 
 
+# Configure each of the Repositories' version header file
 #
-# Configure each of the Repositories version header files
-#
-
 function(tribits_repository_configure_all_version_header_files)
   #print_var(ARGN)
   foreach(REPO ${ARGN})
@@ -2132,9 +2099,8 @@ function(tribits_repository_configure_all_version_header_files)
 endfunction()
 
 
-#
-# Function that generates the VersionDate.cmake and
-# ${REPO_NAME}_version_date.h files.
+# Generate the VersionDate.cmake and ${REPO_NAME}_version_date.h files for a
+# TriBITS Repository
 #
 # NOTE: This is done as a function so that the read-in version variables don't
 # bleed into the outer scope.
@@ -2203,10 +2169,8 @@ function(tribits_repository_configure_version_date_files
 endfunction()
 
 
+# Configure each of the Repositories' version date files
 #
-# Configure each of the Repositories version date files
-#
-
 function(tribits_repository_configure_all_version_date_files)
   #print_var(ARGN)
   if (${PROJECT_NAME}_GENERATE_VERSION_DATE_FILES)
@@ -2221,8 +2185,10 @@ function(tribits_repository_configure_all_version_date_files)
 endfunction()
 
 
+# Configure the enabled packages
 #
-# Macro that does the final set of package configurations
+# This macro actally calls add_subdirectory(<packageDir>) on the enabled
+# TriBITS packages.
 #
 macro(tribits_configure_enabled_packages)
 
@@ -2445,7 +2411,6 @@ macro(tribits_configure_enabled_packages)
 endmacro()
 
 
-#
 # Set up for packaging and distribution
 #
 macro(tribits_setup_packaging_and_distribution)
@@ -2594,6 +2559,7 @@ endmacro()
 
 
 # Create custom 'install_package_by_package' target
+#
 function(tribits_add_install_package_by_package_target)
 
   set(TRIBITS_ENABLED_PACKAGES_BINARY_DIRS)
@@ -2640,7 +2606,6 @@ macro(tribits_setup_for_installation)
 endmacro()
 
 
-#
 # @MACRO: tribits_exclude_files()
 #
 # Exclude package files/dirs from the source distribution by appending
@@ -2716,9 +2681,7 @@ macro(tribits_exclude_files)
 endmacro()
 
 
-#
-#  Macro for helping set up exclude files only for the packages that will not
-#  be supporting autotools.
+# Exclude files only for the packages that will not be supporting autotools.
 #
 macro(tribits_exclude_autotools_files) # PACKAGE_NAME LIST_RETURN)
   set(AUTOTOOLS_FILES

--- a/tribits/ctest_driver/TribitsCTestDriverCoreHelpers.cmake
+++ b/tribits/ctest_driver/TribitsCTestDriverCoreHelpers.cmake
@@ -994,6 +994,8 @@ macro(tribits_ctest_package_by_package)
         "-D${PROJECT_NAME}_ENABLE_${${PROJECT_NAME}_LAST_CONFIGURED_PACKAGE}:BOOL=")
       set(${PROJECT_NAME}_LAST_CONFIGURED_PACKAGE)
     endif()
+    list(APPEND CONFIGURE_OPTIONS
+      "-D${PROJECT_NAME}_DEFINE_MISSING_PACKAGE_LIBS_TARGETS=ON")
     foreach(FAILED_PACKAGE ${${PROJECT_NAME}_FAILED_LIB_BUILD_PACKAGES})
       list(APPEND CONFIGURE_OPTIONS
         "-D${PROJECT_NAME}_ENABLE_${FAILED_PACKAGE}:BOOL=OFF")
@@ -1315,6 +1317,23 @@ macro(tribits_ctest_package_by_package)
     " ${PROJECT_NAME} packages!\n")
 
 endmacro()
+# NOTE: Above, the option
+# ${PROJECT_NAME}_DEFINE_MISSING_PACKAGE_LIBS_TARGETS=ON is passed down
+# through to the inner CMake TriBITS configure to trigger the creation of
+# dummy targets <PackageName>_libs for all the packages for the case where a
+# package is disabled due to a disabled upstream package and
+# ${PROJECT_NAME}_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON but the target
+# <thePackage>_libs is attempted to be built anyway and we expect it to build
+# nothing and result in no error.  (The outer ctest -S driver is not smart
+# enough to know all the lgoic for if a package will actaully be enabled or
+# not.  That is the job of the inner TriBITS dependency logic and
+# ${PROJECT_NAME}_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON.) Otherwise, with
+# CMake 3.19+, cmake_build() catches errors in undefined global build targets
+# like this and reports them correctly.  This workaround allows the
+# package-by-package mode to gracefully disable downstream packages that can't
+# be enabled due to the disable of a broken upstream packages.  See the test
+# TriBITS_CTestDriver_PBP_ST_BreakConfigureRequiredPkg that exercises this use
+# case.
 
 
 # Drive the configure, build, test, and submit all at once for all of the


### PR DESCRIPTION
Fixes one of the tests shown and discussed in #394 (the rest will be fixed by CMake 3.21.2).  This is related to #363.

See the commits for more details.

NOTE: I listed this PR as a bug even though it was triggered by a change in CMake.  This use case should have never relied on cmake_build() building a missing target and not returning an error.  So this really was a bug in TriBITS logic.
