### PR TITLE
Move tribits_get_build_url_and_write_to_file() to stand-alone module (#154)

### DIFF
--- a/tribits/ctest_driver/TribitsCTestDriverCoreHelpers.cmake
+++ b/tribits/ctest_driver/TribitsCTestDriverCoreHelpers.cmake
@@ -703,69 +703,6 @@ function(tribits_remember_configure_passed)
 endfunction()
 
 
-
-# Construct the build URL on CDash given the site name, buildname, and
-# buildstamp (take from the TAG file).
-#
-# Usage::
-#
-#   tribits_get_build_url_and_write_to_file(
-#     <cdashBuildUrlOut>
-#     <cdashBuldUrlFile>
-#     )
-#
-# Here, ``<cdashBuildUrlOut>`` returns the CDash Build URL constructed from
-# the CMake vars:
-#
-#   * ``CTEST_DROP_SITE``
-#   * ``CTEST_DROP_LOCATION`` (``submit.php`` is replaced with ``index.php``)
-#   * ``CTEST_PROJECT_NAME``
-#   * ``CTEST_SITE``
-#   * ``CTEST_BUILD_NAME``
-#
-# and the buildstamp read in from the file
-# ``${CTEST_BINARY_DIRECTORY}/Testing/TAG``.
-#
-# Note that ``<cdashBuildUrlOut>`` will have ``https://`` added to the
-# beginning of it so that GitHub Actions and other systems will put in a link
-# to them.
-#
-# If the file name ``<cdashBuldUrlFile>`` is non-empty, then that CDash URL
-# will be written to the file as a single line.
-#
-function(tribits_get_build_url_and_write_to_file  cdashBuildUrlOut  cdashBuildUrlFile)
-  tribits_get_cdash_index_php_from_drop_site_and_location(
-    CTEST_DROP_SITE "${CTEST_DROP_SITE}"
-    CTEST_DROP_LOCATION "${CTEST_DROP_LOCATION}"
-    INDEX_PHP_URL_OUT indexPhpUrl
-    )
-  tribits_get_cdash_build_url_from_tag_file(
-    INDEX_PHP_URL "${indexPhpUrl}"
-    PROJECT_NAME "${CTEST_PROJECT_NAME}"
-    SITE_NAME "${CTEST_SITE}"
-    BUILD_NAME "${CTEST_BUILD_NAME}"
-    TAG_FILE "${CTEST_BINARY_DIRECTORY}/Testing/TAG"
-    CDASH_BUILD_URL_OUT cdashBuildUrl
-    )
-  set(cdashBuildUrl "https://${cdashBuildUrl}")
-  if (cdashBuildUrlFile)
-    file(WRITE "${cdashBuildUrlFile}" "${cdashBuildUrl}")
-  endif()
-  set(${cdashBuildUrlOut} "${cdashBuildUrl}" PARENT_SCOPE)
-endfunction()
-
-
-# Print the URL on CDash where build results can be found.
-#
-# This will print regardless of the value of CTEST_DO_SUBMIT so not that if
-# that is set to FALSE, then no results will actually be submitted there.
-#
-function(tribits_print_build_url  msg  cdashBuildUrl)
-  message("\n${msg}\n")
-  message("    ${cdashBuildUrl}\n")
-endfunction()
-
-
 # Override CTEST_SUBMIT to drive multiple submits and to detect failed
 # submissions and track them as queued errors.
 #

--- a/tribits/ctest_driver/TribitsGetCDashUrlFromTagFile.cmake
+++ b/tribits/ctest_driver/TribitsGetCDashUrlFromTagFile.cmake
@@ -1,6 +1,72 @@
 include(TribitsReadTagFile)
 
 
+# @FUNCTION: tribits_get_build_url_and_write_to_file()
+#
+# Construct the build URL on CDash given the site name, buildname, and
+# buildstamp (take from the TAG file) from inside of a running ctest -S
+# program and optionally write it to a file as well.
+#
+# Usage::
+#
+#   tribits_get_build_url_and_write_to_file(
+#     <cdashBuildUrlOut> [ <cdashBuldUrlFile> ] )
+#
+# Here, ``<cdashBuildUrlOut>`` returns the CDash Build URL constructed from
+# the following CMake variables already set in a ``ctest -S`` process:
+#
+#   * ``CTEST_DROP_SITE``
+#   * ``CTEST_DROP_LOCATION`` (``submit.php`` is replaced with ``index.php``)
+#   * ``CTEST_PROJECT_NAME``
+#   * ``CTEST_SITE``
+#   * ``CTEST_BUILD_NAME``
+#
+# and the buildstamp read in from the file
+# ``${CTEST_BINARY_DIRECTORY}/Testing/TAG``.
+#
+# Note that ``<cdashBuildUrlOut>`` will have ``https://`` added to the
+# beginning of it so that GitHub Actions and other systems will put in a link
+# to them.
+#
+# If the file name argument ``<cdashBuldUrlFile>`` is non-empty, then that
+# CDash URL will be written to the file as a single line.
+#
+function(tribits_get_build_url_and_write_to_file  cdashBuildUrlOut  cdashBuildUrlFile)
+  tribits_get_cdash_index_php_from_drop_site_and_location(
+    CTEST_DROP_SITE "${CTEST_DROP_SITE}"
+    CTEST_DROP_LOCATION "${CTEST_DROP_LOCATION}"
+    INDEX_PHP_URL_OUT indexPhpUrl
+    )
+  tribits_get_cdash_build_url_from_tag_file(
+    INDEX_PHP_URL "${indexPhpUrl}"
+    PROJECT_NAME "${CTEST_PROJECT_NAME}"
+    SITE_NAME "${CTEST_SITE}"
+    BUILD_NAME "${CTEST_BUILD_NAME}"
+    TAG_FILE "${CTEST_BINARY_DIRECTORY}/Testing/TAG"
+    CDASH_BUILD_URL_OUT cdashBuildUrl
+    )
+  set(cdashBuildUrl "https://${cdashBuildUrl}")
+  if (cdashBuildUrlFile)
+    file(WRITE "${cdashBuildUrlFile}" "${cdashBuildUrl}")
+  endif()
+  set(${cdashBuildUrlOut} "${cdashBuildUrl}" PARENT_SCOPE)
+endfunction()
+
+
+# @FUNCTION: tribits_print_build_url()
+#
+# Print the URL on CDash where build results can be found.
+#
+# Usage::
+#
+#   tribits_print_build_url( <msg> <cdashBuildUrl> )
+#
+function(tribits_print_build_url  msg  cdashBuildUrl)
+  message("\n${msg}\n")
+  message("    ${cdashBuildUrl}\n")
+endfunction()
+
+
 # @FUNCTION: tribits_get_cdash_build_url_from_tag_file()
 #
 # Create CDash index.php URL from the build parts.
@@ -25,11 +91,13 @@ function(tribits_get_cdash_build_url_from_tag_file)
     PREFIX #prefix
     "" #options
     "INDEX_PHP_URL;PROJECT_NAME;SITE_NAME;BUILD_NAME;TAG_FILE;CDASH_BUILD_URL_OUT" #one_value_keywords
-    "" #multi_value_keytowrds
+    "" #multi_value_keywords
     ${ARGN}
     )
   # Read in the tag file and get the build stamp from that
-  tribits_read_ctest_tag_file(${PREFIX_TAG_FILE} buildStartTime cdashGroup cdashModel)
+  tribits_read_ctest_tag_file(${PREFIX_TAG_FILE} buildStartTime cdashGroup
+    cdashModel # The model is not used here but we still need to include this arg
+    )
   set(buildstamp "${buildStartTime}-${cdashGroup}")
   # Build the URL and return it
   tribits_get_cdash_build_url_from_parts(
@@ -89,7 +157,7 @@ function(tribits_get_cdash_build_url_from_parts)
     PREFIX #prefix
     "" #options
     "INDEX_PHP_URL;PROJECT_NAME;SITE_NAME;BUILD_NAME;BUILD_STAMP;CDASH_BUILD_URL_OUT" #one_value_keywords
-    "" #multi_value_keytowrds
+    "" #multi_value_keywords
     ${ARGN}
     )
   # Do replacements for spaces and special chars in data
@@ -109,9 +177,18 @@ function(tribits_get_cdash_build_url_from_parts)
 endfunction()
 
 
+# Replace chars in a regular string for usage in a URL with CDash
+#
 function(tribits_replace_chars_for_url  inputStr  outputStrForUrlOutVar)
   set(outputStrForUrl "${inputStr}")
   string(REPLACE " " "%20" outputStrForUrl "${outputStrForUrl}")
   string(REPLACE "+" "%2B" outputStrForUrl "${outputStrForUrl}")
   set(${outputStrForUrlOutVar} "${outputStrForUrl}" PARENT_SCOPE)
 endfunction()
+
+#  LocalWords:  GitHub tribits url buildname buildstamp
+#  LocalWords:  tribits TRIBITS
+#  LocalWords:  cmake CMake CMAKE
+#  LocalWords:  ctest CTEST cdash CDash CDASH
+#  LocalWords:  SUBSTRING
+#  LocalWords:  endif  endfunction

--- a/tribits/ctest_driver/TribitsReadTagFile.cmake
+++ b/tribits/ctest_driver/TribitsReadTagFile.cmake
@@ -1,7 +1,3 @@
-include(TribitsCMakePolicies)
-include(Split)
-
-
 # @FUNCTION: tribits_read_ctest_tag_file()
 #
 # Read in the <build>/Testing/TAG file contents
@@ -15,7 +11,7 @@ function(tribits_read_ctest_tag_file  tagFileIn
     buildStartTimeOut  cdashGroupOut  cdashModelOut
   )
   file(READ "${tagFileIn}" tagFileStr)
-  split("${tagFileStr}" "\n" tagFileStrList)
+  string(REPLACE "\n" ";" tagFileStrList "${tagFileStr}")
   list(GET tagFileStrList 0 buildStartTime)
   list(GET tagFileStrList 1 cdashGroup)
   list(GET tagFileStrList 2 cdashModel)


### PR DESCRIPTION
Refactoring to code from #154 and PR #401.

See the commit log for details.
