### PR TITLE
Upgrade from cmake 3.21.0 to 3.21.2 (#363, #394)

### DIFF
--- a/.github/workflows/tribits_testing.yml
+++ b/.github/workflows/tribits_testing.yml
@@ -22,7 +22,7 @@ jobs:
           - { os: ubuntu-latest, cmake: "3.17.5", generator: "makefiles", python: "2.7", cc: gcc-8,  cxx: g++-8,  fc: gfortran-8  }
           - { os: ubuntu-latest, cmake: "3.17.5", generator: "makefiles", python: "3.8", cc: gcc-10, cxx: g++-10, fc: gfortran-10 }
           - { os: ubuntu-latest, cmake: "3.17.5", generator: "makefiles", python: "3.8", cc: gcc-11, cxx: g++-11                  }
-          - { os: ubuntu-latest, cmake: "3.21.0", generator: "makefiles", python: "3.8", cc: gcc-9,  cxx: g++-9,  fc: gfortran-9  }
+          - { os: ubuntu-latest, cmake: "3.21.2", generator: "makefiles", python: "3.8", cc: gcc-9,  cxx: g++-9,  fc: gfortran-9  }
 
     runs-on: ${{ matrix.config.os }}
 

--- a/cmake/ctest/github_actions/tribits_cmake-3.21.0_makefiles_python-3.8_g++-9_tweaks.cmake
+++ b/cmake/ctest/github_actions/tribits_cmake-3.21.0_makefiles_python-3.8_g++-9_tweaks.cmake
@@ -7,13 +7,4 @@ function(set_test_disables)
 endfunction()
 
 set_test_disables(
-  TriBITS_CTestDriver_PBP_PT_ALL_PASS_CALLS_2
-  TriBITS_CTestDriver_PBP_PT_ALL_PASS_CALLS_4
-  TriBITS_CTestDriver_PBP_ST_ALL_COVERAGE
-  TriBITS_CTestDriver_PBP_ST_ALL_MEMORY
-  TriBITS_CTestDriver_PBP_ST_ALL_PASS
-  TriBITS_CTestDriver_PBP_ST_BreakBuildAllOptionalPkg
-  TriBITS_CTestDriver_PBP_ST_BreakBuildLibOptionalPkg
-  TriBITS_CTestDriver_PBP_ST_BreakConfigureOptionalPkg
-  TriBITS_CTestDriver_PBP_ST_BreakTestPkg
   )


### PR DESCRIPTION
Also remove all of the test disables as cmake 3.21.2 has a patch that fixes all of the test failures.

Fixes #394 and addresses problem first identified in #363.
