### PR TITLE
Add TribitsExampleApp and tests to test TriBITS-generated <Package>Config.cmake files (#299)

### DIFF
--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4540,6 +4540,93 @@ TribitsExampleApp_ALL_ST_test(ByPackage STATIC)
 TribitsExampleApp_ALL_ST_test(ByPackage SHARED)
 
 
+function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
+
+  if (sharedOrStatic STREQUAL "SHARED")
+    set(buildSharedLibsArg -DBUILD_SHARED_LIBS=ON)
+  elseif (sharedOrStatic STREQUAL "STATIC")
+    set(buildSharedLibsArg -DBUILD_SHARED_LIBS=OFF)
+  else()
+    message(FATAL_ERROR "Invaid value for sharedOrStatic='${sharedOrStatic}'!")
+  endif()
+
+  tribits_add_advanced_test( TribitsExampleApp_ALL_ST_buildtree_${sharedOrStatic}
+    OVERALL_WORKING_DIRECTORY TEST_NAME
+    OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
+    XHOSTTYPE Darwin
+
+    TEST_0
+      MESSAGE "Do the configure of TribitsExampleProject"
+      CMND ${CMAKE_COMMAND}
+      ARGS
+        ${TribitsExampleProject_COMMON_CONFIG_ARGS}
+        -DTribitsExProj_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
+        -DTribitsExProj_ENABLE_Fortran=ON
+        -DTribitsExProj_ENABLE_ALL_PACKAGES=ON
+        -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON
+        -DTribitsExProj_ENABLE_INSTALL_CMAKE_CONFIG_FILES=ON
+        ${buildSharedLibsArg}
+        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
+
+    TEST_1
+      MESSAGE "Build TribitsExampleProject only (no install)"
+      CMND make ARGS ${CTEST_BUILD_FLAGS}
+
+    TEST_2
+      MESSAGE "Configure TribitsExampleApp locally"
+      WORKING_DIRECTORY app_build
+      CMND ${CMAKE_COMMAND} ARGS
+        -DTribitsExApp_FIND_INDIVIDUAL_PACKAGES=TRUE
+        -DTribitsExApp_FIND_UNDER_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_buildtree_${sharedOrStatic}
+        -DTribitsExApp_USE_COMPONENTS=SimpleCxx,MixedLang
+        ${findByProjectOrPackageArg}
+        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleApp
+      PASS_REGULAR_EXPRESSION_ALL
+        "Found SimpleCxx"
+        "Found MixedLang"
+        "-- Configuring done"
+        "-- Generating done"
+        "-- Build files have been written to: .*/TriBITS_TribitsExampleApp_ALL_ST_buildtree_${sharedOrStatic}/app_build"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    TEST_3
+      MESSAGE "Build and install TribitsExampleApp"
+      WORKING_DIRECTORY app_build
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND make ARGS ${CTEST_BUILD_FLAGS}
+      PASS_REGULAR_EXPRESSION_ALL
+        "Built target app"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    TEST_4
+      MESSAGE "Test TribitsExampleApp"
+      WORKING_DIRECTORY app_build
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND ${CMAKE_CTEST_COMMAND} ARGS -VV
+      PASS_REGULAR_EXPRESSION_ALL
+        "Full Deps: MixedLang:Mixed Language[;] SimpleCxx:no_deps"
+        "app_test [.]+   Passed"
+        "100% tests passed, 0 tests failed out of 1"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+    )
+
+endfunction()
+#
+# NOTE: The test above only pulls in top-level packages that don't have any
+# subpackages SimpleCxx and MixedLang.  It seems that whoever implemented the
+# <Package>Config.cmake files in the build dir only got this working for
+# top-level packages that don't have any subpackages.  This test above at
+# least (partially) pins down what already works.  (Later, these
+# <Package>Config.cmake files in the build dir will need to be fixed up so
+# that they work for top-level packages with subpackages as well and then this
+# test can be expanded for that case too.)
+
+
+TribitsExampleApp_ALL_ST_buildtree_test(STATIC)
+TribitsExampleApp_ALL_ST_buildtree_test(SHARED)
+
+
 ########################################################################
 # TribitsExampleProjectAddons
 ########################################################################

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4451,15 +4451,27 @@ TribitsExampleApp_ALL_ST_NoFortran_test(STATIC)
 TribitsExampleApp_ALL_ST_NoFortran_test(SHARED)
 
 
-function(TribitsExampleApp_ALL_ST_test sharedOrStatic)
+function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
+
+  if (byProjectOrPackage STREQUAL "ByProject")
+    set(findByProjectOrPackageArg -DTribitsExApp_FIND_INDIVIDUAL_PACKAGES=OFF)
+    set(foundProjectOrPackageStr "Found TribitsExProj")
+  elseif (byProjectOrPackage STREQUAL "ByPackage")
+    set(findByProjectOrPackageArg -DTribitsExApp_FIND_INDIVIDUAL_PACKAGES=ON)
+    set(foundProjectOrPackageStr "Found SimpleCxx")
+  else()
+    message(FATAL_ERROR "Invaid value for findByProjectOrPackageArg='${findByProjectOrPackageArg}'!")
+  endif()
 
   if (sharedOrStatic STREQUAL "SHARED")
     set(buildSharedLibsArg -DBUILD_SHARED_LIBS=ON)
-  else()
+  elseif (sharedOrStatic STREQUAL "STATIC")
     set(buildSharedLibsArg -DBUILD_SHARED_LIBS=OFF)
+  else()
+    message(FATAL_ERROR "Invaid value for sharedOrStatic='${sharedOrStatic}'!")
   endif()
 
-  tribits_add_advanced_test( TribitsExampleApp_ALL_ST_${sharedOrStatic}
+  tribits_add_advanced_test( TribitsExampleApp_ALL_ST_${byProjectOrPackage}_${sharedOrStatic}
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
     EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
@@ -4487,13 +4499,15 @@ function(TribitsExampleApp_ALL_ST_test sharedOrStatic)
       MESSAGE "Configure TribitsExampleApp locally"
       WORKING_DIRECTORY app_build
       CMND ${CMAKE_COMMAND} ARGS
-        -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_${sharedOrStatic}/install
+        -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_${byProjectOrPackage}_${sharedOrStatic}/install
         -DTribitsExApp_USE_COMPONENTS=SimpleCxx,MixedLang,WithSubpackages
+        ${findByProjectOrPackageArg}
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleApp
       PASS_REGULAR_EXPRESSION_ALL
+        "${foundProjectOrPackageStr}"
         "-- Configuring done"
         "-- Generating done"
-        "-- Build files have been written to: .*/TriBITS_TribitsExampleApp_ALL_ST_${sharedOrStatic}/app_build"
+        "-- Build files have been written to: .*/TriBITS_TribitsExampleApp_ALL_ST_${byProjectOrPackage}_${sharedOrStatic}/app_build"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
     TEST_3
@@ -4520,8 +4534,10 @@ function(TribitsExampleApp_ALL_ST_test sharedOrStatic)
 endfunction()
 
 
-TribitsExampleApp_ALL_ST_test(STATIC)
-TribitsExampleApp_ALL_ST_test(SHARED)
+TribitsExampleApp_ALL_ST_test(ByProject STATIC)
+TribitsExampleApp_ALL_ST_test(ByProject SHARED)
+TribitsExampleApp_ALL_ST_test(ByPackage STATIC)
+TribitsExampleApp_ALL_ST_test(ByPackage SHARED)
 
 
 ########################################################################

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4375,6 +4375,82 @@ tribits_add_advanced_test( TribitsExampleProject_TribitsExampleProjectAddons
 
 
 ########################################################################
+# TribitsExampleApp
+########################################################################
+
+
+function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
+
+  if (sharedOrStatic STREQUAL "SHARED")
+    set(buildSharedLibsArg -DBUILD_SHARED_LIBS=ON)
+  else()
+    set(buildSharedLibsArg -DBUILD_SHARED_LIBS=OFF)
+  endif()
+
+  tribits_add_advanced_test( TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic}
+    OVERALL_WORKING_DIRECTORY TEST_NAME
+    OVERALL_NUM_MPI_PROCS 1
+    XHOSTTYPE Darwin
+
+    TEST_0
+      MESSAGE "Do the configure of TribitsExampleProject"
+      CMND ${CMAKE_COMMAND}
+      ARGS
+        ${TribitsExampleProject_COMMON_CONFIG_ARGS}
+        -DTribitsExProj_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
+        -DTribitsExProj_ENABLE_Fortran=OFF
+        -DTribitsExProj_ENABLE_ALL_PACKAGES=ON
+        -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON
+        -DTribitsExProj_ENABLE_INSTALL_CMAKE_CONFIG_FILES=ON
+        ${buildSharedLibsArg}
+        -DCMAKE_INSTALL_PREFIX=install
+        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
+
+    TEST_1
+      MESSAGE "Build and install TribitsExampleProject locally"
+      CMND make ARGS ${CTEST_BUILD_FLAGS} install
+
+    TEST_2
+      MESSAGE "Configure TribitsExampleApp locally"
+      WORKING_DIRECTORY app_build
+      CMND ${CMAKE_COMMAND} ARGS
+        -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic}/install
+        -DTribitsExApp_USE_COMPONENTS=SimpleCxx,WithSubpackages
+        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleApp
+      PASS_REGULAR_EXPRESSION_ALL
+        "-- Configuring done"
+        "-- Generating done"
+        "-- Build files have been written to: .*/TriBITS_TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic}/app_build"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    TEST_3
+      MESSAGE "Build and install TribitsExampleApp"
+      WORKING_DIRECTORY app_build
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND make ARGS ${CTEST_BUILD_FLAGS}
+      PASS_REGULAR_EXPRESSION_ALL
+        "Built target app"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    TEST_4
+      MESSAGE "Test TribitsExampleApp"
+      WORKING_DIRECTORY app_build
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND ${CMAKE_CTEST_COMMAND}
+      PASS_REGULAR_EXPRESSION_ALL
+        "app_test [.]+   Passed"
+        "100% tests passed, 0 tests failed out of 1"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+    )
+
+endfunction()
+
+
+TribitsExampleApp_ALL_ST_NoFortran_test(STATIC)
+TribitsExampleApp_ALL_ST_NoFortran_test(SHARED)
+
+
+########################################################################
 # TribitsExampleProjectAddons
 ########################################################################
 

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -1957,31 +1957,6 @@ tribits_add_advanced_test( TribitsExampleProject_install_perms_nonowning_base_di
   # an error.
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 tribits_add_advanced_test( TribitsExampleProject_SET_GROUP_AND_PERMISSIONS_ON_INSTALL_BASE_DIR_not_base_dir
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4451,6 +4451,79 @@ TribitsExampleApp_ALL_ST_NoFortran_test(STATIC)
 TribitsExampleApp_ALL_ST_NoFortran_test(SHARED)
 
 
+function(TribitsExampleApp_ALL_ST_test sharedOrStatic)
+
+  if (sharedOrStatic STREQUAL "SHARED")
+    set(buildSharedLibsArg -DBUILD_SHARED_LIBS=ON)
+  else()
+    set(buildSharedLibsArg -DBUILD_SHARED_LIBS=OFF)
+  endif()
+
+  tribits_add_advanced_test( TribitsExampleApp_ALL_ST_${sharedOrStatic}
+    OVERALL_WORKING_DIRECTORY TEST_NAME
+    OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
+    XHOSTTYPE Darwin
+
+    TEST_0
+      MESSAGE "Do the configure of TribitsExampleProject"
+      CMND ${CMAKE_COMMAND}
+      ARGS
+        ${TribitsExampleProject_COMMON_CONFIG_ARGS}
+        -DTribitsExProj_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
+        -DTribitsExProj_ENABLE_Fortran=ON
+        -DTribitsExProj_ENABLE_ALL_PACKAGES=ON
+        -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON
+        -DTribitsExProj_ENABLE_INSTALL_CMAKE_CONFIG_FILES=ON
+        ${buildSharedLibsArg}
+        -DCMAKE_INSTALL_PREFIX=install
+        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
+
+    TEST_1
+      MESSAGE "Build and install TribitsExampleProject locally"
+      CMND make ARGS ${CTEST_BUILD_FLAGS} install
+
+    TEST_2
+      MESSAGE "Configure TribitsExampleApp locally"
+      WORKING_DIRECTORY app_build
+      CMND ${CMAKE_COMMAND} ARGS
+        -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_${sharedOrStatic}/install
+        -DTribitsExApp_USE_COMPONENTS=SimpleCxx,MixedLang,WithSubpackages
+        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleApp
+      PASS_REGULAR_EXPRESSION_ALL
+        "-- Configuring done"
+        "-- Generating done"
+        "-- Build files have been written to: .*/TriBITS_TribitsExampleApp_ALL_ST_${sharedOrStatic}/app_build"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    TEST_3
+      MESSAGE "Build and install TribitsExampleApp"
+      WORKING_DIRECTORY app_build
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND make ARGS ${CTEST_BUILD_FLAGS}
+      PASS_REGULAR_EXPRESSION_ALL
+        "Built target app"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    TEST_4
+      MESSAGE "Test TribitsExampleApp"
+      WORKING_DIRECTORY app_build
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND ${CMAKE_CTEST_COMMAND} ARGS -VV
+      PASS_REGULAR_EXPRESSION_ALL
+        "Full Deps: WithSubpackages:B A no_deps no_deps[;] MixedLang:Mixed Language[;] SimpleCxx:no_deps"
+        "app_test [.]+   Passed"
+        "100% tests passed, 0 tests failed out of 1"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+    )
+
+endfunction()
+
+
+TribitsExampleApp_ALL_ST_test(STATIC)
+TribitsExampleApp_ALL_ST_test(SHARED)
+
+
 ########################################################################
 # TribitsExampleProjectAddons
 ########################################################################

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4436,8 +4436,9 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
       MESSAGE "Test TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
-      CMND ${CMAKE_CTEST_COMMAND}
+      CMND ${CMAKE_CTEST_COMMAND} ARGS -VV
       PASS_REGULAR_EXPRESSION_ALL
+        "Full Deps: WithSubpackages:B A no_deps no_deps[;] SimpleCxx:no_deps"
         "app_test [.]+   Passed"
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN

--- a/tribits/core/installation/TribitsPackageConfigTemplate.cmake.in
+++ b/tribits/core/installation/TribitsPackageConfigTemplate.cmake.in
@@ -4,7 +4,6 @@
 #            TriBITS: Tribal Build, Integrate, and Test System
 #                    Copyright 2013 Sandia Corporation
 #
-#
 # Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 # the U.S. Government retains certain rights in this software.
 #

--- a/tribits/examples/TribitsExampleApp/AppHelperFuncs.cmake
+++ b/tribits/examples/TribitsExampleApp/AppHelperFuncs.cmake
@@ -7,33 +7,79 @@ macro(getTribitsExProjStuff)
     "Set to TRUE to find individual packages and OFF to find project TribitsExProj")
 
   if (${PROJECT_NAME}_FIND_INDIVIDUAL_PACKAGES)
-    message(FATAL_ERROR "ToDo: Implement!")
+    getTribitsExProjStuffByPackage()
   else()
-    getTribitsExProjProjectStuff()
+    getTribitsExProjStuffByProject()
   endif()
 
 endmacro()
 
 
+# Get TribitsExProj stuff with find_package(<Package>) for each
+# package/component.
+#
+macro(getTribitsExProjStuffByPackage)
+
+  # Find each package and gather up all the include dirs and libs for each
+  # package and their TPLs and preserve the order.
+  set(APP_DEPS_PACKAGE_INCLUDE_DIRS "")
+  set(APP_DEPS_TPL_INCLUDE_DIRS "")
+  set(APP_DEPS_PACKAGE_LIBRARIES "")
+  set(APP_DEPS_TPL_LIBRARIES "")
+  foreach (packageName IN LISTS ${PROJECT_NAME}_USE_COMPONENTS)
+    find_package(${packageName} REQUIRED)
+    message("Found ${packageName}!")
+    list(APPEND APP_DEPS_PACKAGE_INCLUDE_DIRS ${${packageName}_INCLUDE_DIRS})
+    list(APPEND APP_DEPS_TPL_INCLUDE_DIRS ${${packageName}_TPL_INCLUDE_DIRS})
+    list(APPEND APP_DEPS_PACKAGE_LIBRARIES ${${packageName}_LIBRARIES})
+    list(APPEND APP_DEPS_TPL_LIBRARIES ${${packageName}_TPL_LIBRARIES})
+    #print_var(APP_DEPS_PACKAGE_INCLUDE_DIRS)
+    #print_var(APP_DEPS_TPL_INCLUDE_DIRS)
+    #print_var(APP_DEPS_PACKAGE_LIBRARIES)
+    #print_var(APP_DEPS_TPL_LIBRARIES)
+  endforeach()
+
+  # Get the full list of include dirs and libs
+  set(APP_DEPS_INCLUDE_DIRS
+    ${APP_DEPS_PACKAGE_INCLUDE_DIRS} ${APP_DEPS_TPL_INCLUDE_DIRS})
+  set(APP_DEPS_LIBRARIES
+    ${APP_DEPS_PACKAGE_LIBRARIES} ${APP_DEPS_TPL_LIBRARIES})
+  #print_var(APP_DEPS_INCLUDE_DIRS)
+  #print_var(APP_DEPS_LIBRARIES)
+
+  # Remove duplicates
+  list(REVERSE APP_DEPS_INCLUDE_DIRS)
+  list(REMOVE_DUPLICATES APP_DEPS_INCLUDE_DIRS)
+  list(REVERSE APP_DEPS_INCLUDE_DIRS)
+  print_var(APP_DEPS_INCLUDE_DIRS)
+  list(REVERSE APP_DEPS_LIBRARIES)
+  list(REMOVE_DUPLICATES APP_DEPS_LIBRARIES)
+  list(REVERSE APP_DEPS_LIBRARIES)
+  print_var(APP_DEPS_LIBRARIES)
+
+endmacro()
+
+
+
 # Get TribitsExProj stuff from find_package(TribitsExProj)
 #
-macro(getTribitsExProjProjectStuff)
+macro(getTribitsExProjStuffByProject)
 
   find_package(TribitsExProj REQUIRED COMPONENTS ${${PROJECT_NAME}_USE_COMPONENTS})
 
-  MESSAGE("\nFound TribitsExProj!  Here are the details: ")
-  MESSAGE("   TribitsExProj_DIR = ${TribitsExProj_DIR}")
-  MESSAGE("   TribitsExProj_VERSION = ${TribitsExProj_VERSION}")
-  MESSAGE("   TribitsExProj_PACKAGE_LIST = ${TribitsExProj_PACKAGE_LIST}")
-  MESSAGE("   TribitsExProj_LIBRARIES = ${TribitsExProj_LIBRARIES}")
-  MESSAGE("   TribitsExProj_INCLUDE_DIRS = ${TribitsExProj_INCLUDE_DIRS}")
-  MESSAGE("   TribitsExProj_LIBRARY_DIRS = ${TribitsExProj_LIBRARY_DIRS}")
-  MESSAGE("   TribitsExProj_TPL_LIST = ${TribitsExProj_TPL_LIST}")
-  MESSAGE("   TribitsExProj_TPL_INCLUDE_DIRS = ${TribitsExProj_TPL_INCLUDE_DIRS}")
-  MESSAGE("   TribitsExProj_TPL_LIBRARIES = ${TribitsExProj_TPL_LIBRARIES}")
-  MESSAGE("   TribitsExProj_TPL_LIBRARY_DIRS = ${TribitsExProj_TPL_LIBRARY_DIRS}")
-  MESSAGE("   TribitsExProj_BUILD_SHARED_LIBS = ${TribitsExProj_BUILD_SHARED_LIBS}")
-  MESSAGE("End of TribitsExProj details\n")
+  message("\nFound TribitsExProj!  Here are the details: ")
+  message("   TribitsExProj_DIR = ${TribitsExProj_DIR}")
+  message("   TribitsExProj_VERSION = ${TribitsExProj_VERSION}")
+  message("   TribitsExProj_PACKAGE_LIST = ${TribitsExProj_PACKAGE_LIST}")
+  message("   TribitsExProj_LIBRARIES = ${TribitsExProj_LIBRARIES}")
+  message("   TribitsExProj_INCLUDE_DIRS = ${TribitsExProj_INCLUDE_DIRS}")
+  message("   TribitsExProj_LIBRARY_DIRS = ${TribitsExProj_LIBRARY_DIRS}")
+  message("   TribitsExProj_TPL_LIST = ${TribitsExProj_TPL_LIST}")
+  message("   TribitsExProj_TPL_INCLUDE_DIRS = ${TribitsExProj_TPL_INCLUDE_DIRS}")
+  message("   TribitsExProj_TPL_LIBRARIES = ${TribitsExProj_TPL_LIBRARIES}")
+  message("   TribitsExProj_TPL_LIBRARY_DIRS = ${TribitsExProj_TPL_LIBRARY_DIRS}")
+  message("   TribitsExProj_BUILD_SHARED_LIBS = ${TribitsExProj_BUILD_SHARED_LIBS}")
+  message("End of TribitsExProj details\n")
 
   # Make sure to use same compilers and flags as TribitsExProj
   set(CMAKE_CXX_COMPILER ${TribitsExProj_CXX_COMPILER} )
@@ -79,4 +125,9 @@ function(appendTestDepsStr componentName depsStrOut str)
     endif()
   endif()
   set(${depsStrOut} "${depsStr}" PARENT_SCOPE)
+endfunction()
+
+
+function(print_var varName)
+  message("-- ${varName} = '${${varName}}'")
 endfunction()

--- a/tribits/examples/TribitsExampleApp/AppHelperFuncs.cmake
+++ b/tribits/examples/TribitsExampleApp/AppHelperFuncs.cmake
@@ -1,4 +1,66 @@
-function(addDepCompileDefine componentName)
+# Find TribitsExProj package(s), load compilers and compiler options, and get
+# libs and include dirs to link against.
+#
+macro(getTribitsExProjStuff)
+
+  set(${PROJECT_NAME}_FIND_INDIVIDUAL_PACKAGES OFF CACHE BOOL
+    "Set to TRUE to find individual packages and OFF to find project TribitsExProj")
+
+  if (${PROJECT_NAME}_FIND_INDIVIDUAL_PACKAGES)
+    message(FATAL_ERROR "ToDo: Implement!")
+  else()
+    getTribitsExProjProjectStuff()
+  endif()
+
+endmacro()
+
+
+# Get TribitsExProj stuff from find_package(TribitsExProj)
+#
+macro(getTribitsExProjProjectStuff)
+
+  find_package(TribitsExProj REQUIRED COMPONENTS ${${PROJECT_NAME}_USE_COMPONENTS})
+
+  MESSAGE("\nFound TribitsExProj!  Here are the details: ")
+  MESSAGE("   TribitsExProj_DIR = ${TribitsExProj_DIR}")
+  MESSAGE("   TribitsExProj_VERSION = ${TribitsExProj_VERSION}")
+  MESSAGE("   TribitsExProj_PACKAGE_LIST = ${TribitsExProj_PACKAGE_LIST}")
+  MESSAGE("   TribitsExProj_LIBRARIES = ${TribitsExProj_LIBRARIES}")
+  MESSAGE("   TribitsExProj_INCLUDE_DIRS = ${TribitsExProj_INCLUDE_DIRS}")
+  MESSAGE("   TribitsExProj_LIBRARY_DIRS = ${TribitsExProj_LIBRARY_DIRS}")
+  MESSAGE("   TribitsExProj_TPL_LIST = ${TribitsExProj_TPL_LIST}")
+  MESSAGE("   TribitsExProj_TPL_INCLUDE_DIRS = ${TribitsExProj_TPL_INCLUDE_DIRS}")
+  MESSAGE("   TribitsExProj_TPL_LIBRARIES = ${TribitsExProj_TPL_LIBRARIES}")
+  MESSAGE("   TribitsExProj_TPL_LIBRARY_DIRS = ${TribitsExProj_TPL_LIBRARY_DIRS}")
+  MESSAGE("   TribitsExProj_BUILD_SHARED_LIBS = ${TribitsExProj_BUILD_SHARED_LIBS}")
+  MESSAGE("End of TribitsExProj details\n")
+
+  # Make sure to use same compilers and flags as TribitsExProj
+  set(CMAKE_CXX_COMPILER ${TribitsExProj_CXX_COMPILER} )
+  set(CMAKE_C_COMPILER ${TribitsExProj_C_COMPILER} )
+  set(CMAKE_Fortran_COMPILER ${TribitsExProj_Fortran_COMPILER} )
+
+  set(CMAKE_CXX_FLAGS "${TribitsExProj_CXX_COMPILER_FLAGS} ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_C_FLAGS "${TribitsExProj_C_COMPILER_FLAGS} ${CMAKE_C_FLAGS}")
+  set(CMAKE_Fortran_FLAGS "${TribitsExProj_Fortran_COMPILER_FLAGS} ${CMAKE_Fortran_FLAGS}")
+
+  # Get the include directories and libraries for building and linking
+  set(APP_DEPS_INCLUDE_DIRS
+    ${TribitsExProj_INCLUDE_DIRS} ${TribitsExProj_TPL_INCLUDE_DIRS})
+  set(APP_DEPS_LIBRARIES
+    ${TribitsExProj_LIBRARIES} ${TribitsExProj_TPL_LIBRARIES})
+
+endmacro()
+
+
+function(addAppDepCompileDefines)
+  addAppDepCompileDefine("SimpleCxx")
+  addAppDepCompileDefine("MixedLang")
+  addAppDepCompileDefine("WithSubpackages")
+endfunction()
+
+
+function(addAppDepCompileDefine componentName)
   if (${componentName} IN_LIST ${PROJECT_NAME}_USE_COMPONENTS)
     string(TOUPPER "${componentName}" componentNameUpper)
     target_compile_definitions(app PRIVATE TRIBITSEXAPP_HAVE_${componentNameUpper})
@@ -6,7 +68,7 @@ function(addDepCompileDefine componentName)
 endfunction()
 
 
-function(appendDepsStr componentName depsStrOut str)
+function(appendTestDepsStr componentName depsStrOut str)
   set(depsStr "${${depsStrOut}}")  # Should be value of var in parent scope!
   #message("-- depsStr (inner) = '${depsStr}'")
   if (${componentName} IN_LIST ${PROJECT_NAME}_USE_COMPONENTS)
@@ -18,5 +80,3 @@ function(appendDepsStr componentName depsStrOut str)
   endif()
   set(${depsStrOut} "${depsStr}" PARENT_SCOPE)
 endfunction()
-
-

--- a/tribits/examples/TribitsExampleApp/AppHelperFuncs.cmake
+++ b/tribits/examples/TribitsExampleApp/AppHelperFuncs.cmake
@@ -1,0 +1,22 @@
+function(addDepCompileDefine componentName)
+  if (${componentName} IN_LIST ${PROJECT_NAME}_USE_COMPONENTS)
+    string(TOUPPER "${componentName}" componentNameUpper)
+    target_compile_definitions(app PRIVATE TRIBITSEXAPP_HAVE_${componentNameUpper})
+  endif()
+endfunction()
+
+
+function(appendDepsStr componentName depsStrOut str)
+  set(depsStr "${${depsStrOut}}")  # Should be value of var in parent scope!
+  #message("-- depsStr (inner) = '${depsStr}'")
+  if (${componentName} IN_LIST ${PROJECT_NAME}_USE_COMPONENTS)
+    if (depsStr)
+      set(depsStr "${depsStr}[;] ${str}")
+    else()
+      set(depsStr "${str}")
+    endif()
+  endif()
+  set(${depsStrOut} "${depsStr}" PARENT_SCOPE)
+endfunction()
+
+

--- a/tribits/examples/TribitsExampleApp/CMakeLists.txt
+++ b/tribits/examples/TribitsExampleApp/CMakeLists.txt
@@ -7,35 +7,15 @@ project(TribitsExApp
   LANGUAGES NONE  # Defined below after reading in compilers
   )
 
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+include(AppHelperFuncs)
+
 set(${PROJECT_NAME}_USE_COMPONENTS "" CACHE STRING
-  "Components to use from TribitsExampleProject: <C0>,<C1>,..." )
+  "Components/Packages to use from TribitsExampleProject: <C0>,<C1>,..." )
 string(REPLACE "," ";" ${PROJECT_NAME}_USE_COMPONENTS
   "${${PROJECT_NAME}_USE_COMPONENTS}")
 
-find_package(TribitsExProj REQUIRED COMPONENTS ${${PROJECT_NAME}_USE_COMPONENTS})
-
-MESSAGE("\nFound TribitsExProj!  Here are the details: ")
-MESSAGE("   TribitsExProj_DIR = ${TribitsExProj_DIR}")
-MESSAGE("   TribitsExProj_VERSION = ${TribitsExProj_VERSION}")
-MESSAGE("   TribitsExProj_PACKAGE_LIST = ${TribitsExProj_PACKAGE_LIST}")
-MESSAGE("   TribitsExProj_LIBRARIES = ${TribitsExProj_LIBRARIES}")
-MESSAGE("   TribitsExProj_INCLUDE_DIRS = ${TribitsExProj_INCLUDE_DIRS}")
-MESSAGE("   TribitsExProj_LIBRARY_DIRS = ${TribitsExProj_LIBRARY_DIRS}")
-MESSAGE("   TribitsExProj_TPL_LIST = ${TribitsExProj_TPL_LIST}")
-MESSAGE("   TribitsExProj_TPL_INCLUDE_DIRS = ${TribitsExProj_TPL_INCLUDE_DIRS}")
-MESSAGE("   TribitsExProj_TPL_LIBRARIES = ${TribitsExProj_TPL_LIBRARIES}")
-MESSAGE("   TribitsExProj_TPL_LIBRARY_DIRS = ${TribitsExProj_TPL_LIBRARY_DIRS}")
-MESSAGE("   TribitsExProj_BUILD_SHARED_LIBS = ${TribitsExProj_BUILD_SHARED_LIBS}")
-MESSAGE("End of TribitsExProj details\n")
-
-# Make sure to use same compilers and flags as TribitsExProj
-set(CMAKE_CXX_COMPILER ${TribitsExProj_CXX_COMPILER} )
-set(CMAKE_C_COMPILER ${TribitsExProj_C_COMPILER} )
-set(CMAKE_Fortran_COMPILER ${TribitsExProj_Fortran_COMPILER} )
-
-set(CMAKE_CXX_FLAGS  "${TribitsExProj_CXX_COMPILER_FLAGS} ${CMAKE_CXX_FLAGS}")
-set(CMAKE_C_FLAGS  "${TribitsExProj_C_COMPILER_FLAGS} ${CMAKE_C_FLAGS}")
-set(CMAKE_Fortran_FLAGS  "${TribitsExProj_Fortran_COMPILER_FLAGS} ${CMAKE_Fortran_FLAGS}")
+getTribitsExProjStuff()
 
 # Now enable the compilers now that we have gotten them from TribitsExProj
 enable_language(C)
@@ -44,23 +24,15 @@ if (CMAKE_Fortran_COMPILER)
   enable_language(Fortran)
 endif()
 
-# Load modules
-list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-include(AppHelperFuncs)
-
 # Build the APP and link to TribitsExProj
 add_executable(app ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp)
-target_include_directories(app PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR} ${TribitsExProj_INCLUDE_DIRS} ${TribitsExProj_TPL_INCLUDE_DIRS})
-target_link_libraries(app PRIVATE
-  ${TribitsExProj_LIBRARIES} ${TribitsExProj_TPL_LIBRARIES})
+target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  ${APP_DEPS_INCLUDE_DIRS})
+target_link_libraries(app PRIVATE ${APP_DEPS_LIBRARIES})
+addAppDepCompileDefines()
 
-# Tell app.cpp what components are supported
-addDepCompileDefine("SimpleCxx")
-addDepCompileDefine("MixedLang")
-addDepCompileDefine("WithSubpackages")
+# Set up tests
 
-# Set up a test
 enable_testing()
 
 #set(NUM_MPI_PROCS ${TribitsExProj_MPI_EXEC_MAX_NUMPROCS})
@@ -73,9 +45,9 @@ enable_testing()
 #  )
 
 set(depsStr "")
-appendDepsStr("WithSubpackages" depsStr "WithSubpackages:B A no_deps no_deps")
-appendDepsStr("MixedLang" depsStr "MixedLang:Mixed Language")
-appendDepsStr("SimpleCxx" depsStr "SimpleCxx:no_deps")
+appendTestDepsStr("WithSubpackages" depsStr "WithSubpackages:B A no_deps no_deps")
+appendTestDepsStr("MixedLang" depsStr "MixedLang:Mixed Language")
+appendTestDepsStr("SimpleCxx" depsStr "SimpleCxx:no_deps")
 
 add_test(app_test app)
 set_tests_properties(app_test PROPERTIES

--- a/tribits/examples/TribitsExampleApp/CMakeLists.txt
+++ b/tribits/examples/TribitsExampleApp/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.17.1)
+
+project(TribitsExApp
+  DESCRIPTION
+    "Example raw CMake project using packages installed from TribitsExampleProject"
+  VERSION 0.0.0
+  LANGUAGES NONE  # Defined below after reading in compilers
+  )
+
+set(${PROJECT_NAME}_USE_COMPONENTS "" CACHE STRING
+  "Components to use from TribitsExampleProject: <C0>,<C1>,..." )
+string(REPLACE "," ";" ${PROJECT_NAME}_USE_COMPONENTS
+  "${${PROJECT_NAME}_USE_COMPONENTS}")
+
+find_package(TribitsExProj REQUIRED COMPONENTS ${${PROJECT_NAME}_USE_COMPONENTS})
+
+MESSAGE("\nFound TribitsExProj!  Here are the details: ")
+MESSAGE("   TribitsExProj_DIR = ${TribitsExProj_DIR}")
+MESSAGE("   TribitsExProj_VERSION = ${TribitsExProj_VERSION}")
+MESSAGE("   TribitsExProj_PACKAGE_LIST = ${TribitsExProj_PACKAGE_LIST}")
+MESSAGE("   TribitsExProj_LIBRARIES = ${TribitsExProj_LIBRARIES}")
+MESSAGE("   TribitsExProj_INCLUDE_DIRS = ${TribitsExProj_INCLUDE_DIRS}")
+MESSAGE("   TribitsExProj_LIBRARY_DIRS = ${TribitsExProj_LIBRARY_DIRS}")
+MESSAGE("   TribitsExProj_TPL_LIST = ${TribitsExProj_TPL_LIST}")
+MESSAGE("   TribitsExProj_TPL_INCLUDE_DIRS = ${TribitsExProj_TPL_INCLUDE_DIRS}")
+MESSAGE("   TribitsExProj_TPL_LIBRARIES = ${TribitsExProj_TPL_LIBRARIES}")
+MESSAGE("   TribitsExProj_TPL_LIBRARY_DIRS = ${TribitsExProj_TPL_LIBRARY_DIRS}")
+MESSAGE("   TribitsExProj_BUILD_SHARED_LIBS = ${TribitsExProj_BUILD_SHARED_LIBS}")
+MESSAGE("End of TribitsExProj details\n")
+
+# Make sure to use same compilers and flags as TribitsExProj
+set(CMAKE_CXX_COMPILER ${TribitsExProj_CXX_COMPILER} )
+set(CMAKE_C_COMPILER ${TribitsExProj_C_COMPILER} )
+set(CMAKE_Fortran_COMPILER ${TribitsExProj_Fortran_COMPILER} )
+
+set(CMAKE_CXX_FLAGS  "${TribitsExProj_CXX_COMPILER_FLAGS} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_C_FLAGS  "${TribitsExProj_C_COMPILER_FLAGS} ${CMAKE_C_FLAGS}")
+set(CMAKE_Fortran_FLAGS  "${TribitsExProj_Fortran_COMPILER_FLAGS} ${CMAKE_Fortran_FLAGS}")
+
+# Now enable the compilers now that we have gotten them from TribitsExProj
+enable_language(C)
+enable_language(CXX)
+if (CMAKE_Fortran_COMPILER)
+  enable_language(Fortran)
+endif()
+
+# Load modules
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+include(AppHelperFuncs)
+
+# Build the APP and link to TribitsExProj
+add_executable(app ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp)
+target_include_directories(app PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR} ${TribitsExProj_INCLUDE_DIRS} ${TribitsExProj_TPL_INCLUDE_DIRS})
+target_link_libraries(app PRIVATE
+  ${TribitsExProj_LIBRARIES} ${TribitsExProj_TPL_LIBRARIES})
+
+# Tell app.cpp what components are supported
+addDepCompileDefine("SimpleCxx")
+addDepCompileDefine("MixedLang")
+addDepCompileDefine("WithSubpackages")
+
+# Set up a test
+enable_testing()
+
+#set(NUM_MPI_PROCS ${TribitsExProj_MPI_EXEC_MAX_NUMPROCS})
+#add_test(app_test
+#  ${TribitsExProj_MPI_EXEC} ${TribitsExProj_MPI_EXEC_NUMPROCS_FLAG} ${NUM_MPI_PROCS}
+#  app)
+#set_tests_properties(app_test PROPERTIES
+#  PROCESSORS ${NUM_MPI_PROCS}
+#  PASS_REGULAR_EXPRESSION "DUMMY NO MATCH"
+#  )
+
+set(depsStr "")
+appendDepsStr("WithSubpackages" depsStr "WithSubpackages:B A no_deps no_deps")
+appendDepsStr("MixedLang" depsStr "MixedLang:Mixed Language")
+appendDepsStr("SimpleCxx" depsStr "SimpleCxx:no_deps")
+
+add_test(app_test app)
+set_tests_properties(app_test PROPERTIES
+  PASS_REGULAR_EXPRESSION "Full Deps: ${depsStr}"
+  )

--- a/tribits/examples/TribitsExampleApp/app.cpp
+++ b/tribits/examples/TribitsExampleApp/app.cpp
@@ -1,0 +1,58 @@
+#ifdef TRIBITSEXAPP_HAVE_SIMPLECXX
+#  include "SimpleCxx_HelloWorld.hpp"
+#endif
+#ifdef TRIBITSEXAPP_HAVE_MIXEDLANG
+#  include "MixedLang.hpp"
+#endif
+#ifdef TRIBITSEXAPP_HAVE_WITHSUBPACKAGES
+#  include "wsp_c/C.hpp"
+#endif
+
+
+#include <iostream>
+#include <string>
+
+//#include <mpi.h>
+
+
+void appendDepsStr(std::string &depsStr, const std::string &str)
+{
+  if (depsStr.length()) {
+    depsStr += "; "+str;
+  }
+  else {
+    depsStr = str;
+  }
+}
+
+
+int main(int argc, char *argv[]) {
+  //MPI_Init(&argc, &argv);
+  //MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Make sure MPI works
+  //int oneVal = 1;
+  //int numProcs = 0;
+  //MPI_Reduce(&onVal, &numProcs, MPI_SUM, 0, MPI_COMM_WORLD);
+  const int rank = 0; 
+
+  // Get deps down the deps graph
+  std::string depsStr;
+#ifdef TRIBITSEXAPP_HAVE_WITHSUBPACKAGES
+  appendDepsStr(depsStr, "WithSubpackages:"+WithSubpackages::depsC());
+#endif
+#ifdef TRIBITSEXAPP_HAVE_MIXEDLANG
+  appendDepsStr(depsStr, "MixedLang:"+tribits_mixed::mixedLang());
+#endif
+#ifdef TRIBITSEXAPP_HAVE_SIMPLECXX
+  appendDepsStr(depsStr, "SimpleCxx:"+SimpleCxx::deps());
+#endif
+  // NOTE: The above all call functions from the libraries and requires that
+  // both the header files be found at compile time and the libraries be found
+  // at link time and runtime for this these function calls to work.
+
+  if (rank == 0) {
+    std::cout << "Full Deps: " << depsStr << "\n";
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Working towards #299

This PR adds the new example/test raw CMake project TribitsExampleApp. It define a C++ application that calls some functions defined in TribitsExampleProject (TribitsExProj) and pulls in what it needs through `<Package>Config.cmake` files.  This APP can conditionally use different packages/components from TribitsExampleProject and can pull in either `find_package(TribitExProj REQUIRED COMPONENTS ... )` at the project level or pull in individual packages with individual `find_package(<Package> REQUIRED)` calls.

The primary purpose of CMake project is to test the `<Package>Config.cmake` files currently being generated by TriBITS.  I added several TriBITS tests with this for these files both being installed and those being placed in the build tree.

With these tests in place, I feel fairly confidence to refactor the existing library and exec targets for internal packages to use modern modern CMake for handling include dirs and other bits of info (see #299).
 