### PR TITLE
Enable SimpleTpl to TribitsExampleApp tests (#299)

### DIFF
--- a/.github/workflows/tribits_testing.yml
+++ b/.github/workflows/tribits_testing.yml
@@ -80,6 +80,7 @@ jobs:
         run: |
           cd ..
           env CTEST_BUILD_NAME_SUFFIX=${{ github.event.inputs.ctest_build_name_suffix }} \
+            TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL=ON \
           ./TriBITS/cmake/ctest/github_actions/run_github_actions_ctest_driver.sh \
             --os ${{ matrix.config.os }} \
             --cmake-ver ${{ matrix.config.cmake }} \

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4450,7 +4450,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
     TEST_5
-      MESSAGE "Build and install TribitsExampleApp"
+      MESSAGE "Build TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
       CMND make ARGS ${CTEST_BUILD_FLAGS}
@@ -4562,7 +4562,7 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
     TEST_5
-      MESSAGE "Build and install TribitsExampleApp"
+      MESSAGE "Build TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
       CMND make ARGS ${CTEST_BUILD_FLAGS}
@@ -4646,7 +4646,7 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
     TEST_3
-      MESSAGE "Build and install TribitsExampleApp"
+      MESSAGE "Build TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
       CMND make ARGS ${CTEST_BUILD_FLAGS}

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4403,6 +4403,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
       CMND ${CMAKE_COMMAND}
       ARGS
         ${SERIAL_PASSTHROUGH_CONFIGURE_ARGS}
+        -DCMAKE_BUILD_TYPE=RelWithDepInfo
         -DCMAKE_INSTALL_PREFIX=install
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/tpls/SimpleTpl
 

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -3896,6 +3896,8 @@ tribits_add_advanced_test( SimpleTpl_install_shared
       -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE
       -DCMAKE_MACOSX_RPATH=TRUE
       -DCMAKE_INSTALL_PREFIX=${SimpleTpl_install_shared_DIR}/install
+      -DCMAKE_INSTALL_INCLUDEDIR=include
+      -DCMAKE_INSTALL_LIBDIR=lib
       ${${PROJECT_NAME}_TRIBITS_DIR}/examples/tpls/SimpleTpl
     PASS_REGULAR_EXPRESSION_ALL
       "Configuring done"

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4387,12 +4387,30 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
     set(buildSharedLibsArg -DBUILD_SHARED_LIBS=OFF)
   endif()
 
+  set(buildDir
+    ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic})
+
   tribits_add_advanced_test( TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic}
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
     XHOSTTYPE Darwin
 
     TEST_0
+      MESSAGE "Configure SimpleTpl to be installed for TribitsExampleProject"
+      WORKING_DIRECTORY simpletpl_build
+      CMND ${CMAKE_COMMAND}
+      ARGS
+        ${SERIAL_PASSTHROUGH_CONFIGURE_ARGS}
+        -DCMAKE_INSTALL_PREFIX=install
+        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/tpls/SimpleTpl
+
+    TEST_1
+      MESSAGE "Build and install SimpleTpl locally"
+      WORKING_DIRECTORY simpletpl_build
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND make ARGS ${CTEST_BUILD_FLAGS} install
+
+    TEST_2
       MESSAGE "Do the configure of TribitsExampleProject"
       CMND ${CMAKE_COMMAND}
       ARGS
@@ -4402,28 +4420,31 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
         -DTribitsExProj_ENABLE_ALL_PACKAGES=ON
         -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON
         -DTribitsExProj_ENABLE_INSTALL_CMAKE_CONFIG_FILES=ON
+        -DTPL_ENABLE_SimpleTpl=ON
+        -DSimpleTpl_INCLUDE_DIRS=${buildDir}/simpletpl_build/install/include
+        -DSimpleTpl_LIBRARY_DIRS=${buildDir}/simpletpl_build/install/lib
         ${buildSharedLibsArg}
         -DCMAKE_INSTALL_PREFIX=install
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
 
-    TEST_1
+    TEST_3
       MESSAGE "Build and install TribitsExampleProject locally"
       CMND make ARGS ${CTEST_BUILD_FLAGS} install
 
-    TEST_2
+    TEST_4
       MESSAGE "Configure TribitsExampleApp locally"
       WORKING_DIRECTORY app_build
       CMND ${CMAKE_COMMAND} ARGS
-        -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic}/install
+        -DCMAKE_PREFIX_PATH=${buildDir}/install
         -DTribitsExApp_USE_COMPONENTS=SimpleCxx,WithSubpackages
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleApp
       PASS_REGULAR_EXPRESSION_ALL
         "-- Configuring done"
         "-- Generating done"
-        "-- Build files have been written to: .*/TriBITS_TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic}/app_build"
+        "-- Build files have been written to: .*/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic}/app_build"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_3
+    TEST_5
       MESSAGE "Build and install TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
@@ -4432,7 +4453,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
         "Built target app"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_4
+    TEST_6
       MESSAGE "Test TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
@@ -4442,6 +4463,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
         "app_test [.]+   Passed"
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN
+
     )
 
 endfunction()

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4380,6 +4380,16 @@ tribits_add_advanced_test( TribitsExampleProject_TribitsExampleProjectAddons
 # TribitsExampleApp
 ########################################################################
 
+if (NOT "$ENV{TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL}" STREQUAL "")
+  set(TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_DEFAULT
+    $ENV{TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL})
+else()
+  set($ENV{TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL} OFF)
+endif()
+advanced_set(TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL
+  ${TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_DEFAULT} CACHE BOOL
+  "Set to TRUE to add LD_LIBRARY_PATH to libsimpletpl.so for platforms where RPATH not working")
+
 
 function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
 
@@ -4392,6 +4402,21 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
   set(testBaseName TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic})
   set(testName ${PACKAGE_NAME}_${testBaseName})
   set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
+
+  if (TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL)
+    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG
+      ENVIRONMENT LD_LIBRARY_PATH=${buildDir}/simpletpl_build/install/lib)
+  else()
+    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG "")
+  endif()
+  # NOTE: Above, we have to set LD_LIBRARY_PATH to pick up the
+  # libsimpletpl.so because CMake 3.17.5 and 3.21.2 with the GitHub Actions
+  # Umbuntu build is refusing to put in the RPATH for libsimpletpl.so into
+  # libsimplecxx.so even through CMAKE_INSTALL_RPATH_USE_LINK_PATH=ON is
+  # set.  This is not needed for the RHEL 7 builds that I have tried where
+  # CMake is behaving correctly and putting in RPATH correctly.  But because
+  # I can't log into this system, it is very hard and time consuming to
+  # debug this so I am just giving up at this point.
 
   tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
@@ -4469,6 +4494,8 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
+    ${LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG}
+
     )
 
 endfunction()
@@ -4501,6 +4528,14 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
   set(testBaseName TribitsExampleApp_ALL_ST_${byProjectOrPackage}_${sharedOrStatic})
   set(testName ${PACKAGE_NAME}_${testBaseName})
   set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
+
+  if (TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL)
+    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG
+      ENVIRONMENT LD_LIBRARY_PATH=${buildDir}/simpletpl_build/install/lib)
+  else()
+    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG "")
+  endif()
+  # NOTE: Above, see comment above!
 
   tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
@@ -4580,6 +4615,9 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
         "app_test [.]+   Passed"
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    ${LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG}
+
     )
 
 endfunction()
@@ -4604,6 +4642,14 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
   set(testBaseName TribitsExampleApp_ALL_ST_buildtree_${sharedOrStatic})
   set(testName ${PACKAGE_NAME}_${testBaseName})
   set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
+
+  if (TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL)
+    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG
+      ENVIRONMENT LD_LIBRARY_PATH=${buildDir}/simpletpl_build/install/lib)
+  else()
+    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG "")
+  endif()
+  # NOTE: Above, see comment above!
 
   tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
@@ -4664,6 +4710,9 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
         "app_test [.]+   Passed"
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    ${LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG}
+
     )
 
 endfunction()

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4389,10 +4389,11 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
     set(buildSharedLibsArg -DBUILD_SHARED_LIBS=OFF)
   endif()
 
-  set(buildDir
-    ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic})
+  set(testBaseName TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic})
+  set(testName ${PACKAGE_NAME}_${testBaseName})
+  set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
 
-  tribits_add_advanced_test( TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic}
+  tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
     XHOSTTYPE Darwin
@@ -4445,7 +4446,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
       PASS_REGULAR_EXPRESSION_ALL
         "-- Configuring done"
         "-- Generating done"
-        "-- Build files have been written to: .*/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic}/app_build"
+        "-- Build files have been written to: .*/${testName}/app_build"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
     TEST_5
@@ -4497,13 +4498,34 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
     message(FATAL_ERROR "Invaid value for sharedOrStatic='${sharedOrStatic}'!")
   endif()
 
-  tribits_add_advanced_test( TribitsExampleApp_ALL_ST_${byProjectOrPackage}_${sharedOrStatic}
+  set(testBaseName TribitsExampleApp_ALL_ST_${byProjectOrPackage}_${sharedOrStatic})
+  set(testName ${PACKAGE_NAME}_${testBaseName})
+  set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
+
+  tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
     EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
     XHOSTTYPE Darwin
 
     TEST_0
+      MESSAGE "Configure SimpleTpl to be installed for TribitsExampleProject"
+      WORKING_DIRECTORY simpletpl_build
+      CMND ${CMAKE_COMMAND}
+      ARGS
+        ${SERIAL_PASSTHROUGH_CONFIGURE_ARGS}
+        -DCMAKE_BUILD_TYPE=RelWithDepInfo
+        ${buildSharedLibsArg}
+        -DCMAKE_INSTALL_PREFIX=install
+        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/tpls/SimpleTpl
+
+    TEST_1
+      MESSAGE "Build and install SimpleTpl locally"
+      WORKING_DIRECTORY simpletpl_build
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND make ARGS ${CTEST_BUILD_FLAGS} install
+
+    TEST_2
       MESSAGE "Do the configure of TribitsExampleProject"
       CMND ${CMAKE_COMMAND}
       ARGS
@@ -4513,19 +4535,22 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
         -DTribitsExProj_ENABLE_ALL_PACKAGES=ON
         -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON
         -DTribitsExProj_ENABLE_INSTALL_CMAKE_CONFIG_FILES=ON
+        -DTPL_ENABLE_SimpleTpl=ON
+        -DSimpleTpl_INCLUDE_DIRS=${buildDir}/simpletpl_build/install/include
+        -DSimpleTpl_LIBRARY_DIRS=${buildDir}/simpletpl_build/install/lib
         ${buildSharedLibsArg}
         -DCMAKE_INSTALL_PREFIX=install
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
 
-    TEST_1
+    TEST_3
       MESSAGE "Build and install TribitsExampleProject locally"
       CMND make ARGS ${CTEST_BUILD_FLAGS} install
 
-    TEST_2
+    TEST_4
       MESSAGE "Configure TribitsExampleApp locally"
       WORKING_DIRECTORY app_build
       CMND ${CMAKE_COMMAND} ARGS
-        -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_${byProjectOrPackage}_${sharedOrStatic}/install
+        -DCMAKE_PREFIX_PATH=${buildDir}/install
         -DTribitsExApp_USE_COMPONENTS=SimpleCxx,MixedLang,WithSubpackages
         ${findByProjectOrPackageArg}
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleApp
@@ -4533,10 +4558,10 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
         "${foundProjectOrPackageStr}"
         "-- Configuring done"
         "-- Generating done"
-        "-- Build files have been written to: .*/TriBITS_TribitsExampleApp_ALL_ST_${byProjectOrPackage}_${sharedOrStatic}/app_build"
+        "-- Build files have been written to: .*/${testName}/app_build"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_3
+    TEST_5
       MESSAGE "Build and install TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
@@ -4545,13 +4570,13 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
         "Built target app"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_4
+    TEST_6
       MESSAGE "Test TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
       CMND ${CMAKE_CTEST_COMMAND} ARGS -VV
       PASS_REGULAR_EXPRESSION_ALL
-        "Full Deps: WithSubpackages:B A headeronlytpl headeronlytpl[;] MixedLang:Mixed Language[;] SimpleCxx:headeronlytpl"
+        "Full Deps: WithSubpackages:B A simpletpl headeronlytpl simpletpl headeronlytpl[;] MixedLang:Mixed Language[;] SimpleCxx:simpletpl headeronlytpl"
         "app_test [.]+   Passed"
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN
@@ -4576,7 +4601,11 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
     message(FATAL_ERROR "Invaid value for sharedOrStatic='${sharedOrStatic}'!")
   endif()
 
-  tribits_add_advanced_test( TribitsExampleApp_ALL_ST_buildtree_${sharedOrStatic}
+  set(testBaseName TribitsExampleApp_ALL_ST_buildtree_${sharedOrStatic})
+  set(testName ${PACKAGE_NAME}_${testBaseName})
+  set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
+
+  tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
     EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
@@ -4604,7 +4633,7 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
       WORKING_DIRECTORY app_build
       CMND ${CMAKE_COMMAND} ARGS
         -DTribitsExApp_FIND_INDIVIDUAL_PACKAGES=TRUE
-        -DTribitsExApp_FIND_UNDER_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_TribitsExampleApp_ALL_ST_buildtree_${sharedOrStatic}
+        -DTribitsExApp_FIND_UNDER_BUILD_DIR=${buildDir}
         -DTribitsExApp_USE_COMPONENTS=SimpleCxx,MixedLang
         ${findByProjectOrPackageArg}
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleApp
@@ -4613,7 +4642,7 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
         "Found MixedLang"
         "-- Configuring done"
         "-- Generating done"
-        "-- Build files have been written to: .*/TriBITS_TribitsExampleApp_ALL_ST_buildtree_${sharedOrStatic}/app_build"
+        "-- Build files have been written to: .*/${testName}/app_build"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
     TEST_3

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4404,6 +4404,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
       ARGS
         ${SERIAL_PASSTHROUGH_CONFIGURE_ARGS}
         -DCMAKE_BUILD_TYPE=RelWithDepInfo
+        ${buildSharedLibsArg}
         -DCMAKE_INSTALL_PREFIX=install
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/tpls/SimpleTpl
 
@@ -4462,7 +4463,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
       SKIP_CLEAN_WORKING_DIRECTORY
       CMND ${CMAKE_CTEST_COMMAND} ARGS -VV
       PASS_REGULAR_EXPRESSION_ALL
-        "Full Deps: WithSubpackages:B A no_deps no_deps[;] SimpleCxx:no_deps"
+        "Full Deps: WithSubpackages:B A simpletpl headeronlytpl simpletpl headeronlytpl[;] SimpleCxx:simpletpl headeronlytpl"
         "app_test [.]+   Passed"
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN
@@ -4550,7 +4551,7 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
       SKIP_CLEAN_WORKING_DIRECTORY
       CMND ${CMAKE_CTEST_COMMAND} ARGS -VV
       PASS_REGULAR_EXPRESSION_ALL
-        "Full Deps: WithSubpackages:B A no_deps no_deps[;] MixedLang:Mixed Language[;] SimpleCxx:no_deps"
+        "Full Deps: WithSubpackages:B A headeronlytpl headeronlytpl[;] MixedLang:Mixed Language[;] SimpleCxx:headeronlytpl"
         "app_test [.]+   Passed"
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN
@@ -4630,7 +4631,7 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
       SKIP_CLEAN_WORKING_DIRECTORY
       CMND ${CMAKE_CTEST_COMMAND} ARGS -VV
       PASS_REGULAR_EXPRESSION_ALL
-        "Full Deps: MixedLang:Mixed Language[;] SimpleCxx:no_deps"
+        "Full Deps: MixedLang:Mixed Language[;] SimpleCxx:headeronlytpl"
         "app_test [.]+   Passed"
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -1174,6 +1174,144 @@ tribits_add_advanced_test( RawAndTribitsHelloWorld_Tribits
 
 
 ########################################################################
+# Setup for RPATH handling
+########################################################################
+
+
+
+if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+  set(SHARED_LIB_EXT "dylib")
+  set(RPATH_INSPECT_CMND "otool")
+  set(RPATH_INSPECT_ARG "-L")
+elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+  set(SHARED_LIB_EXT "so")
+  set(RPATH_INSPECT_CMND "objdump")
+  set(RPATH_INSPECT_ARG "-x")
+endif()
+
+
+########################################################################
+# SimpleTpl installs
+########################################################################
+
+
+function(SimpleTpl_install_test sharedOrStatic)
+
+  if (sharedOrStatic STREQUAL "SHARED")
+    set(buildSharedLibsArg
+      -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE
+      -DCMAKE_MACOSX_RPATH=TRUE)
+  else()
+    set(buildSharedLibsArg -DBUILD_SHARED_LIBS=OFF)
+  endif()
+
+  # A) Build and install SharedTpl
+
+  set(testNameBase SimpleTpl_install_${sharedOrStatic})
+  set(testName ${PACKAGE_NAME}_${testNameBase})
+  set(testDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
+
+  tribits_add_advanced_test( ${testNameBase}
+    OVERALL_WORKING_DIRECTORY TEST_NAME
+    OVERALL_NUM_MPI_PROCS 1
+
+    TEST_0
+      MESSAGE "Copy source for SimpleTpl"
+      CMND ${CMAKE_COMMAND}
+      ARGS -E copy_directory ${${PROJECT_NAME}_TRIBITS_DIR}/examples/tpls/SimpleTpl .
+      WORKING_DIRECTORY SimpleTpl
+
+    TEST_1
+      MESSAGE "Configure SimpleTpl"
+      WORKING_DIRECTORY BUILD
+      CMND ${CMAKE_COMMAND}
+      ARGS
+        ${SERIAL_PASSTHROUGH_CONFIGURE_ARGS}
+        ${buildSharedLibsArg}
+        -DCMAKE_BUILD_TYPE=RelWithDepInfo
+        -DCMAKE_INSTALL_PREFIX=${testDir}/install
+        -DCMAKE_INSTALL_INCLUDEDIR=include
+        -DCMAKE_INSTALL_LIBDIR=lib
+        ${testDir}/SimpleTpl
+      PASS_REGULAR_EXPRESSION_ALL
+        "Configuring done"
+        "Generating done"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    TEST_2
+      MESSAGE "Build and install SimpleTpl"
+      WORKING_DIRECTORY BUILD
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND make ARGS ${CTEST_BUILD_FLAGS} install
+      PASS_REGULAR_EXPRESSION_ALL
+        "Built target simpletpl"
+        "Installing: ${testDir}/install/lib/libsimpletpl[.]"
+        "Installing: ${testDir}/install/include/SimpleTpl.hpp"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    TEST_3
+      MESSAGE "Delete source and build directory for SimpleTpl"
+      CMND ${CMAKE_COMMAND} ARGS -E rm -rf SimpleTpl BUILD
+
+      ADDED_TEST_NAME_OUT SimpleTpl_install_${sharedOrStatic}_NAME
+    )
+
+  # Name of added test to use to create test dependencies
+  set(SimpleTpl_install_${sharedOrStatic}_NAME
+    ${SimpleTpl_install_${sharedOrStatic}_NAME} PARENT_SCOPE)
+
+  # Reusable location of the SimpleTPL install
+  set(SimpleTpl_install_${sharedOrStatic}_DIR ${testDir} PARENT_SCOPE)
+
+  # B) Check the RPATH of SHARED SharedTpl
+
+  if (sharedOrStatic STREQUAL "SHARED")
+
+    if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+      set(THIS_RPATH_INSPECT_CMND "${RPATH_INSPECT_CMND}")
+      set(THIS_RPATH_INSPECT_ARG "${RPATH_INSPECT_ARG}")
+      set(RPATH_GREP_STR "@rpath/libsimpletpl.dylib")
+    elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+      set(THIS_RPATH_INSPECT_CMND "ls")
+      set(THIS_RPATH_INSPECT_ARG "")
+      set(RPATH_GREP_STR "libsimpletpl")
+    else()
+      set(THIS_RPATH_INSPECT_CMND "")
+      set(THIS_RPATH_INSPECT_ARG "")
+      set(RPATH_GREP_STR "")
+    endif()
+
+    tribits_add_advanced_test( ${testNameBase}_check_RPATH
+      OVERALL_WORKING_DIRECTORY TEST_NAME
+      OVERALL_NUM_MPI_PROCS 1
+      EXCLUDE_IF_NOT_TRUE THIS_RPATH_INSPECT_CMND
+
+      TEST_0
+        MESSAGE "Inspect the RPATH of the installed shared lib libsimpletpl"
+        CMND ${THIS_RPATH_INSPECT_CMND}
+        ARGS
+          ${THIS_RPATH_INSPECT_ARG} ${testDir}/install/lib/libsimpletpl.${SHARED_LIB_EXT}
+        PASS_REGULAR_EXPRESSION  "${THIS_RPATH_GREP_STR}"
+        ALWAYS_FAIL_ON_NONZERO_RETURN
+
+      ADDED_TEST_NAME_OUT ${testNameBase}_check_RPATH_NAME
+      )
+
+    if (${testNameBase}_check_RPATH_NAME)
+      set_tests_properties(${${testNameBase}_check_RPATH_NAME}
+        PROPERTIES DEPENDS ${SimpleTpl_install_${sharedOrStatic}_NAME} )
+    endif()
+
+  endif()
+
+endfunction()
+
+
+SimpleTpl_install_test(SHARED)
+SimpleTpl_install_test(STATIC)
+
+
+########################################################################
 # TribitsExampleProject
 ########################################################################
 
@@ -3846,78 +3984,9 @@ tribits_add_advanced_test( TribitsExampleProject_DisableWithSubpackagesB_EnableW
 # package enable is not set.
 
 
-##################################
-# RPATH handling
-##################################
-
-
-if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
-  set(SHARED_LIB_EXT "dylib")
-  set(RPATH_INSPECT_CMND "otool")
-  set(RPATH_INSPECT_ARG "-L")
-elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
-  set(SHARED_LIB_EXT "so")
-  set(RPATH_INSPECT_CMND "objdump")
-  set(RPATH_INSPECT_ARG "-x")
-endif()
-
-
-#
-# SimpleTpl_install_shared
-#
-
-if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
-  set(THIS_RPATH_INSPECT_CMND "${RPATH_INSPECT_CMND}")
-  set(THIS_RPATH_INSPECT_ARG "${RPATH_INSPECT_ARG}")
-  set(RPATH_GREP_STR "@rpath/libsimpletpl.dylib")
-elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
-  set(THIS_RPATH_INSPECT_CMND "ls")
-  set(THIS_RPATH_INSPECT_ARG "")
-  set(RPATH_GREP_STR "libsimpletpl")
-else()
-  set(THIS_RPATH_INSPECT_CMND "")
-  set(THIS_RPATH_INSPECT_ARG "")
-  set(RPATH_GREP_STR "")
-endif()
-
-set(SimpleTpl_install_shared_DIR
-  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_SimpleTpl_install_shared)
-
-tribits_add_advanced_test( SimpleTpl_install_shared
-  OVERALL_WORKING_DIRECTORY TEST_NAME
-  OVERALL_NUM_MPI_PROCS 1
-  EXCLUDE_IF_NOT_TRUE THIS_RPATH_INSPECT_CMND
-
-  TEST_0
-    CMND ${CMAKE_COMMAND}
-    ARGS
-      ${SERIAL_PASSTHROUGH_CONFIGURE_ARGS}
-      -DBUILD_SHARED_LIBS=ON
-      -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE
-      -DCMAKE_MACOSX_RPATH=TRUE
-      -DCMAKE_INSTALL_PREFIX=${SimpleTpl_install_shared_DIR}/install
-      -DCMAKE_INSTALL_INCLUDEDIR=include
-      -DCMAKE_INSTALL_LIBDIR=lib
-      ${${PROJECT_NAME}_TRIBITS_DIR}/examples/tpls/SimpleTpl
-    PASS_REGULAR_EXPRESSION_ALL
-      "Configuring done"
-      "Generating done"
-
-  TEST_1 CMND make
-    ARGS ${CTEST_BUILD_FLAGS} install
-    PASS_REGULAR_EXPRESSION_ALL
-      "Built target simpletpl"
-      "Installing: ${SimpleTpl_install_shared_DIR}/install/lib/libsimpletpl[.]"
-      "Installing: ${SimpleTpl_install_shared_DIR}/install/include/SimpleTpl.hpp"
-
-  TEST_2 CMND ${THIS_RPATH_INSPECT_CMND}
-    ARGS ${THIS_RPATH_INSPECT_ARG}  install/lib/libsimpletpl.${SHARED_LIB_EXT}
-    PASS_REGULAR_EXPRESSION  "${THIS_RPATH_GREP_STR}"
-    ALWAYS_FAIL_ON_NONZERO_RETURN
-
-    ADDED_TEST_NAME_OUT SimpleTpl_install_shared_NAME
-
-  )
+########################################################################
+# Test RPATH handling
+########################################################################
 
 
 #
@@ -3933,8 +4002,8 @@ set(TEST_RPATH_COMMON_CONFIG_ARGS
   -DTribitsExProj_ENABLE_SimpleCxx=ON
   -DTribitsExProj_ENABLE_TESTS=ON
   -DTPL_ENABLE_SimpleTpl=ON
-  -DSimpleTpl_INCLUDE_DIRS=${SimpleTpl_install_shared_DIR}/install/include
-  -DSimpleTpl_LIBRARY_DIRS=${SimpleTpl_install_shared_DIR}/install/lib
+  -DSimpleTpl_INCLUDE_DIRS=${SimpleTpl_install_SHARED_DIR}/install/include
+  -DSimpleTpl_LIBRARY_DIRS=${SimpleTpl_install_SHARED_DIR}/install/lib
   )
 
 set(LD_LIBRARY_PATH_ORIG $ENV{LD_LIBRARY_PATH})
@@ -3951,7 +4020,7 @@ if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
   set(RPATH_GREP_STR "@rpath/libsimplecxx[.].*[.]dylib;@rpath/libsimpletpl[.]dylib")
 elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
   set(RPATH_GREP_STR
-    "R.*PATH *${RPATH_CURRENT_TEST_DIR}/install/lib:${SimpleTpl_install_shared_DIR}/install/lib")
+    "R.*PATH *${RPATH_CURRENT_TEST_DIR}/install/lib:${SimpleTpl_install_SHARED_DIR}/install/lib")
   # NOTE: Above matches both RPATH and RUNPATH which are used on different
   # Linux systems.
 endif()
@@ -4006,9 +4075,10 @@ tribits_add_advanced_test( TribitsExampleProject_SimpleTpl_RPATH_default
 
   ADDED_TEST_NAME_OUT RPATH_CURRENT_TEST_NAME_NAME
   )
+
 if (RPATH_CURRENT_TEST_NAME_NAME)
   set_tests_properties(${RPATH_CURRENT_TEST_NAME_NAME}
-    PROPERTIES DEPENDS ${SimpleTpl_install_shared_NAME} )
+    PROPERTIES DEPENDS ${SimpleTpl_install_SHARED_NAME} )
 endif()
 
 
@@ -4028,7 +4098,7 @@ if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
   set(RPATH_GREP_STR "@rpath/libsimplecxx[.].*[.]dylib;@rpath/libsimpletpl[.]dylib")
 elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
   set(RPATH_GREP_STR
-    "R.*PATH *${SimpleTpl_install_shared_DIR}/install/lib")
+    "R.*PATH *${SimpleTpl_install_SHARED_DIR}/install/lib")
 endif()
 
 tribits_add_advanced_test( TribitsExampleProject_SimpleTpl_RPATH_no_SET_INSTALL_RPATH
@@ -4063,9 +4133,10 @@ tribits_add_advanced_test( TribitsExampleProject_SimpleTpl_RPATH_no_SET_INSTALL_
 
   ADDED_TEST_NAME_OUT RPATH_CURRENT_TEST_NAME_NAME
   )
+
 if (RPATH_CURRENT_TEST_NAME_NAME)
   set_tests_properties(${RPATH_CURRENT_TEST_NAME_NAME}
-    PROPERTIES DEPENDS ${SimpleTpl_install_shared_NAME} )
+    PROPERTIES DEPENDS ${SimpleTpl_install_SHARED_NAME} )
 endif()
 
 
@@ -4099,7 +4170,7 @@ if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
   set(RPATH_GREP_STR "@rpath/libsimplecxx[.].*[.]dylib;@rpath/libsimpletpl[.]dylib")
 elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
   set(RPATH_GREP_STR
-    "R.*PATH *${RPATH_CURRENT_TEST_DIR}/install2/nonstd_lib_location:${SimpleTpl_install_shared_DIR}/install/lib")
+    "R.*PATH *${RPATH_CURRENT_TEST_DIR}/install2/nonstd_lib_location:${SimpleTpl_install_SHARED_DIR}/install/lib")
 endif()
 
 tribits_add_advanced_test( TribitsExampleProject_SimpleTpl_RPATH_CMAKE_INSTALL_RPATH
@@ -4114,7 +4185,7 @@ tribits_add_advanced_test( TribitsExampleProject_SimpleTpl_RPATH_CMAKE_INSTALL_R
       -DCMAKE_INSTALL_PREFIX=${RPATH_CURRENT_TEST_DIR}/install
       -DTribitsExProj_INSTALL_LIB_DIR:STRING=nonstd_lib_location
       -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE
-      -DCMAKE_INSTALL_RPATH="${RPATH_CURRENT_TEST_DIR}/install2/nonstd_lib_location:${SimpleTpl_install_shared_DIR}/install/lib"
+      -DCMAKE_INSTALL_RPATH="${RPATH_CURRENT_TEST_DIR}/install2/nonstd_lib_location:${SimpleTpl_install_SHARED_DIR}/install/lib"
       ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
   # Above tests with a non-standard lib location to see that TriBITS has the
   # right logic in this case.
@@ -4152,9 +4223,10 @@ tribits_add_advanced_test( TribitsExampleProject_SimpleTpl_RPATH_CMAKE_INSTALL_R
 
   ADDED_TEST_NAME_OUT RPATH_CURRENT_TEST_NAME_NAME
   )
+
 if (RPATH_CURRENT_TEST_NAME_NAME)
   set_tests_properties(${RPATH_CURRENT_TEST_NAME_NAME}
-    PROPERTIES DEPENDS ${SimpleTpl_install_shared_NAME} )
+    PROPERTIES DEPENDS ${SimpleTpl_install_SHARED_NAME} )
 endif()
 
 
@@ -4193,7 +4265,7 @@ tribits_add_advanced_test( TribitsExampleProject_SimpleTpl_RPATH_CMAKE_SKIP_INST
   TEST_2 CMND ${RPATH_INSPECT_CMND}
     ARGS  ${RPATH_INSPECT_ARG}  install3/lib/libsimplecxx.${SHARED_LIB_EXT}
     PASS_REGULAR_EXPRESSION_ALL  "${RPATH_GREP_STR}"
-    FAIL_REGULAR_EXPRESSION  "RPATH.*${SimpleTpl_install_shared_DIR}/install/lib"
+    FAIL_REGULAR_EXPRESSION  "RPATH.*${SimpleTpl_install_SHARED_DIR}/install/lib"
     ALWAYS_FAIL_ON_NONZERO_RETURN
 
   TEST_3 CMND ${CMAKE_CTEST_COMMAND} ARGS -VV
@@ -4208,9 +4280,10 @@ tribits_add_advanced_test( TribitsExampleProject_SimpleTpl_RPATH_CMAKE_SKIP_INST
 
   ADDED_TEST_NAME_OUT RPATH_CURRENT_TEST_NAME_NAME
   )
+
 if (RPATH_CURRENT_TEST_NAME_NAME)
   set_tests_properties(${RPATH_CURRENT_TEST_NAME_NAME}
-    PROPERTIES DEPENDS ${SimpleTpl_install_shared_NAME} )
+    PROPERTIES DEPENDS ${SimpleTpl_install_SHARED_NAME} )
 endif()
 
 
@@ -4223,7 +4296,7 @@ tribits_add_test(
   PASS_REGULAR_EXPRESSION
     "Hello World"
   ENVIRONMENT
-    LD_LIBRARY_PATH=${RPATH_CURRENT_TEST_DIR}/install3/lib:${SimpleTpl_install_shared_DIR}/install/lib:${LD_LIBRARY_PATH_ORIG}
+    LD_LIBRARY_PATH=${RPATH_CURRENT_TEST_DIR}/install3/lib:${SimpleTpl_install_SHARED_DIR}/install/lib:${LD_LIBRARY_PATH_ORIG}
   ADDED_TESTS_NAMES_OUT TribitsExampleProject_SimpleTpl_RPATH_CMAKE_SKIP_INSTALL_RPATH_run_NAMES
   )
 if (TribitsExampleProject_SimpleTpl_RPATH_CMAKE_SKIP_INSTALL_RPATH_run_NAMES
@@ -4380,6 +4453,7 @@ tribits_add_advanced_test( TribitsExampleProject_TribitsExampleProjectAddons
 # TribitsExampleApp
 ########################################################################
 
+
 if (NOT "$ENV{TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL}" STREQUAL "")
   set(TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_DEFAULT
     $ENV{TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL})
@@ -4389,6 +4463,25 @@ endif()
 advanced_set(TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL
   ${TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_DEFAULT} CACHE BOOL
   "Set to TRUE to add LD_LIBRARY_PATH to libsimpletpl.so for platforms where RPATH not working")
+
+function(set_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG sharedOrStatic)
+  if (TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL)
+    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_${sharedOrStatic}_ENVIRONMENT_ARG
+      ENVIRONMENT LD_LIBRARY_PATH=${SimpleTpl_install_${sharedOrStatic}_DIR}/install/lib)
+  else()
+    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_${sharedOrStatic}_ENVIRONMENT_ARG "")
+  endif()
+endfunction()
+set_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG(STATIC)
+set_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG(SHARED)
+# NOTE: Above, we have to set LD_LIBRARY_PATH to pick up the
+# libsimpletpl.so because CMake 3.17.5 and 3.21.2 with the GitHub Actions
+# Umbuntu build is refusing to put in the RPATH for libsimpletpl.so into
+# libsimplecxx.so even through CMAKE_INSTALL_RPATH_USE_LINK_PATH=ON is
+# set.  This is not needed for the RHEL 7 builds that I have tried where
+# CMake is behaving correctly and putting in RPATH correctly.  But because
+# I can't log into this system, it is very hard and time consuming to
+# debug this so I am just giving up at this point.
 
 
 function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
@@ -4403,44 +4496,12 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
   set(testName ${PACKAGE_NAME}_${testBaseName})
   set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
 
-  if (TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL)
-    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG
-      ENVIRONMENT LD_LIBRARY_PATH=${buildDir}/simpletpl_build/install/lib)
-  else()
-    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG "")
-  endif()
-  # NOTE: Above, we have to set LD_LIBRARY_PATH to pick up the
-  # libsimpletpl.so because CMake 3.17.5 and 3.21.2 with the GitHub Actions
-  # Umbuntu build is refusing to put in the RPATH for libsimpletpl.so into
-  # libsimplecxx.so even through CMAKE_INSTALL_RPATH_USE_LINK_PATH=ON is
-  # set.  This is not needed for the RHEL 7 builds that I have tried where
-  # CMake is behaving correctly and putting in RPATH correctly.  But because
-  # I can't log into this system, it is very hard and time consuming to
-  # debug this so I am just giving up at this point.
-
   tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
     XHOSTTYPE Darwin
 
     TEST_0
-      MESSAGE "Configure SimpleTpl to be installed for TribitsExampleProject"
-      WORKING_DIRECTORY simpletpl_build
-      CMND ${CMAKE_COMMAND}
-      ARGS
-        ${SERIAL_PASSTHROUGH_CONFIGURE_ARGS}
-        -DCMAKE_BUILD_TYPE=RelWithDepInfo
-        ${buildSharedLibsArg}
-        -DCMAKE_INSTALL_PREFIX=install
-        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/tpls/SimpleTpl
-
-    TEST_1
-      MESSAGE "Build and install SimpleTpl locally"
-      WORKING_DIRECTORY simpletpl_build
-      SKIP_CLEAN_WORKING_DIRECTORY
-      CMND make ARGS ${CTEST_BUILD_FLAGS} install
-
-    TEST_2
       MESSAGE "Do the configure of TribitsExampleProject"
       CMND ${CMAKE_COMMAND}
       ARGS
@@ -4451,17 +4512,17 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
         -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON
         -DTribitsExProj_ENABLE_INSTALL_CMAKE_CONFIG_FILES=ON
         -DTPL_ENABLE_SimpleTpl=ON
-        -DSimpleTpl_INCLUDE_DIRS=${buildDir}/simpletpl_build/install/include
-        -DSimpleTpl_LIBRARY_DIRS=${buildDir}/simpletpl_build/install/lib
+        -DSimpleTpl_INCLUDE_DIRS=${SimpleTpl_install_${sharedOrStatic}_DIR}/install/include
+        -DSimpleTpl_LIBRARY_DIRS=${SimpleTpl_install_${sharedOrStatic}_DIR}/install/lib
         ${buildSharedLibsArg}
         -DCMAKE_INSTALL_PREFIX=install
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
 
-    TEST_3
+    TEST_1
       MESSAGE "Build and install TribitsExampleProject locally"
       CMND make ARGS ${CTEST_BUILD_FLAGS} install
 
-    TEST_4
+    TEST_2
       MESSAGE "Configure TribitsExampleApp locally"
       WORKING_DIRECTORY app_build
       CMND ${CMAKE_COMMAND} ARGS
@@ -4474,7 +4535,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
         "-- Build files have been written to: .*/${testName}/app_build"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_5
+    TEST_3
       MESSAGE "Build TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
@@ -4483,7 +4544,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
         "Built target app"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_6
+    TEST_4
       MESSAGE "Test TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
@@ -4494,9 +4555,15 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    ${LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG}
+    ${LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_${sharedOrStatic}_ENVIRONMENT_ARG}
 
+    ADDED_TEST_NAME_OUT ${testNameBase}_NAME
     )
+
+  if (${testNameBase}_NAME)
+    set_tests_properties(${${testNameBase}_NAME}
+      PROPERTIES DEPENDS ${SimpleTpl_install_${sharedOrStatic}_NAME} )
+  endif()
 
 endfunction()
 
@@ -4529,14 +4596,6 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
   set(testName ${PACKAGE_NAME}_${testBaseName})
   set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
 
-  if (TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL)
-    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG
-      ENVIRONMENT LD_LIBRARY_PATH=${buildDir}/simpletpl_build/install/lib)
-  else()
-    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG "")
-  endif()
-  # NOTE: Above, see comment above!
-
   tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
@@ -4544,23 +4603,6 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
     XHOSTTYPE Darwin
 
     TEST_0
-      MESSAGE "Configure SimpleTpl to be installed for TribitsExampleProject"
-      WORKING_DIRECTORY simpletpl_build
-      CMND ${CMAKE_COMMAND}
-      ARGS
-        ${SERIAL_PASSTHROUGH_CONFIGURE_ARGS}
-        -DCMAKE_BUILD_TYPE=RelWithDepInfo
-        ${buildSharedLibsArg}
-        -DCMAKE_INSTALL_PREFIX=install
-        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/tpls/SimpleTpl
-
-    TEST_1
-      MESSAGE "Build and install SimpleTpl locally"
-      WORKING_DIRECTORY simpletpl_build
-      SKIP_CLEAN_WORKING_DIRECTORY
-      CMND make ARGS ${CTEST_BUILD_FLAGS} install
-
-    TEST_2
       MESSAGE "Do the configure of TribitsExampleProject"
       CMND ${CMAKE_COMMAND}
       ARGS
@@ -4571,17 +4613,17 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
         -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON
         -DTribitsExProj_ENABLE_INSTALL_CMAKE_CONFIG_FILES=ON
         -DTPL_ENABLE_SimpleTpl=ON
-        -DSimpleTpl_INCLUDE_DIRS=${buildDir}/simpletpl_build/install/include
-        -DSimpleTpl_LIBRARY_DIRS=${buildDir}/simpletpl_build/install/lib
+        -DSimpleTpl_INCLUDE_DIRS=${SimpleTpl_install_${sharedOrStatic}_DIR}/install/include
+        -DSimpleTpl_LIBRARY_DIRS=${SimpleTpl_install_${sharedOrStatic}_DIR}/install/lib
         ${buildSharedLibsArg}
         -DCMAKE_INSTALL_PREFIX=install
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
 
-    TEST_3
+    TEST_1
       MESSAGE "Build and install TribitsExampleProject locally"
       CMND make ARGS ${CTEST_BUILD_FLAGS} install
 
-    TEST_4
+    TEST_2
       MESSAGE "Configure TribitsExampleApp locally"
       WORKING_DIRECTORY app_build
       CMND ${CMAKE_COMMAND} ARGS
@@ -4596,7 +4638,7 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
         "-- Build files have been written to: .*/${testName}/app_build"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_5
+    TEST_3
       MESSAGE "Build TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
@@ -4605,7 +4647,7 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
         "Built target app"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_6
+    TEST_4
       MESSAGE "Test TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
@@ -4616,9 +4658,15 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    ${LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG}
+    ${LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_${sharedOrStatic}_ENVIRONMENT_ARG}
 
+    ADDED_TEST_NAME_OUT ${testNameBase}_NAME
     )
+
+  if (${testNameBase}_NAME)
+    set_tests_properties(${${testNameBase}_NAME}
+      PROPERTIES DEPENDS ${SimpleTpl_install_${sharedOrStatic}_NAME} )
+  endif()
 
 endfunction()
 
@@ -4642,14 +4690,6 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
   set(testBaseName TribitsExampleApp_ALL_ST_buildtree_${sharedOrStatic})
   set(testName ${PACKAGE_NAME}_${testBaseName})
   set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
-
-  if (TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL)
-    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG
-      ENVIRONMENT LD_LIBRARY_PATH=${buildDir}/simpletpl_build/install/lib)
-  else()
-    set(LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG "")
-  endif()
-  # NOTE: Above, see comment above!
 
   tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
@@ -4710,9 +4750,6 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
         "app_test [.]+   Passed"
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN
-
-    ${LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_ENVIRONMENT_ARG}
-
     )
 
 endfunction()

--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -4494,7 +4494,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
 
   set(testBaseName TribitsExampleApp_ALL_ST_NoFortran_${sharedOrStatic})
   set(testName ${PACKAGE_NAME}_${testBaseName})
-  set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
+  set(testDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
 
   tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
@@ -4502,7 +4502,15 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
     XHOSTTYPE Darwin
 
     TEST_0
+      MESSAGE "Copy source for TribitsExampleProject"
+      CMND ${CMAKE_COMMAND}
+      ARGS -E copy_directory
+        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject .
+      WORKING_DIRECTORY TribitsExampleProject
+
+    TEST_1
       MESSAGE "Do the configure of TribitsExampleProject"
+      WORKING_DIRECTORY BUILD
       CMND ${CMAKE_COMMAND}
       ARGS
         ${TribitsExampleProject_COMMON_CONFIG_ARGS}
@@ -4515,18 +4523,24 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
         -DSimpleTpl_INCLUDE_DIRS=${SimpleTpl_install_${sharedOrStatic}_DIR}/install/include
         -DSimpleTpl_LIBRARY_DIRS=${SimpleTpl_install_${sharedOrStatic}_DIR}/install/lib
         ${buildSharedLibsArg}
-        -DCMAKE_INSTALL_PREFIX=install
-        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
-
-    TEST_1
-      MESSAGE "Build and install TribitsExampleProject locally"
-      CMND make ARGS ${CTEST_BUILD_FLAGS} install
+        -DCMAKE_INSTALL_PREFIX=${testDir}/install
+        ${testDir}/TribitsExampleProject
 
     TEST_2
+      MESSAGE "Build and install TribitsExampleProject locally"
+      WORKING_DIRECTORY BUILD
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND make ARGS ${CTEST_BUILD_FLAGS} install
+
+    TEST_3
+      MESSAGE "Delete source and build directory for TribitsExampleProject"
+      CMND ${CMAKE_COMMAND} ARGS -E rm -rf TribitsExampleProject BUILD
+
+    TEST_4
       MESSAGE "Configure TribitsExampleApp locally"
       WORKING_DIRECTORY app_build
       CMND ${CMAKE_COMMAND} ARGS
-        -DCMAKE_PREFIX_PATH=${buildDir}/install
+        -DCMAKE_PREFIX_PATH=${testDir}/install
         -DTribitsExApp_USE_COMPONENTS=SimpleCxx,WithSubpackages
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleApp
       PASS_REGULAR_EXPRESSION_ALL
@@ -4535,7 +4549,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
         "-- Build files have been written to: .*/${testName}/app_build"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_3
+    TEST_5
       MESSAGE "Build TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
@@ -4544,7 +4558,7 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
         "Built target app"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_4
+    TEST_6
       MESSAGE "Test TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
@@ -4559,6 +4573,9 @@ function(TribitsExampleApp_ALL_ST_NoFortran_test sharedOrStatic)
 
     ADDED_TEST_NAME_OUT ${testNameBase}_NAME
     )
+  # NOTE: Above test deletes the source and build dir for
+  # TribitsExampleProject after the install to ensure that the install dir is
+  # stand-alone.
 
   if (${testNameBase}_NAME)
     set_tests_properties(${${testNameBase}_NAME}
@@ -4594,7 +4611,7 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
 
   set(testBaseName TribitsExampleApp_ALL_ST_${byProjectOrPackage}_${sharedOrStatic})
   set(testName ${PACKAGE_NAME}_${testBaseName})
-  set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
+  set(testDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
 
   tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
@@ -4603,7 +4620,15 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
     XHOSTTYPE Darwin
 
     TEST_0
+      MESSAGE "Copy source for TribitsExampleProject"
+      CMND ${CMAKE_COMMAND}
+      ARGS -E copy_directory
+        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject .
+      WORKING_DIRECTORY TribitsExampleProject
+
+    TEST_1
       MESSAGE "Do the configure of TribitsExampleProject"
+      WORKING_DIRECTORY BUILD
       CMND ${CMAKE_COMMAND}
       ARGS
         ${TribitsExampleProject_COMMON_CONFIG_ARGS}
@@ -4616,18 +4641,24 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
         -DSimpleTpl_INCLUDE_DIRS=${SimpleTpl_install_${sharedOrStatic}_DIR}/install/include
         -DSimpleTpl_LIBRARY_DIRS=${SimpleTpl_install_${sharedOrStatic}_DIR}/install/lib
         ${buildSharedLibsArg}
-        -DCMAKE_INSTALL_PREFIX=install
-        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
-
-    TEST_1
-      MESSAGE "Build and install TribitsExampleProject locally"
-      CMND make ARGS ${CTEST_BUILD_FLAGS} install
+        -DCMAKE_INSTALL_PREFIX=${testDir}/install
+        ${testDir}/TribitsExampleProject
 
     TEST_2
+      MESSAGE "Build and install TribitsExampleProject locally"
+      WORKING_DIRECTORY BUILD
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND make ARGS ${CTEST_BUILD_FLAGS} install
+
+    TEST_3
+      MESSAGE "Delete source and build directory for TribitsExampleProject"
+      CMND ${CMAKE_COMMAND} ARGS -E rm -rf TribitsExampleProject BUILD
+
+    TEST_4
       MESSAGE "Configure TribitsExampleApp locally"
       WORKING_DIRECTORY app_build
       CMND ${CMAKE_COMMAND} ARGS
-        -DCMAKE_PREFIX_PATH=${buildDir}/install
+        -DCMAKE_PREFIX_PATH=${testDir}/install
         -DTribitsExApp_USE_COMPONENTS=SimpleCxx,MixedLang,WithSubpackages
         ${findByProjectOrPackageArg}
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleApp
@@ -4638,7 +4669,7 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
         "-- Build files have been written to: .*/${testName}/app_build"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_3
+    TEST_5
       MESSAGE "Build TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
@@ -4647,7 +4678,7 @@ function(TribitsExampleApp_ALL_ST_test byProjectOrPackage sharedOrStatic)
         "Built target app"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    TEST_4
+    TEST_6
       MESSAGE "Test TribitsExampleApp"
       WORKING_DIRECTORY app_build
       SKIP_CLEAN_WORKING_DIRECTORY
@@ -4689,7 +4720,7 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
 
   set(testBaseName TribitsExampleApp_ALL_ST_buildtree_${sharedOrStatic})
   set(testName ${PACKAGE_NAME}_${testBaseName})
-  set(buildDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
+  set(testDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
 
   tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
@@ -4719,7 +4750,7 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
       WORKING_DIRECTORY app_build
       CMND ${CMAKE_COMMAND} ARGS
         -DTribitsExApp_FIND_INDIVIDUAL_PACKAGES=TRUE
-        -DTribitsExApp_FIND_UNDER_BUILD_DIR=${buildDir}
+        -DTribitsExApp_FIND_UNDER_BUILD_DIR=${testDir}
         -DTribitsExApp_USE_COMPONENTS=SimpleCxx,MixedLang
         ${findByProjectOrPackageArg}
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleApp
@@ -4755,10 +4786,10 @@ function(TribitsExampleApp_ALL_ST_buildtree_test sharedOrStatic)
 endfunction()
 #
 # NOTE: The test above only pulls in top-level packages that don't have any
-# subpackages SimpleCxx and MixedLang.  It seems that whoever implemented the
-# <Package>Config.cmake files in the build dir only got this working for
-# top-level packages that don't have any subpackages.  This test above at
-# least (partially) pins down what already works.  (Later, these
+# subpackages which are SimpleCxx and MixedLang.  It seems that whoever
+# implemented the <Package>Config.cmake files in the build dir only got this
+# working for top-level packages that don't have any subpackages.  This test
+# above at least (partially) pins down what already works.  (Later, these
 # <Package>Config.cmake files in the build dir will need to be fixed up so
 # that they work for top-level packages with subpackages as well and then this
 # test can be expanded for that case too.)

--- a/tribits/examples/InsertedPkg/test/CMakeLists.txt
+++ b/tribits/examples/InsertedPkg/test/CMakeLists.txt
@@ -2,5 +2,5 @@ tribits_add_executable_and_test( test
   SOURCES InsertedPkg_test.cpp
   NUM_MPI_PROCS 1
   PASS_REGULAR_EXPRESSION
-    "InsertedPkg deps are: no_deps"
+    "InsertedPkg deps are: headeronlytpl"
   )

--- a/tribits/examples/TribitsExampleApp/AppHelperFuncs.cmake
+++ b/tribits/examples/TribitsExampleApp/AppHelperFuncs.cmake
@@ -65,21 +65,18 @@ macro(getTribitsExProjStuffByPackage)
   set(APP_DEPS_PACKAGE_INCLUDE_DIRS "")
   set(APP_DEPS_TPL_INCLUDE_DIRS "")
   set(APP_DEPS_PACKAGE_LIBRARIES "")
-  set(APP_DEPS_TPL_LIBRARIES "")
   foreach (packageName IN LISTS ${PROJECT_NAME}_USE_COMPONENTS)
     find_package(${packageName} REQUIRED)
     message("Found ${packageName}!")
     list(APPEND APP_DEPS_PACKAGE_INCLUDE_DIRS ${${packageName}_INCLUDE_DIRS})
     list(APPEND APP_DEPS_TPL_INCLUDE_DIRS ${${packageName}_TPL_INCLUDE_DIRS})
     list(APPEND APP_DEPS_PACKAGE_LIBRARIES ${${packageName}_LIBRARIES})
-    list(APPEND APP_DEPS_TPL_LIBRARIES ${${packageName}_TPL_LIBRARIES})
   endforeach()
 
   # Get the full list of include dirs and libs
   set(APP_DEPS_INCLUDE_DIRS
     ${APP_DEPS_PACKAGE_INCLUDE_DIRS} ${APP_DEPS_TPL_INCLUDE_DIRS})
-  set(APP_DEPS_LIBRARIES
-    ${APP_DEPS_PACKAGE_LIBRARIES} ${APP_DEPS_TPL_LIBRARIES})
+  set(APP_DEPS_LIBRARIES ${APP_DEPS_PACKAGE_LIBRARIES})
 
   # Remove duplicates
   list(REVERSE APP_DEPS_INCLUDE_DIRS)
@@ -126,8 +123,7 @@ macro(getTribitsExProjStuffByProject)
   # Get the include directories and libraries for building and linking
   set(APP_DEPS_INCLUDE_DIRS
     ${TribitsExProj_INCLUDE_DIRS} ${TribitsExProj_TPL_INCLUDE_DIRS})
-  set(APP_DEPS_LIBRARIES
-    ${TribitsExProj_LIBRARIES} ${TribitsExProj_TPL_LIBRARIES})
+  set(APP_DEPS_LIBRARIES ${TribitsExProj_LIBRARIES})
 
 endmacro()
 

--- a/tribits/examples/TribitsExampleApp/CMakeLists.txt
+++ b/tribits/examples/TribitsExampleApp/CMakeLists.txt
@@ -44,10 +44,17 @@ enable_testing()
 #  PASS_REGULAR_EXPRESSION "DUMMY NO MATCH"
 #  )
 
+if ("SimpleTpl" IN_LIST SimpleCxx_TPL_LIST)
+  set(simpleCxxDeps "simpletpl ")
+else()
+  set(simpleCxxDeps "")
+endif()
+set(simpleCxxDeps "${simpleCxxDeps}headeronlytpl")
+
 set(depsStr "")
-appendTestDepsStr("WithSubpackages" depsStr "WithSubpackages:B A no_deps no_deps")
+appendTestDepsStr("WithSubpackages" depsStr "WithSubpackages:B A ${simpleCxxDeps} ${simpleCxxDeps}")
 appendTestDepsStr("MixedLang" depsStr "MixedLang:Mixed Language")
-appendTestDepsStr("SimpleCxx" depsStr "SimpleCxx:no_deps")
+appendTestDepsStr("SimpleCxx" depsStr "SimpleCxx:${simpleCxxDeps}")
 
 add_test(app_test app)
 set_tests_properties(app_test PROPERTIES

--- a/tribits/examples/TribitsExampleProject/packages/simple_cxx/src/SimpleCxx_HelloWorld.cpp
+++ b/tribits/examples/TribitsExampleProject/packages/simple_cxx/src/SimpleCxx_HelloWorld.cpp
@@ -8,7 +8,12 @@
 
 std::string SimpleCxx::deps()
 {
-  return "no_deps";
+  std::string deps;
+#ifdef HAVE_SIMPLECXX_SIMPLETPL
+  deps = SimpleTpl::itsme();
+#endif
+  deps += (deps.length() ? " " : "") + HeaderOnlyTpl::itsme();
+  return deps;
 }
 
 

--- a/tribits/examples/TribitsExampleProject/packages/with_subpackages/a/tests/CMakeLists.txt
+++ b/tribits/examples/TribitsExampleProject/packages/with_subpackages/a/tests/CMakeLists.txt
@@ -5,5 +5,5 @@ tribits_add_advanced_test( test_of_a
   TEST_0 EXEC a_test
     PASS_REGULAR_EXPRESSION_ALL 
       "A label is: A"
-      "A deps are: no_deps"
+      "A deps are: headeronlytpl"
   )

--- a/tribits/examples/TribitsExampleProject/packages/with_subpackages/b/tests/CMakeLists.txt
+++ b/tribits/examples/TribitsExampleProject/packages/with_subpackages/b/tests/CMakeLists.txt
@@ -25,12 +25,12 @@ add_subdirectory(testlib)
 set(EXPECTED_B_DEPS)
 assert_defined(${PACKAGE_NAME}_ENABLE_WithSubpackagesA)
 if(${PACKAGE_NAME}_ENABLE_WithSubpackagesA)
-  set(EXPECTED_B_DEPS "${EXPECTED_B_DEPS} A no_deps")
+  set(EXPECTED_B_DEPS "${EXPECTED_B_DEPS} A headeronlytpl")
 endif()
 if(${PACKAGE_NAME}_ENABLE_InsertedPkg)
-  set(EXPECTED_B_DEPS "${EXPECTED_B_DEPS} InsertedPkg no_deps")
+  set(EXPECTED_B_DEPS "${EXPECTED_B_DEPS} InsertedPkg headeronlytpl")
 endif()
-set(EXPECTED_B_DEPS "${EXPECTED_B_DEPS} no_deps")
+set(EXPECTED_B_DEPS "${EXPECTED_B_DEPS} headeronlytpl")
 
 tribits_add_advanced_test( test_of_b
   OVERALL_NUM_MPI_PROCS 1

--- a/tribits/examples/TribitsExampleProject/packages/with_subpackages/c/tests/CMakeLists.txt
+++ b/tribits/examples/TribitsExampleProject/packages/with_subpackages/c/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(WithSubpackagesB_ENABLE_InsertedPkg)
-  set(EXPECTED_EXTERNALPKG_DEPS "InsertedPkg no_deps ")
+  set(EXPECTED_EXTERNALPKG_DEPS "InsertedPkg headeronlytpl ")
 endif()
 
 tribits_add_test( c_util
@@ -8,7 +8,7 @@ tribits_add_test( c_util
   NAME test_of_c_util
   NUM_MPI_PROCS 1
   PASS_REGULAR_EXPRESSION
-    "Called c_util: A no_deps ${EXPECTED_EXTERNALPKG_DEPS}no_deps no_deps"
+    "Called c_util: A headeronlytpl ${EXPECTED_EXTERNALPKG_DEPS}headeronlytpl headeronlytpl"
   ADDED_TESTS_NAMES_OUT  c_util_TEST_NAME
   )
 
@@ -59,7 +59,7 @@ if (WithSubpackagesB_ENABLE_MixedLang AND
     TESTONLYLIBS  c_b_mixed_lang
     NUM_MPI_PROCS  1
     PASS_REGULAR_EXPRESSION
-      "B A no_deps no_deps B Mixed Language"
+      "B A headeronlytpl headeronlytpl B Mixed Language"
     ADDED_EXE_TARGET_NAME_OUT  test_of_c_b_mixed_lang_TARGET_NAME
     ADDED_TESTS_NAMES_OUT  test_of_c_b_mixed_lang_TEST_NAME
     )

--- a/tribits/examples/TribitsExampleProject/packages/wrap_external/CMakeLists.txt
+++ b/tribits/examples/TribitsExampleProject/packages/wrap_external/CMakeLists.txt
@@ -147,7 +147,7 @@ if (${PACKAGE_NAME}_ENABLE_TESTS)
 
   tribits_add_executable_and_test(run_external_func
     SOURCES run_external_func.cpp
-    PASS_REGULAR_EXPRESSION "external_func A no_deps"
+    PASS_REGULAR_EXPRESSION "external_func A headeronlytpl"
     NUM_MPI_PROCS 1
     )
 

--- a/tribits/examples/TribitsExampleProjectAddons/packages/addon1/tests/CMakeLists.txt
+++ b/tribits/examples/TribitsExampleProjectAddons/packages/addon1/tests/CMakeLists.txt
@@ -5,5 +5,5 @@ tribits_add_advanced_test( test
   TEST_0  EXEC  test
     PASS_REGULAR_EXPRESSION_ALL 
       "Addon1 label is: Addon1"
-      "Addon1 deps are: no_deps"
+      "Addon1 deps are: headeronlytpl"
   )

--- a/tribits/examples/tpls/HeaderOnlyTpl/HeaderOnlyTpl_stuff.hpp
+++ b/tribits/examples/tpls/HeaderOnlyTpl/HeaderOnlyTpl_stuff.hpp
@@ -1,6 +1,7 @@
 #ifndef HEADER_ONLY_TPL_STUFF_HPP
 #define HEADER_ONLY_TPL_STUFF_HPP
 
+#include <string>
 
 namespace HeaderOnlyTpl {
 
@@ -9,6 +10,12 @@ template <typename T>
 T  sqr(const T &v)
 {
   return v*v;
+}
+
+/** \brief . */
+inline std::string itsme()
+{
+  return "headeronlytpl";
 }
 
 } // namespace HeaderOnlyTpl

--- a/tribits/examples/tpls/SimpleTpl/CMakeLists.txt
+++ b/tribits/examples/tpls/SimpleTpl/CMakeLists.txt
@@ -1,15 +1,31 @@
 cmake_minimum_required(VERSION 3.17.0)
 
+project(SimpleTpl
+  DESCRIPTION
+    "Simple TPL with a header file and a library"
+  LANGUAGES C CXX
+  )
+
 add_library(simpletpl SimpleTpl.hpp SimpleTpl.cpp)
+target_include_directories(simpletpl
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  )
+
+include(GNUInstallDirs)
 
 install(
   TARGETS simpletpl
-  RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/lib"
-  LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/lib"
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_PREFIX}/lib"
+  EXPORT SimpleTpl
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   )
 
 install(
   FILES SimpleTpl.hpp
-  DESTINATION "${CMAKE_INSTALL_PREFIX}/include"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  )
+
+install(EXPORT SimpleTpl
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SimpleTpl
+  NAMESPACE SimpleTpl::
+  FILE SimplTplConfig.cmake
   )

--- a/tribits/examples/tpls/SimpleTpl/SimpleTpl.cpp
+++ b/tribits/examples/tpls/SimpleTpl/SimpleTpl.cpp
@@ -4,3 +4,8 @@ double SimpleTpl::cube(const double &v)
 {
   return v*v*v;
 }
+
+std::string SimpleTpl::itsme()
+{
+  return "simpletpl";
+}

--- a/tribits/examples/tpls/SimpleTpl/SimpleTpl.hpp
+++ b/tribits/examples/tpls/SimpleTpl/SimpleTpl.hpp
@@ -1,10 +1,15 @@
 #ifndef SIMPLE_TPL_HPP
 #define SIMPLE_TPL_HPP
 
+#include <string>
+
 namespace SimpleTpl {
 
 /** \brief . */
 double cube(const double &v);
+
+/** \brief . */
+std::string itsme();
 
 } // namespace SimpleTpl
 


### PR DESCRIPTION
This will allow testing the generation of `<tplName>Config.cmake` files with modern CMake targets for external packages/TPLs.  I will need more extensive tests for TPLs but this allows that refactoring to occur with some testing.

NOTE: With this PR, we now have test cases using `<Package>Config.cmake` and `<Project>Config.cmake` files that have two TPLs enables (with that is headers only, and one with a header file and a library).

NOTE: This changed what the `SimpleCxx::deps()` function returns to include calling functions from the TPLs so that required updating several tests in TriBTS.  These are all now much better tests of the usage of a TPL in TriBITS (but very limited obviously because there are just two TPLs here).

See the commit messages for more details.
