### PR TITLE
Add example of DartMeasurement in test STDOUT (SNL Kitware issue 183)

### DIFF
--- a/tribits/examples/TribitsExampleProject/packages/simple_cxx/test/SimpleCxx_HelloWorld_Tests.cpp
+++ b/tribits/examples/TribitsExampleProject/packages/simple_cxx/test/SimpleCxx_HelloWorld_Tests.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <cstdlib>
 #include "SimpleCxx_HelloWorld.hpp"
+#include "HeaderOnlyTpl_stuff.hpp"
 
 
 #define TEST_FIND_SUBSTR_IN_STR(SUBSTR, STR) \
@@ -41,6 +42,14 @@ int main() {
 #ifdef HAVE_SIMPLECXX_SIMPLETPL
   TEST_FIND_SUBSTR_IN_STR("Cube(3) = 27", oss.str());
 #endif
+
+  srand(time(NULL));
+  std::cout
+    << "<DartMeasurement type=\"numeric/double\" name=\"sqr_rand\">"
+    << HeaderOnlyTpl::sqr(rand() % 10)  // Random number between 1 and 100
+    << "</DartMeasurement>\n";
+  // NOTE: The above produces a numeric test measurement that change each time
+  // it calls and produce an interesting numeric plot on CDash.
 
   if (success) {
     std::cout << "End Result: TEST PASSED\n";


### PR DESCRIPTION
Adds a [`<DartMeasurement>`](https://cmake.org/cmake/help/v3.21/command/ctest_test.html#additional-test-measurements) element to a test so it can be displayed on CDash to help test out:

* https://gitlab.kitware.com/snl/project-1/-/issues/183

 