### PR TITLE
Fix issue on native Windows and partial test suite port (#299)

### DIFF
--- a/test/core/ExamplesUnitTests/SimpleTpl_installs_Tests.cmake
+++ b/test/core/ExamplesUnitTests/SimpleTpl_installs_Tests.cmake
@@ -73,7 +73,7 @@ function(SimpleTpl_install_test sharedOrStatic)
       ARGS
         ${SERIAL_PASSTHROUGH_CONFIGURE_ARGS}
         ${buildSharedLibsArg}
-        -DCMAKE_BUILD_TYPE=RelWithDepInfo
+        -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=${testDir}/install
         -DCMAKE_INSTALL_INCLUDEDIR=include
         -DCMAKE_INSTALL_LIBDIR=lib
@@ -87,10 +87,9 @@ function(SimpleTpl_install_test sharedOrStatic)
       MESSAGE "Build and install SimpleTpl"
       WORKING_DIRECTORY BUILD
       SKIP_CLEAN_WORKING_DIRECTORY
-      CMND make ARGS ${CTEST_BUILD_FLAGS} install
+      CMND ${CMAKE_COMMAND} ARGS --build . --config Release --target install
       PASS_REGULAR_EXPRESSION_ALL
-        "Built target simpletpl"
-        "Installing: ${testDir}/install/lib/libsimpletpl[.]"
+        "Installing: ${testDir}/install/.*simpletpl[.]"
         "Installing: ${testDir}/install/include/SimpleTpl.hpp"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 

--- a/test/core/ExamplesUnitTests/SimpleTpl_installs_Tests.cmake
+++ b/test/core/ExamplesUnitTests/SimpleTpl_installs_Tests.cmake
@@ -74,6 +74,7 @@ function(SimpleTpl_install_test sharedOrStatic)
         ${SERIAL_PASSTHROUGH_CONFIGURE_ARGS}
         ${buildSharedLibsArg}
         -DCMAKE_BUILD_TYPE=Release
+	-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
         -DCMAKE_INSTALL_PREFIX=${testDir}/install
         -DCMAKE_INSTALL_INCLUDEDIR=include
         -DCMAKE_INSTALL_LIBDIR=lib

--- a/test/core/ExamplesUnitTests/TribitsExampleApp2_Tests.cmake
+++ b/test/core/ExamplesUnitTests/TribitsExampleApp2_Tests.cmake
@@ -40,47 +40,6 @@
 ########################################################################
 
 
-if (NOT "$ENV{TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_TPL1}" STREQUAL "")
-  set(TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_TPL1_DEFAULT
-    $ENV{TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_TPL1})
-else()
-  set($ENV{TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_TPL1} OFF)
-endif()
-advanced_set(TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_TPL1
-  ${TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_TPL1_DEFAULT} CACHE BOOL
-  "Set to TRUE to add LD_LIBRARY_PATH to libtpl1.so for platforms where RPATH not working")
-
-function(set_LD_LIBRARY_PATH_HACK_FOR_TPL1_ENVIRONMENT_ARG sharedOrStatic)
-  set(LD_LIBRARY_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ENVIRONMENT_ARG_ON
-    ENVIRONMENT LD_LIBRARY_PATH=${Tpl1_install_${sharedOrStatic}_DIR}/install/lib)
-  if (TRIBITS_ADD_LD_LIBRARY_PATH_HACK_FOR_TPL1)
-    set(LD_LIBRARY_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ENVIRONMENT_ARG
-      ${LD_LIBRARY_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ENVIRONMENT_ARG_ON})
-  else()
-    set(LD_LIBRARY_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ENVIRONMENT_ARG "")
-  endif()
-  set(LD_LIBRARY_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ENVIRONMENT_ARG_ON
-    ${LD_LIBRARY_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ENVIRONMENT_ARG_ON}
-    PARENT_SCOPE)
-  set(LD_LIBRARY_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ENVIRONMENT_ARG
-    ${LD_LIBRARY_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ENVIRONMENT_ARG}
-    PARENT_SCOPE)
-endfunction()
-set_LD_LIBRARY_PATH_HACK_FOR_TPL1_ENVIRONMENT_ARG(STATIC)
-set_LD_LIBRARY_PATH_HACK_FOR_TPL1_ENVIRONMENT_ARG(SHARED)
-# NOTE: Above, we have to set LD_LIBRARY_PATH to pick up the
-# libtpl1.so because CMake 3.17.5 and 3.21.2 with the GitHub Actions
-# Umbuntu build is refusing to put in the RPATH for libtpl1.so into
-# libsimplecxx.so even through CMAKE_INSTALL_RPATH_USE_LINK_PATH=ON is
-# set.  This is not needed for the RHEL 7 builds that I have tried where
-# CMake is behaving correctly and putting in RPATH correctly.  But because
-# I can't log into this system, it is very hard and time consuming to
-# debug this so I am just giving up at this point.
-
-
-################################################################################
-
-
 set(tribitsExProj2TestNameBaseBase TribitsExampleProject2_find_tpl_parts)
 set(sharedOrStatic STATIC)
 set(fullOrComponents COMPONENTS)
@@ -107,7 +66,7 @@ tribits_add_advanced_test( ${testBaseName}
       "-- Configuring incomplete, errors occurred"
     ALWAYS_FAIL_ON_ZERO_RETURN
 
-  ${LD_LIBRARY_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ENVIRONMENT_ARG}
+  ${ENV_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ARG}
 
   ADDED_TEST_NAME_OUT ${testNameBase}_NAME
   )
@@ -187,7 +146,7 @@ function(TribitsExampleApp2_test  tribitsExProj2TestNameBaseBase
         "100% tests passed, 0 tests failed out of 1"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
-    ${LD_LIBRARY_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ENVIRONMENT_ARG}
+    ${ENV_PATH_HACK_FOR_TPL1_${sharedOrStatic}_ARG}
 
     ADDED_TEST_NAME_OUT ${testNameBase}_NAME
     )
@@ -209,5 +168,6 @@ TribitsExampleApp2_test(TribitsExampleProject2_find_tpl_parts STATIC FULL)
 TribitsExampleApp2_test(TribitsExampleProject2_find_tpl_parts STATIC COMPONENTS)
 TribitsExampleApp2_test(TribitsExampleProject2_find_tpl_parts SHARED COMPONENTS)
 TribitsExampleApp2_test(TribitsExampleProject2_explicit_tpl_vars STATIC COMPONENTS)
+TribitsExampleApp2_test(TribitsExampleProject2_explicit_tpl_vars SHARED COMPONENTS)
 TribitsExampleApp2_test(TribitsExampleProject2_find_package SHARED COMPONENTS)
 TribitsExampleApp2_test(TribitsExampleProject2_find_package STATIC COMPONENTS)

--- a/test/core/ExamplesUnitTests/copy_files_glob.cmake
+++ b/test/core/ExamplesUnitTests/copy_files_glob.cmake
@@ -1,0 +1,24 @@
+# Copy files from a list of directories given a glob experession
+#
+# Usage::
+#
+#   cmake
+#     -D FROM_DIRS="<dir1>;<dir2>;..."
+#     -D GLOB_EXPR="<glob-expr>"
+#     -D TO_DIR="<to-dir>"
+#     -P copy_files_glob.cmake
+#
+#
+# NOTE: Commas in 'FROM_DIR' will be replaced with ';'.
+#
+
+string(REPLACE "," ";" FROM_DIRS "${FROM_DIRS}")
+
+foreach(dir ${FROM_DIRS})
+  file(GLOB_RECURSE matchedFiles "${dir}/${GLOB_EXPR}")
+  foreach(file ${matchedFiles})
+    message("Coping file '${file}' to '${TO_DIR}'")
+    file(COPY "${file}" DESTINATION "${TO_DIR}")
+  endforeach()
+endforeach()
+

--- a/tribits/ReleaseNotes.txt
+++ b/tribits/ReleaseNotes.txt
@@ -2,6 +2,12 @@
 Release Notes for TriBITS
 ----------------------------------------
 
+2021/11/18:
+
+(*) MAJOR: The default value for <Project>_ENABLE_Fortran is set to OFF on
+    WIN32 systems.  (Getting a Fortran compiler for native Windows is not
+    typically very easy.)
+
 2021/10/11:
 
 (*) MAJOR: The `<Package>Config.cmake` for each enabled package generated in

--- a/tribits/ReleaseNotes.txt
+++ b/tribits/ReleaseNotes.txt
@@ -4,6 +4,10 @@ Release Notes for TriBITS
 
 2021/11/18:
 
+(*) MAJOR: The default <Project>_GENERATE_REPO_VERSION_FILE_DEFAULT will be
+    overridden to OFF if the 'git' executable cannot be found at configure
+    time.  See updated TriBITS Developer's Guilde documenation.
+
 (*) MAJOR: The default value for <Project>_ENABLE_Fortran is set to OFF on
     WIN32 systems.  (Getting a Fortran compiler for native Windows is not
     typically very easy.)

--- a/tribits/core/package_arch/TribitsExternalPackageWriteConfigFile.cmake
+++ b/tribits/core/package_arch/TribitsExternalPackageWriteConfigFile.cmake
@@ -437,11 +437,17 @@ function(tribits_external_package_get_libname_from_full_lib_path  full_lib_path
   if (full_libname_len LESS 0)
     tribits_print_invalid_lib_name(${tplName} "${full_libname}")
   endif()
-  string(SUBSTRING "${full_libname}" 0 3 libPart)
-  if (NOT libPart STREQUAL "lib")
-    tribits_print_invalid_lib_name(${tplName} "${full_libname}")
+  if (WIN32)
+    # Native windows compilers does not prepend library names with 'lib'
+    set(libname "${full_libname}")
+  else()
+    # Every other system prepends the library name with 'lib'
+    string(SUBSTRING "${full_libname}" 0 3 libPart)
+    if (NOT libPart STREQUAL "lib")
+      tribits_print_invalid_lib_name(${tplName} "${full_libname}")
+    endif()
+    string(SUBSTRING "${full_libname}" 3 -1 libname)
   endif()
-  string(SUBSTRING "${full_libname}" 3 -1 libname)
   set(${libnameOut} ${libname} PARENT_SCOPE)
 endfunction()
 

--- a/tribits/core/package_arch/TribitsGlobalMacros.cmake
+++ b/tribits/core/package_arch/TribitsGlobalMacros.cmake
@@ -291,7 +291,11 @@ macro(tribits_define_global_options_and_define_extra_repos)
   set(${PROJECT_NAME}_ENABLE_CXX11 ON)
 
   if ("${${PROJECT_NAME}_ENABLE_Fortran_DEFAULT}" STREQUAL "")
-    set(${PROJECT_NAME}_ENABLE_Fortran_DEFAULT ON)
+    if (WIN32)
+      set(${PROJECT_NAME}_ENABLE_Fortran_DEFAULT OFF)
+    else()
+      set(${PROJECT_NAME}_ENABLE_Fortran_DEFAULT ON)
+    endif()
   endif()
 
   option(${PROJECT_NAME}_ENABLE_Fortran

--- a/tribits/core/package_arch/TribitsGlobalMacros.cmake
+++ b/tribits/core/package_arch/TribitsGlobalMacros.cmake
@@ -653,7 +653,9 @@ macro(tribits_define_global_options_and_define_extra_repos)
     )
   tribits_get_invalid_categories(${PROJECT_NAME}_TEST_CATEGORIES)
 
-  if ("${${PROJECT_NAME}_GENERATE_REPO_VERSION_FILE_DEFAULT}" STREQUAL "" )
+  if (NOT GIT_EXECUTABLE)
+    set(${PROJECT_NAME}_GENERATE_REPO_VERSION_FILE_DEFAULT OFF)
+  elseif ("${${PROJECT_NAME}_GENERATE_REPO_VERSION_FILE_DEFAULT}" STREQUAL "" )
     set(${PROJECT_NAME}_GENERATE_REPO_VERSION_FILE_DEFAULT OFF)
   endif()
   advanced_set(
@@ -1391,6 +1393,7 @@ function(tribits_generate_repo_version_output_and_file_and_install)
   # A) Create the ${PROJECT_NAME}RepoVersion.txt file if requested
   #
 
+  print_var(${PROJECT_NAME}_GENERATE_REPO_VERSION_FILE)
   if (${PROJECT_NAME}_GENERATE_REPO_VERSION_FILE)
 
     # A) Make sure that there is a .git dir in the project before generating

--- a/tribits/doc/guides/TribitsCoreDetailedReference.rst
+++ b/tribits/doc/guides/TribitsCoreDetailedReference.rst
@@ -483,6 +483,12 @@ These options are described below.
     set(${PROJECT_NAME}_GENERATE_REPO_VERSION_FILE_DEFAULT ON)
 
   in the `<projectDir>/ProjectName.cmake`_ file.
+
+  Note that if a ``git`` exectauble cannot be found at configure time, then
+  the default ``${PROJECT_NAME}_GENERATE_REPO_VERSION_FILE_DEFAULT`` will be
+  overridden to ``OFF``.  But if the user sets
+  ``${PROJECT_NAME}_GENERATE_REPO_VERSION_FILE=ON`` in the cache and ``git``
+  can't be found, then an configure-time error will occur.
   
 .. _${PROJECT_NAME}_INSTALL_LIBRARIES_AND_HEADERS:
 

--- a/tribits/doc/guides/TribitsCoreDetailedReference.rst
+++ b/tribits/doc/guides/TribitsCoreDetailedReference.rst
@@ -368,6 +368,10 @@ These options are described below.
 
   This default can be set in `<projectDir>/ProjectName.cmake`_ or `<projectDir>/CMakeLists.txt`_.
 
+  On WIN32 sytems, the default for ``${PROJECT_NAME}_ENABLE_Fortran_DEFAULT``
+  is set to ``OFF`` since it can be difficult to get a Fortran compiler for
+  native Windows.
+
   Given that a native Fortran compiler is not supported by default on Windows
   and on most Mac OSX systems, projects that have optional Fortran code may
   decide to set the default depending on the platform by setting, for example::


### PR DESCRIPTION
The most important main thing I did here was to address a problem with the code in  `TribitsExternalPackageWriteConfigFile.cmake` that generates `<tplName>Config.cmake` files that assumed that all libraries started with `lib` (see commit 55b95a67a70d640fb5d116849e5e2f391d944c2a).  Most of the other commits get a subset of the tests running on Cygwin and native Windows to be able to test the generation of `<tplName>Config.cmake` files to pass.  I also make the default configuration on native Windows work out of the box to deal with no Fortran and no Git without having to manually disable anything.

I am now pretty confident that the work on #299 will not be breaking Windows builds.

But a lot more work would be needed to update the TriBITS test suite (not so much TriBITS production code itself) to make it pass on Cygwin and native Windows.  (This would be needed to set up a GitHub Actions build/test case.)

## Testing on Cygwin

The following test suite passes on Cygwin (with CMake 3.21.4 and GCC 9.3.0):

```
$ ctest -j4 -R "(SimpleTpl|TribitsExampleProject2|TribitsExampleApp)"
Test project /home/rabartl/TriBITS.base/BUILDS/GCC-9.3.0/TRIBITS_SERIAL_DEBUG                                                                                                                                      
      Start 241: TriBITS_TribitsExampleProject2_Tpls_install_SHARED                                                                                                                                                
      Start 242: TriBITS_TribitsExampleProject2_Tpls_install_STATIC                                                                                                                                                
      Start 187: TriBITS_SimpleTpl_install_STATIC                                                                                                                                                                  
      Start 186: TriBITS_SimpleTpl_install_SHARED                                                                                                                                                                  
 1/31 Test #187: TriBITS_SimpleTpl_install_STATIC ........................................................   Passed    9.36 sec                                                                                    
      Start 221: TriBITS_TribitsExampleApp_ALL_ST_tpl_link_options_ByProject_STATIC                                                                                                                                
 2/31 Test #186: TriBITS_SimpleTpl_install_SHARED ........................................................   Passed    9.73 sec                                                                                    
      Start 222: TriBITS_TribitsExampleApp_ALL_ST_tpl_link_options_ByProject_SHARED                                                                                                                                
 3/31 Test #241: TriBITS_TribitsExampleProject2_Tpls_install_SHARED ......................................   Passed   10.19 sec                                                                                    
      Start 248: TriBITS_TribitsExampleProject2_find_package_SHARED                                                                                                                                                
 4/31 Test #242: TriBITS_TribitsExampleProject2_Tpls_install_STATIC ......................................   Passed   10.59 sec                                                                                    
      Start 243: TriBITS_TribitsExampleProject2_find_tpl_parts_STATIC                                                                                                                                              
 5/31 Test #243: TriBITS_TribitsExampleProject2_find_tpl_parts_STATIC ....................................   Passed   91.67 sec                                                                                    
      Start 247: TriBITS_TribitsExampleProject2_find_package_STATIC                                                                                                                                                
 6/31 Test #248: TriBITS_TribitsExampleProject2_find_package_SHARED ......................................   Passed   92.42 sec                                                                                    
      Start 245: TriBITS_TribitsExampleProject2_explicit_tpl_vars_STATIC                                                                                                                                           
 7/31 Test #221: TriBITS_TribitsExampleApp_ALL_ST_tpl_link_options_ByProject_STATIC ......................   Passed  118.42 sec
      Start 244: TriBITS_TribitsExampleProject2_find_tpl_parts_SHARED
 8/31 Test #222: TriBITS_TribitsExampleApp_ALL_ST_tpl_link_options_ByProject_SHARED ......................   Passed  119.19 sec
      Start 246: TriBITS_TribitsExampleProject2_explicit_tpl_vars_SHARED
 9/31 Test #247: TriBITS_TribitsExampleProject2_find_package_STATIC ......................................   Passed   90.86 sec
      Start 249: TriBITS_TribitsExampleProject2_install_config_again
10/31 Test #245: TriBITS_TribitsExampleProject2_explicit_tpl_vars_STATIC .................................   Passed   92.37 sec
      Start 218: TriBITS_TribitsExampleApp_ALL_ST_ByProject_SHARED
11/31 Test #244: TriBITS_TribitsExampleProject2_find_tpl_parts_SHARED ....................................   Passed   93.40 sec
      Start 220: TriBITS_TribitsExampleApp_ALL_ST_ByPackage_SHARED
12/31 Test #246: TriBITS_TribitsExampleProject2_explicit_tpl_vars_SHARED .................................   Passed   92.35 sec
      Start 224: TriBITS_TribitsExampleApp_ALL_ST_tpl_link_options_ByPackage_SHARED
13/31 Test #218: TriBITS_TribitsExampleApp_ALL_ST_ByProject_SHARED .......................................   Passed  153.25 sec
      Start 217: TriBITS_TribitsExampleApp_ALL_ST_ByProject_STATIC
14/31 Test #220: TriBITS_TribitsExampleApp_ALL_ST_ByPackage_SHARED .......................................   Passed  157.39 sec
      Start 219: TriBITS_TribitsExampleApp_ALL_ST_ByPackage_STATIC
15/31 Test #224: TriBITS_TribitsExampleApp_ALL_ST_tpl_link_options_ByPackage_SHARED ......................   Passed  157.53 sec
      Start 223: TriBITS_TribitsExampleApp_ALL_ST_tpl_link_options_ByPackage_STATIC
16/31 Test #249: TriBITS_TribitsExampleProject2_install_config_again .....................................   Passed  209.26 sec
      Start 225: TriBITS_TribitsExampleApp_ALL_ST_buildtree_STATIC
17/31 Test #217: TriBITS_TribitsExampleApp_ALL_ST_ByProject_STATIC .......................................   Passed  142.31 sec
      Start 253: TriBITS_TribitsExampleApp2_TribitsExampleProject2_find_tpl_parts_SHARED_COMPONENTS
18/31 Test #253: TriBITS_TribitsExampleApp2_TribitsExampleProject2_find_tpl_parts_SHARED_COMPONENTS ......   Passed   15.86 sec
      Start 256: TriBITS_TribitsExampleApp2_TribitsExampleProject2_find_package_SHARED_COMPONENTS
19/31 Test #219: TriBITS_TribitsExampleApp_ALL_ST_ByPackage_STATIC .......................................   Passed  141.59 sec
      Start 257: TriBITS_TribitsExampleApp2_TribitsExampleProject2_find_package_STATIC_COMPONENTS
20/31 Test #223: TriBITS_TribitsExampleApp_ALL_ST_tpl_link_options_ByPackage_STATIC ......................   Passed  142.70 sec
      Start 252: TriBITS_TribitsExampleApp2_TribitsExampleProject2_find_tpl_parts_STATIC_COMPONENTS
21/31 Test #256: TriBITS_TribitsExampleApp2_TribitsExampleProject2_find_package_SHARED_COMPONENTS ........   Passed   15.80 sec
      Start 254: TriBITS_TribitsExampleApp2_TribitsExampleProject2_explicit_tpl_vars_STATIC_COMPONENTS
22/31 Test #257: TriBITS_TribitsExampleApp2_TribitsExampleProject2_find_package_STATIC_COMPONENTS ........   Passed   15.87 sec
      Start 251: TriBITS_TribitsExampleApp2_TribitsExampleProject2_find_tpl_parts_STATIC_FULL
23/31 Test #252: TriBITS_TribitsExampleApp2_TribitsExampleProject2_find_tpl_parts_STATIC_COMPONENTS ......   Passed   15.27 sec
      Start 255: TriBITS_TribitsExampleApp2_TribitsExampleProject2_explicit_tpl_vars_SHARED_COMPONENTS
24/31 Test #254: TriBITS_TribitsExampleApp2_TribitsExampleProject2_explicit_tpl_vars_STATIC_COMPONENTS ...   Passed   15.33 sec
      Start 250: TriBITS_TribitsExampleApp2_find_package_missing_component_error_msg
25/31 Test #250: TriBITS_TribitsExampleApp2_find_package_missing_component_error_msg .....................   Passed    0.70 sec
      Start 214: TriBITS_TribitsExampleApp_NoFortran_STATIC_FULL
26/31 Test #225: TriBITS_TribitsExampleApp_ALL_ST_buildtree_STATIC .......................................   Passed  136.34 sec
      Start 215: TriBITS_TribitsExampleApp_NoFortran_STATIC_COMPONENTS
27/31 Test #251: TriBITS_TribitsExampleApp2_TribitsExampleProject2_find_tpl_parts_STATIC_FULL ............   Passed   15.81 sec
      Start 216: TriBITS_TribitsExampleApp_NoFortran_SHARED_COMPONENTS
28/31 Test #255: TriBITS_TribitsExampleApp2_TribitsExampleProject2_explicit_tpl_vars_SHARED_COMPONENTS ...   Passed   16.77 sec
29/31 Test #214: TriBITS_TribitsExampleApp_NoFortran_STATIC_FULL .........................................   Passed   56.59 sec
30/31 Test #215: TriBITS_TribitsExampleApp_NoFortran_STATIC_COMPONENTS ...................................   Passed   56.36 sec
31/31 Test #216: TriBITS_TribitsExampleApp_NoFortran_SHARED_COMPONENTS ...................................   Passed   52.03 sec

100% tests passed, 0 tests failed out of 31

Subproject Time Summary:
TriBITS    = 2347.33 sec*proc (31 tests)

Total Test time (real) = 604.03 sec
```

## Testing on native Windows

The following test suite passes on native Windows (with CMake 3.22.0-rc2 and Visual Studio 17 2022):

```
$ cmake --build . --config Release > make.out && ctest -C Release -j4 -R "(SimpleTpl|TribitsExampleApp_)"
Test project C:/cygwin64/home/rabartl/B
    Start 163: TriBITS_SimpleTpl_install_SHARED
    Start 164: TriBITS_SimpleTpl_install_STATIC
1/5 Test #164: TriBITS_SimpleTpl_install_STATIC ........................   Passed    6.91 sec
    Start 182: TriBITS_TribitsExampleApp_NoFortran_STATIC_FULL
    Start 183: TriBITS_TribitsExampleApp_NoFortran_STATIC_COMPONENTS
2/5 Test #163: TriBITS_SimpleTpl_install_SHARED ........................   Passed    7.20 sec
    Start 184: TriBITS_TribitsExampleApp_NoFortran_SHARED_COMPONENTS
3/5 Test #182: TriBITS_TribitsExampleApp_NoFortran_STATIC_FULL .........   Passed   31.42 sec
4/5 Test #183: TriBITS_TribitsExampleApp_NoFortran_STATIC_COMPONENTS ...   Passed   31.42 sec
5/5 Test #184: TriBITS_TribitsExampleApp_NoFortran_SHARED_COMPONENTS ...   Passed   32.02 sec

100% tests passed, 0 tests failed out of 5

Subproject Time Summary:
TriBITS    = 108.98 sec*proc (5 tests)

Total Test time (real) =  39.29 sec
```

Getting the more of the TriBITS test suite to pass with native Windows would require similar efforts (mostly switching to `cmake --build . --config <config>` and removing greps for expected build output).
