### PR TITLE
Fix issues with <tplName>Config.cmake generation for TriBITGS TPLs from trilinos/Trilinos#9894 (#433)

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -16,6 +16,7 @@ endif()
 
 if (CTEST_DROP_METHOD STREQUAL "http" OR CTEST_DROP_METHOD STREQUAL "https")
   set_default_and_from_env(CTEST_DROP_SITE "testing.sandia.gov")
+  set_default_and_from_env(TRIBITS_2ND_CTEST_DROP_SITE "testing-dev.sandia.gov")
   set_default_and_from_env(CTEST_PROJECT_NAME "TriBITS")
   set_default_and_from_env(CTEST_DROP_LOCATION "/cdash/submit.php?project=TriBITS")
   set_default_and_from_env(CTEST_TRIGGER_SITE "")

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -145,7 +145,7 @@ tribits_add_advanced_test( TribitsExternalPackageWriteConfigFile_UnitTests
       -DCURRENT_TEST_DIRECTORY=${CMAKE_CURRENT_BINARY_DIR}
       -P "${CMAKE_CURRENT_SOURCE_DIR}/TribitsExternalPackageWriteConfigFile_UnitTests.cmake"
     PASS_REGULAR_EXPRESSION_ALL
-      "Final UnitTests Result: num_run = 35"
+      "Final UnitTests Result: num_run = 39"
       "Final UnitTests Result: PASSED"
   )
 

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -145,7 +145,7 @@ tribits_add_advanced_test( TribitsExternalPackageWriteConfigFile_UnitTests
       -DCURRENT_TEST_DIRECTORY=${CMAKE_CURRENT_BINARY_DIR}
       -P "${CMAKE_CURRENT_SOURCE_DIR}/TribitsExternalPackageWriteConfigFile_UnitTests.cmake"
     PASS_REGULAR_EXPRESSION_ALL
-      "Final UnitTests Result: num_run = 31"
+      "Final UnitTests Result: num_run = 35"
       "Final UnitTests Result: PASSED"
   )
 

--- a/test/core/TribitsExternalPackageWriteConfigFile_UnitTests.cmake
+++ b/test/core/TribitsExternalPackageWriteConfigFile_UnitTests.cmake
@@ -348,6 +348,48 @@ target_link_libraries(SomeTpl::lib3
 endfunction()
 
 
+function(unittest_tribits_external_package_process_libraries_list_incl_dirs_0_link_opt_1)
+
+  message("\n***")
+  message("*** Testing tribits_external_package_process_libraries_list(): incl dirs 0, link opt 1")
+  message("***\n")
+
+  set(tplName SomeTpl)
+  set(TPL_${tplName}_LIBRARIES "-mkl")
+
+  set(configFileFragStr "#beginning\n\n")
+
+  set(MESSAGE_WRAPPER_UNIT_TEST_MODE ON)
+  global_null_set(MESSAGE_WRAPPER_INPUT)
+
+  tribits_external_package_process_libraries_list( ${tplName}
+    LIB_TARGETS_LIST_OUT libTargetsList
+    LIB_LINK_FLAGS_LIST_OUT libLinkFlagsList
+    CONFIG_FILE_STR_INOUT configFileFragStr
+    )
+
+  unittest_compare_const( MESSAGE_WRAPPER_INPUT
+    "NOTE: Moving the general link argument '-mkl' in TPL_${tplName}_LIBRARIES forward on the link line which may change the link and break the link!"
+    )
+
+  unittest_compare_const( libTargetsList
+    ""
+    )
+
+  unittest_compare_const( libLinkFlagsList
+    "-mkl"
+    )
+
+  unittest_string_block_compare( configFileFragStr
+[=[
+#beginning
+
+]=]
+    )
+
+endfunction()
+
+
 function(unittest_tribits_external_package_process_libraries_list_incl_dirs_0_lib_opts_2_2_lib_files_1)
 
   message("\n***")
@@ -692,7 +734,7 @@ function(unittest_tribits_external_package_write_config_file_str_incl_dirs_1_bad
     tplConfigFileStr )
 
   unittest_compare_const( MESSAGE_WRAPPER_INPUT
-    "SEND_ERROR;ERROR: Can't handle argument 'some-other-option' in list TPL_SomeTpl_LIBRARIES;SEND_ERROR;ERROR: Can't handle argument '-o' in list TPL_SomeTpl_LIBRARIES"
+    "SEND_ERROR;ERROR: Can't handle argument 'some-other-option' in list TPL_SomeTpl_LIBRARIES;NOTE: Moving the general link argument '-o' in TPL_SomeTpl_LIBRARIES forward on the link line which may change the link and break the link!"
     )
 
   unittest_string_block_compare( tplConfigFileStr
@@ -723,6 +765,7 @@ target_include_directories(SomeTpl::all_libs SYSTEM
   )
 target_link_options(SomeTpl::all_libs
   INTERFACE "-L/some/explicit/path2"
+  INTERFACE "-o"
   INTERFACE "-L/some/explicit/path1"
   )
 
@@ -751,6 +794,7 @@ unittest_tribits_external_package_process_libraries_list_incl_dirs_0_lib_opts_1_
 unittest_tribits_external_package_process_libraries_list_incl_dirs_0_lib_opts_2_2()
 unittest_tribits_external_package_process_libraries_list_incl_dirs_0_lib_opts_3_3()
 unittest_tribits_external_package_process_libraries_list_incl_dirs_0_lib_opts_2_2_lib_files_1()
+unittest_tribits_external_package_process_libraries_list_incl_dirs_0_link_opt_1()
 unittest_tribits_external_package_process_libraries_list_duplicate_libs()
 
 unittest_tribits_external_package_write_config_file_str_incl_dirs_0_lib_files_1()
@@ -761,4 +805,4 @@ unittest_tribits_external_package_write_config_file_str_incl_dirs_2_lib_opts_2_2
 unittest_tribits_external_package_write_config_file_str_incl_dirs_1_bad_lib_args()
 
 # Pass in the number of expected tests that must pass!
-unittest_final_result(31)
+unittest_final_result(35)

--- a/test/core/TribitsExternalPackageWriteConfigFile_UnitTests.cmake
+++ b/test/core/TribitsExternalPackageWriteConfigFile_UnitTests.cmake
@@ -390,6 +390,62 @@ function(unittest_tribits_external_package_process_libraries_list_incl_dirs_0_li
 endfunction()
 
 
+function(unittest_tribits_external_package_process_libraries_list_incl_dirs_0_libname_2)
+
+  message("\n***")
+  message("*** Testing tribits_external_package_process_libraries_list(): incl dirs 0, libname 2")
+  message("***\n")
+
+  set(tplName SomeTpl)
+  set(TPL_${tplName}_LIBRARIES
+    some1_Longer2-Name3  # Lower case, upper case, _, -, and digits
+    -   # One-char special case that should never happen
+    c   # One-char special case like 'm'
+    )
+
+  set(configFileFragStr "#beginning\n\n")
+
+  set(MESSAGE_WRAPPER_UNIT_TEST_MODE ON)
+  global_null_set(MESSAGE_WRAPPER_INPUT)
+
+  tribits_external_package_process_libraries_list( ${tplName}
+    LIB_TARGETS_LIST_OUT libTargetsList
+    LIB_LINK_FLAGS_LIST_OUT libLinkFlagsList
+    CONFIG_FILE_STR_INOUT configFileFragStr
+    )
+
+  unittest_compare_const( MESSAGE_WRAPPER_INPUT
+    "NOTE: Moving the general link argument '-' in TPL_SomeTpl_LIBRARIES forward on the link line which may change the link and break the link!"
+    )
+
+  unittest_compare_const( libTargetsList
+    "SomeTpl::c;SomeTpl::some1_Longer2-Name3"
+    )
+
+  unittest_compare_const( libLinkFlagsList "-" )
+
+  message("configFileFragStr:\n\n${configFileFragStr}")
+
+  unittest_string_block_compare( configFileFragStr
+[=[
+#beginning
+
+add_library(SomeTpl::c IMPORTED INTERFACE GLOBAL)
+set_target_properties(SomeTpl::c PROPERTIES
+  IMPORTED_LIBNAME "c")
+
+add_library(SomeTpl::some1_Longer2-Name3 IMPORTED INTERFACE GLOBAL)
+set_target_properties(SomeTpl::some1_Longer2-Name3 PROPERTIES
+  IMPORTED_LIBNAME "some1_Longer2-Name3")
+target_link_libraries(SomeTpl::some1_Longer2-Name3
+  INTERFACE SomeTpl::c)
+
+]=]
+    )
+
+endfunction()
+
+
 function(unittest_tribits_external_package_process_libraries_list_incl_dirs_0_lib_opts_2_2_lib_files_1)
 
   message("\n***")
@@ -724,6 +780,7 @@ function(unittest_tribits_external_package_write_config_file_str_incl_dirs_1_bad
   set(TPL_${tplName}_LIBRARIES
     -llib2 -L/some/explicit/path2
     -o some-other-option
+    some=nonsupported-opt
     -llib1 -L/some/explicit/path1
     )
 
@@ -734,7 +791,7 @@ function(unittest_tribits_external_package_write_config_file_str_incl_dirs_1_bad
     tplConfigFileStr )
 
   unittest_compare_const( MESSAGE_WRAPPER_INPUT
-    "SEND_ERROR;ERROR: Can't handle argument 'some-other-option' in list TPL_SomeTpl_LIBRARIES;NOTE: Moving the general link argument '-o' in TPL_SomeTpl_LIBRARIES forward on the link line which may change the link and break the link!"
+    "SEND_ERROR;ERROR: Can't handle argument 'some=nonsupported-opt' in list TPL_SomeTpl_LIBRARIES;NOTE: Moving the general link argument '-o' in TPL_SomeTpl_LIBRARIES forward on the link line which may change the link and break the link!"
     )
 
   unittest_string_block_compare( tplConfigFileStr
@@ -749,15 +806,22 @@ add_library(SomeTpl::lib1 IMPORTED INTERFACE GLOBAL)
 set_target_properties(SomeTpl::lib1 PROPERTIES
   IMPORTED_LIBNAME "lib1")
 
+add_library(SomeTpl::some-other-option IMPORTED INTERFACE GLOBAL)
+set_target_properties(SomeTpl::some-other-option PROPERTIES
+  IMPORTED_LIBNAME "some-other-option")
+target_link_libraries(SomeTpl::some-other-option
+  INTERFACE SomeTpl::lib1)
+
 add_library(SomeTpl::lib2 IMPORTED INTERFACE GLOBAL)
 set_target_properties(SomeTpl::lib2 PROPERTIES
   IMPORTED_LIBNAME "lib2")
 target_link_libraries(SomeTpl::lib2
-  INTERFACE SomeTpl::lib1)
+  INTERFACE SomeTpl::some-other-option)
 
 add_library(SomeTpl::all_libs INTERFACE IMPORTED GLOBAL)
 target_link_libraries(SomeTpl::all_libs
   INTERFACE SomeTpl::lib1
+  INTERFACE SomeTpl::some-other-option
   INTERFACE SomeTpl::lib2
   )
 target_include_directories(SomeTpl::all_libs SYSTEM
@@ -795,6 +859,7 @@ unittest_tribits_external_package_process_libraries_list_incl_dirs_0_lib_opts_2_
 unittest_tribits_external_package_process_libraries_list_incl_dirs_0_lib_opts_3_3()
 unittest_tribits_external_package_process_libraries_list_incl_dirs_0_lib_opts_2_2_lib_files_1()
 unittest_tribits_external_package_process_libraries_list_incl_dirs_0_link_opt_1()
+unittest_tribits_external_package_process_libraries_list_incl_dirs_0_libname_2()
 unittest_tribits_external_package_process_libraries_list_duplicate_libs()
 
 unittest_tribits_external_package_write_config_file_str_incl_dirs_0_lib_files_1()
@@ -805,4 +870,4 @@ unittest_tribits_external_package_write_config_file_str_incl_dirs_2_lib_opts_2_2
 unittest_tribits_external_package_write_config_file_str_incl_dirs_1_bad_lib_args()
 
 # Pass in the number of expected tests that must pass!
-unittest_final_result(35)
+unittest_final_result(39)

--- a/tribits/core/package_arch/TribitsExternalPackageWriteConfigFile.cmake
+++ b/tribits/core/package_arch/TribitsExternalPackageWriteConfigFile.cmake
@@ -230,7 +230,7 @@ endfunction()
 #
 # Read the ``TPL_<tplName>_LIBRARIES` list variable and produce the string for
 # the IMPORTED targets commands and return list of targets and left over
-# linker flags..
+# linker flags.
 #
 # Usage::
 #
@@ -243,17 +243,17 @@ endfunction()
 #
 # The arguments are:
 #
-#   ``<tplName>``: Name of the external package/TPL
+#   ``<tplName>``: [In] Name of the external package/TPL
 #
-#   ``<libTargetsListOut>``: Name of list variable that will be set with the
-#   list of IMPORTED library targets generated from this list.
+#   ``<libTargetsListOut>``: [Out] Name of list variable that will be set with
+#   the list of IMPORTED library targets generated from this list.
 #
-#   ``<libLinkFlagsListOut>``: Name of list variable that will be set with the
-#   list of ``-L<dir>`` library directoy paths.
+#   ``<libLinkFlagsListOut>``: [Out] Name of list variable that will be set
+#   with the list of ``-L<dir>`` library directoy paths.
 #
-#   ``<configFileFragStrInOut>``: A string variable that will be appended with
-#   the IMPORTED library commands for the list of targts given in
-#   ``<libTargetsList>``.
+#   ``<configFileFragStrInOut>``: [Inout] A string variable that will be
+#   appended with the IMPORTED library commands for the list of targts given
+#   in ``<libTargetsList>``.
 #
 function(tribits_external_package_process_libraries_list  tplName)
 
@@ -294,6 +294,9 @@ function(tribits_external_package_process_libraries_list  tplName)
         "ERROR: Can't handle argument '${libentry}' in list TPL_${tplName}_LIBRARIES")
     elseif (libEntryType STREQUAL "LIB_DIR_LINK_OPTION")
       list(APPEND libLinkFlagsList "${libentry}")
+    elseif (libEntryType STREQUAL "GENERAL_LINK_OPTION")
+      message_wrapper("NOTE: Moving the general link argument '${libentry}' in TPL_${tplName}_LIBRARIES forward on the link line which may change the link and break the link!")
+      list(APPEND libLinkFlagsList "${libentry}")
     else()
       tribits_external_package_process_libraries_list_library_entry(
         ${tplName}  "${libentry}"  ${libEntryType}  libTargets  lastLib  configFileStr )
@@ -329,14 +332,20 @@ endfunction()
 #   ``LIB_DIR_LINK_OPTION``: A library directory search option of the form
 #   ``-L<dir>``
 #
+#   ``GENERAL_LINK_OPTION``: Some other general link option that starts with
+#   ``-`` but is not ``-l`` or ``-L``.
+#
 #   ``UNSUPPORTED_LIB_ENTRY``: An unsupported lib option
 #
 function(tribits_tpl_libraries_entry_type  libentry  libEntryTypeOut)
+  string(SUBSTRING "${libentry}" 0 1 firstCharLibEntry)
   string(SUBSTRING "${libentry}" 0 2 firstTwoCharsLibEntry)
   if (firstTwoCharsLibEntry STREQUAL "-l")
     set(libEntryType LIB_NAME_LINK_OPTION)
   elseif (firstTwoCharsLibEntry STREQUAL "-L")
     set(libEntryType LIB_DIR_LINK_OPTION)
+  elseif (firstCharLibEntry STREQUAL "-")
+    set(libEntryType GENERAL_LINK_OPTION)
   elseif (IS_ABSOLUTE "${libentry}")
     set(libEntryType FULL_LIB_PATH)
   else()


### PR DESCRIPTION
This PR should fix all of the issues with the TriBITS snapshot merged to Trilinos in trilinos/Trilinos#9894 as noted in #433 (as part of #299).

## How was this tested?

I tested a configuration of Trilinos that used `-mkl` and it passed the configure and build (but had an unrelated runtime problem as per trilinos/Trilinos#10022).

## Tasks:

* [ ] Get passing ATDM Trilinos builds and tests using `-mkl`
* [ ] Test against Albany
* [ ] Test against Nalu

