### PR TITLE
Add back deprecated non-namespaced library targets (#299, #433)

### DIFF
--- a/test/core/ExamplesUnitTests/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/CMakeLists.txt
@@ -59,6 +59,8 @@ include(TribitsExampleApp_Tests.cmake)
 
 include(TribitsSimpleExampleApp_Tests.cmake)
 
+include(TribitsOldSimpleExampleApp_Tests.cmake)
+
 include(TribitsExampleProjectAddons_Tests.cmake)
 
 include(TribitsExampleMetaProject_Tests.cmake)

--- a/test/core/ExamplesUnitTests/TribitsOldSimpleExampleApp_Tests.cmake
+++ b/test/core/ExamplesUnitTests/TribitsOldSimpleExampleApp_Tests.cmake
@@ -39,10 +39,13 @@
 # TribitsOldSimpleExampleApp
 ########################################################################
 
+set(
+  TribitsOldSimpleExampleApp_TribitsExampleProject_TRIBITS_DIR_default
+  "${${PROJECT_NAME}_TRIBITS_DIR}" )
 
 set_default_and_from_env(
   TribitsOldSimpleExampleApp_TribitsExampleProject_TRIBITS_DIR
-  "${${PROJECT_NAME}_TRIBITS_DIR}"
+  "${TribitsOldSimpleExampleApp_TribitsExampleProject_TRIBITS_DIR_default}"
   )
 # NOTE: The above var can be overridden to use an older version of TriBITS and
 # TribitsExampleProject to build and install and test against this
@@ -50,6 +53,8 @@ set_default_and_from_env(
 
 
 function(TribitsOldSimpleExampleApp sharedOrStatic useDeprecatedTargets)
+
+  set(appConfigurePassRegexAll "")
 
   if (sharedOrStatic STREQUAL "SHARED")
     set(buildSharedLibsArg -DBUILD_SHARED_LIBS=ON)
@@ -61,6 +66,19 @@ function(TribitsOldSimpleExampleApp sharedOrStatic useDeprecatedTargets)
 
   if (useDeprecatedTargets STREQUAL "USE_DEPRECATED_TARGETS")
     set(useDeprecatedTargetsArg -DTribitsOldSimpleExApp_USE_DEPRECATED_TARGETS=ON)
+    if (TribitsOldSimpleExampleApp_TribitsExampleProject_TRIBITS_DIR STREQUAL
+      TribitsOldSimpleExampleApp_TribitsExampleProject_TRIBITS_DIR_default
+      )
+      list(APPEND appConfigurePassRegexAll
+        "The library that is being linked to, pws_b, is marked as being deprecated"
+        "WARNING: The non-namespaced target 'pws_b' is deprecated"
+        "'WithSubpackagesB::pws_b'"
+        "'WithSubpackagesB::all_libs'"
+        "package 'WithSubpackagesB'"
+        "project 'TribitsExProj'"
+        "'WithSubpackagesB_LIBRARIES'"
+        )
+    endif()
   elseif (useDeprecatedTargets STREQUAL "USE_NEW_TARGETS")
     set(useDeprecatedTargetsArg "")
   else()
@@ -83,7 +101,6 @@ function(TribitsOldSimpleExampleApp sharedOrStatic useDeprecatedTargets)
       CMND ${CMAKE_COMMAND}
       ARGS
         ${TribitsExampleProject_COMMON_CONFIG_ARGS}
-        -DTribitsExProj_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
         -DTribitsExProj_ENABLE_Fortran=ON
         -DTribitsExProj_ENABLE_ALL_PACKAGES=ON
         -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON
@@ -110,6 +127,7 @@ function(TribitsOldSimpleExampleApp sharedOrStatic useDeprecatedTargets)
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsOldSimpleExampleApp
       PASS_REGULAR_EXPRESSION_ALL
         "${foundProjectOrPackageStr}"
+        "${appConfigurePassRegexAll}"
         "-- Configuring done"
         "-- Generating done"
         "-- Build files have been written to: .*/${testName}/app_build"

--- a/test/core/ExamplesUnitTests/TribitsOldSimpleExampleApp_Tests.cmake
+++ b/test/core/ExamplesUnitTests/TribitsOldSimpleExampleApp_Tests.cmake
@@ -1,0 +1,155 @@
+# @HEADER
+# ************************************************************************
+#
+#            TriBITS: Tribal Build, Integrate, and Test System
+#                    Copyright 2013 Sandia Corporation
+#
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the Corporation nor the names of the
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+########################################################################
+# TribitsOldSimpleExampleApp
+########################################################################
+
+
+set_default_and_from_env(
+  TribitsOldSimpleExampleApp_TribitsExampleProject_TRIBITS_DIR
+  "${${PROJECT_NAME}_TRIBITS_DIR}"
+  )
+# NOTE: The above var can be overridden to use an older version of TriBITS and
+# TribitsExampleProject to build and install and test against this
+# TribitsOldSimpleExampleApp.
+
+
+function(TribitsOldSimpleExampleApp sharedOrStatic useDeprecatedTargets)
+
+  if (sharedOrStatic STREQUAL "SHARED")
+    set(buildSharedLibsArg -DBUILD_SHARED_LIBS=ON)
+  elseif (sharedOrStatic STREQUAL "STATIC")
+    set(buildSharedLibsArg -DBUILD_SHARED_LIBS=OFF)
+  else()
+    message(FATAL_ERROR "Invaid value for sharedOrStatic='${sharedOrStatic}'!")
+  endif()
+
+  if (useDeprecatedTargets STREQUAL "USE_DEPRECATED_TARGETS")
+    set(useDeprecatedTargetsArg -DTribitsOldSimpleExApp_USE_DEPRECATED_TARGETS=ON)
+  elseif (useDeprecatedTargets STREQUAL "USE_NEW_TARGETS")
+    set(useDeprecatedTargetsArg "")
+  else()
+    message(FATAL_ERROR "Invaid value for useDeprecatedTargets='${useDeprecatedTargets}'!")
+  endif()
+
+  set(testBaseName ${CMAKE_CURRENT_FUNCTION}_${sharedOrStatic}_${useDeprecatedTargets})
+  set(testName ${PACKAGE_NAME}_${testBaseName})
+  set(testDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
+
+  tribits_add_advanced_test( ${testBaseName}
+    OVERALL_WORKING_DIRECTORY TEST_NAME
+    OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
+    XHOSTTYPE Darwin
+
+    TEST_0
+      MESSAGE "Do the configure of TribitsExampleProject"
+      WORKING_DIRECTORY BUILD
+      CMND ${CMAKE_COMMAND}
+      ARGS
+        ${TribitsExampleProject_COMMON_CONFIG_ARGS}
+        -DTribitsExProj_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
+        -DTribitsExProj_ENABLE_Fortran=ON
+        -DTribitsExProj_ENABLE_ALL_PACKAGES=ON
+        -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON
+        -DTribitsExProj_ENABLE_INSTALL_CMAKE_CONFIG_FILES=ON
+        -DTPL_ENABLE_SimpleTpl=ON
+        -DSimpleTpl_INCLUDE_DIRS=${SimpleTpl_install_${sharedOrStatic}_DIR}/install/include
+        -DSimpleTpl_LIBRARY_DIRS=${SimpleTpl_install_${sharedOrStatic}_DIR}/install/lib
+        ${buildSharedLibsArg}
+        -DCMAKE_INSTALL_PREFIX=${testDir}/install
+        ${TribitsOldSimpleExampleApp_TribitsExampleProject_TRIBITS_DIR}/examples/TribitsExampleProject
+
+    TEST_1
+      MESSAGE "Build and install TribitsExampleProject locally"
+      WORKING_DIRECTORY BUILD
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND make ARGS ${CTEST_BUILD_FLAGS} install
+
+    TEST_2
+      MESSAGE "Configure TribitsOldSimpleExampleApp locally"
+      WORKING_DIRECTORY app_build
+      CMND ${CMAKE_COMMAND} ARGS
+        ${useDeprecatedTargetsArg}
+        -DCMAKE_PREFIX_PATH=${testDir}/install
+        ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsOldSimpleExampleApp
+      PASS_REGULAR_EXPRESSION_ALL
+        "${foundProjectOrPackageStr}"
+        "-- Configuring done"
+        "-- Generating done"
+        "-- Build files have been written to: .*/${testName}/app_build"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    TEST_3
+      MESSAGE "Build TribitsOldSimpleExampleApp"
+      WORKING_DIRECTORY app_build
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND make ARGS ${CTEST_BUILD_FLAGS}
+      PASS_REGULAR_EXPRESSION_ALL
+        "Built target app"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    TEST_4
+      MESSAGE "Test TribitsOldSimpleExampleApp"
+      WORKING_DIRECTORY app_build
+      SKIP_CLEAN_WORKING_DIRECTORY
+      CMND ${CMAKE_CTEST_COMMAND} ARGS -VV
+      PASS_REGULAR_EXPRESSION_ALL
+        "Util Deps: B A SimpleCxx simpletpl headeronlytpl SimpleCxx simpletpl headeronlytpl"
+        "Full Deps: WithSubpackages:B A SimpleCxx simpletpl headeronlytpl SimpleCxx simpletpl headeronlytpl A SimpleCxx simpletpl headeronlytpl[;] MixedLang:Mixed Language[;] SimpleCxx:simpletpl headeronlytpl"
+        "util_test [.]+   Passed"
+        "app_test [.]+   Passed"
+        "100% tests passed, 0 tests failed out of 2"
+      ALWAYS_FAIL_ON_NONZERO_RETURN
+
+    ${LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_${sharedOrStatic}_ENVIRONMENT_ARG}
+
+    ADDED_TEST_NAME_OUT ${testNameBase}_NAME
+    )
+  # NOTE: The above test verifies 
+
+  if (${testNameBase}_NAME)
+    set_tests_properties(${${testNameBase}_NAME}
+      PROPERTIES DEPENDS ${SimpleTpl_install_${sharedOrStatic}_NAME} )
+  endif()
+
+endfunction()
+
+
+TribitsOldSimpleExampleApp(STATIC USE_DEPRECATED_TARGETS)
+TribitsOldSimpleExampleApp(SHARED USE_NEW_TARGETS)

--- a/tribits/core/installation/TribitsPackageConfigTemplate.cmake.in
+++ b/tribits/core/installation/TribitsPackageConfigTemplate.cmake.in
@@ -136,3 +136,29 @@ set(${EXPORT_FILE_VAR_PREFIX}_PACKAGE_LIST "${FULL_PACKAGE_SET}")
 set(${EXPORT_FILE_VAR_PREFIX}_TPL_LIST "${ORDERED_FULL_TPL_SET}")
 
 ${PACKAGE_CONFIG_CODE}
+
+## ----------------------------------------------------------------------------
+## Create deprecated non-namespaced library targets for backwards compatibility
+## ----------------------------------------------------------------------------
+
+set(${EXPORT_FILE_VAR_PREFIX}_EXPORTED_PACKAGE_LIBS_NAMES "${EXPORTED_PACKAGE_LIBS_NAMES}")
+
+foreach(libname IN LISTS ${EXPORT_FILE_VAR_PREFIX}_EXPORTED_PACKAGE_LIBS_NAMES)
+  if (NOT TARGET ${PDOLLAR}{libname})
+    add_library(${PDOLLAR}{libname} INTERFACE IMPORTED)
+    target_link_libraries(${PDOLLAR}{libname}
+       INTERFACE ${PACKAGE_NAME}::${PDOLLAR}{libname})
+    set(deprecationMessage
+      "WARNING: The non-namespaced target '${PDOLLAR}{libname}' is deprecated!"
+      "  If always using newer versions of the project '${PROJECT_NAME}', then use the"
+      " new namespaced target '${PACKAGE_NAME}::${PDOLLAR}{libname}', or better yet,"
+      " '${PACKAGE_NAME}::all_libs' to be less sensitive to changes in the definition"
+      " of targets in the package '${PACKAGE_NAME}'.  Or, to maintain compatibility with"
+      " older or newer versions the project '${PROJECT_NAME}', instead link against the"
+      " libraries specified by the variable '${PACKAGE_NAME}_LIBRARIES'."
+      )
+    string(REPLACE ";" "" deprecationMessage "${PDOLLAR}{deprecationMessage}")
+    set_target_properties(${PDOLLAR}{libname}
+      PROPERTIES DEPRECATION "${PDOLLAR}{deprecationMessage}" )
+  endif()
+endforeach()

--- a/tribits/core/package_arch/TribitsPackageMacros.cmake
+++ b/tribits/core/package_arch/TribitsPackageMacros.cmake
@@ -728,6 +728,8 @@ macro(tribits_package_create_all_libs_interface_library)
       endif()
     endforeach()
     #print_var(packageLibsInAllLibsList)
+    global_set(${PACKAGE_NAME}_EXPORTED_PACKAGE_LIBS_NAMES
+      ${packageLibsInAllLibsList})
 
     # Create the ${PACKAGE_NAME}_all_libs INTERFACE interface target
     add_library(${PACKAGE_NAME}_all_libs INTERFACE)

--- a/tribits/core/package_arch/TribitsWriteClientExportFiles.cmake
+++ b/tribits/core/package_arch/TribitsWriteClientExportFiles.cmake
@@ -413,12 +413,18 @@ function(tribits_generate_package_config_file_for_build_tree  packageName)
       # Replace " by \".
       string(REGEX REPLACE "\"" "\\\\\"" CMAKE_CXX_FLAGS_ESCAPED ${CMAKE_CXX_FLAGS})
     endif()
+
+    # Used in configured file below
+    set(EXPORTED_PACKAGE_LIBS_NAMES ${${packageName}_EXPORTED_PACKAGE_LIBS_NAMES})
+    set(PDOLLAR "$")
+
     set(tribitsConfigFilesDir
       "${${PROJECT_NAME}_TRIBITS_DIR}/${TRIBITS_CMAKE_INSTALLATION_FILES_DIR}")
     configure_file(
       "${tribitsConfigFilesDir}/TribitsPackageConfigTemplate.cmake.in"
       "${PARSE_PACKAGE_CONFIG_FOR_BUILD_BASE_DIR}/${packageName}Config.cmake"
       )
+
   endif()
 
 endfunction()
@@ -491,6 +497,10 @@ function(tribits_generate_package_config_file_for_install_tree  packageName)
   endif()
 
   tribits_set_compiler_vars_for_config_file(INSTALL_DIR)
+
+  # Used in configure file below
+  set(EXPORTED_PACKAGE_LIBS_NAMES ${${packageName}_EXPORTED_PACKAGE_LIBS_NAMES})
+  set(PDOLLAR "$")
 
   if (PARSE_PACKAGE_CONFIG_FOR_INSTALL_BASE_DIR)
     configure_file(
@@ -874,6 +884,8 @@ include(\"${${TRIBITS_PACKAGE}_BINARY_DIR}/${TRIBITS_PACKAGE}Config.cmake\")")
 
     # Custom code in configuration file.
     set(PROJECT_CONFIG_CODE "")
+
+    set(PDOLLAR "$")  # Hack used in configure file below
 
     configure_file(
       "${${PROJECT_NAME}_TRIBITS_DIR}/${TRIBITS_CMAKE_INSTALLATION_FILES_DIR}/TribitsProjectConfigTemplate.cmake.in"

--- a/tribits/examples/TribitsOldSimpleExampleApp/CMakeLists.txt
+++ b/tribits/examples/TribitsOldSimpleExampleApp/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.17.1)
+
+project(TribitsOldSimpleExApp
+  DESCRIPTION
+    "Example raw CMake project using packages installed from new or old TribitsExampleProject"
+  VERSION 0.0.0
+  LANGUAGES NONE  # Defined below after reading in compilers
+  )
+
+find_package(TribitsExProj REQUIRED
+  COMPONENTS SimpleCxx MixedLang WithSubpackages)
+
+message("Setting compilers and flags read in from 'TribitsExProjConfig.cmake' file:")
+
+set(CMAKE_CXX_COMPILER ${TribitsExProj_CXX_COMPILER} )
+set(CMAKE_C_COMPILER ${TribitsExProj_C_COMPILER} )
+set(CMAKE_Fortran_COMPILER ${TribitsExProj_Fortran_COMPILER} )
+
+set(CMAKE_CXX_FLAGS "${TribitsExProj_CXX_COMPILER_FLAGS} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_C_FLAGS "${TribitsExProj_C_COMPILER_FLAGS} ${CMAKE_C_FLAGS}")
+set(CMAKE_Fortran_FLAGS "${TribitsExProj_Fortran_COMPILER_FLAGS} ${CMAKE_Fortran_FLAGS}")
+
+# Enable the compilers now that we have gotten them from TribitsExProjConfig.cmake
+enable_language(C)
+enable_language(CXX)
+if (CMAKE_Fortran_COMPILER)
+  enable_language(Fortran)
+endif()
+
+# Build a utility and link to libraries from SimpleCxx package
+add_executable(util util.cpp)
+if (${PROJECT_NAME}_USE_DEPRECATED_TARGETS)
+  target_link_libraries(util PRIVATE pws_b)
+  # NOTE: Above will generate a DEPRECATION warning for newer TriBITS
+  # versions!
+else()
+  target_link_libraries(util PRIVATE ${WithSubpackagesB_LIBRARIES})
+  # NOTE: Above is the correct way to link against libraries from an
+  # individual package for old and new TriBITS!
+endif()
+target_include_directories(util
+  PRIVATE ${SimpleCxx_INCLUDE_DIRS} ${SimpleCxx_TPL_INCLUDE_DIRS})
+
+# Build the APP and link to libraries from TribitsExProj packages
+add_executable(app app.cpp)
+target_link_libraries(app
+  PRIVATE ${TribitsExProj_LIBRARIES})
+target_include_directories(app
+  PRIVATE ${TribitsExProj_INCLUDE_DIRS} ${TribitsExProj_TPL_INCLUDE_DIRS})
+
+# Set up tests
+
+enable_testing()
+
+if ("SimpleTpl" IN_LIST TribitsExProj_TPL_LIST)
+  set(simpleCxxDeps "simpletpl headeronlytpl")
+else()
+  set(simpleCxxDeps "headeronlytpl")
+endif()
+
+add_test(util_test util)
+set_tests_properties(util_test PROPERTIES
+  PASS_REGULAR_EXPRESSION "Util Deps: B A SimpleCxx ${simpleCxxDeps} SimpleCxx ${simpleCxxDeps}"
+  )
+
+add_test(app_test app)
+set_tests_properties(app_test PROPERTIES
+  PASS_REGULAR_EXPRESSION "Full Deps: WithSubpackages:B A SimpleCxx ${simpleCxxDeps} SimpleCxx ${simpleCxxDeps} A SimpleCxx ${simpleCxxDeps}[;] MixedLang:Mixed Language[;] SimpleCxx:${simpleCxxDeps}"
+  )

--- a/tribits/examples/TribitsOldSimpleExampleApp/README.md
+++ b/tribits/examples/TribitsOldSimpleExampleApp/README.md
@@ -1,0 +1,31 @@
+# TribitsOldSimpleExampleApp
+
+Simple example project `TribitsOldSimpleExampleApp` is a raw CMake project
+that pulls in libraries from a few packages from `TribitsExampleProject` using
+just `find_package(TribitsExProj REQUIRED COMPONENTS ...)` but uses the old
+specification for using an installed TriBITS project (i.e. through CMake
+variables `<Project>_LIBRARIES`, `<Project>_INCLUDE_DIRS`, and
+`<Project>_TPL_INCLUDE_DIRS`).
+
+After building and installing TribitsExampleProject under
+`<upstreamInstallDir>`, then configure, build, and test
+`TribitsSimpleExampleApp` with:
+
+```
+  cmake \
+    -DCMAKE_PREFIX_PATH=<upstreamInstallDir> \
+    <base-dir>/TribitsOldSimpleExampleApp
+
+  make
+
+  ctest
+```
+
+This project can be instructed to use the old deprecated targets by adding the
+CMake cache var:
+
+```
+  -D TribitsOldSimpleExApp_USE_DEPRECATED_TARGETS=ON
+```
+
+This will generated deprecated warnings with newer versions of TriBITS.

--- a/tribits/examples/TribitsOldSimpleExampleApp/app.cpp
+++ b/tribits/examples/TribitsOldSimpleExampleApp/app.cpp
@@ -1,0 +1,33 @@
+#include "SimpleCxx_HelloWorld.hpp"
+#include "MixedLang.hpp"
+#include "wsp_c/C.hpp"
+
+#include <iostream>
+#include <string>
+
+
+void appendDepsStr(std::string &depsStr, const std::string &str)
+{
+  if (depsStr.length()) {
+    depsStr += "; "+str;
+  }
+  else {
+    depsStr = str;
+  }
+}
+
+
+int main(int argc, char *argv[]) {
+  // Get deps down the deps graph
+  std::string depsStr;
+  appendDepsStr(depsStr, "WithSubpackages:"+WithSubpackages::depsC());
+  appendDepsStr(depsStr, "MixedLang:"+tribits_mixed::mixedLang());
+  appendDepsStr(depsStr, "SimpleCxx:"+SimpleCxx::deps());
+  // NOTE: The above all call functions from the libraries and requires that
+  // both the header files be found at compile time and the libraries be found
+  // at link time and runtime for this these function calls to work.
+
+  std::cout << "Full Deps: " << depsStr << "\n";
+
+  return 0;
+}

--- a/tribits/examples/TribitsOldSimpleExampleApp/util.cpp
+++ b/tribits/examples/TribitsOldSimpleExampleApp/util.cpp
@@ -1,0 +1,10 @@
+#include "B.hpp"
+
+#include <iostream>
+#include <string>
+
+int main(int argc, char *argv[]) {
+  std::string depsStr = WithSubpackages::getB()+" "+WithSubpackages::depsB();
+  std::cout << "Util Deps: " << depsStr << "\n";
+  return 0;
+}

--- a/tribits/examples/TribitsSimpleExampleApp/CMakeLists.txt
+++ b/tribits/examples/TribitsSimpleExampleApp/CMakeLists.txt
@@ -35,7 +35,15 @@ target_link_libraries(app PRIVATE TribitsExProj::all_selected_libs)
 
 enable_testing()
 
+if ("SimpleTpl" IN_LIST TribitsExProj_TPL_LIST)
+  set(simpleCxxDeps "simpletpl headeronlytpl")
+else()
+  set(simpleCxxDeps "headeronlytpl")
+endif()
+
+add_test(app_test app)
+
 add_test(app_test app)
 set_tests_properties(app_test PROPERTIES
-  PASS_REGULAR_EXPRESSION "Full Deps: WithSubpackages:B A headeronlytpl headeronlytpl; MixedLang:Mixed Language; SimpleCxx:headeronlytpl"
+  PASS_REGULAR_EXPRESSION "Full Deps: WithSubpackages:B A SimpleCxx ${simpleCxxDeps} SimpleCxx ${simpleCxxDeps} A SimpleCxx ${simpleCxxDeps}[;] MixedLang:Mixed Language[;] SimpleCxx:${simpleCxxDeps}"
   )


### PR DESCRIPTION
## Description

This PR adds back the non-namespaced library targets described in https://github.com/TriBITSPub/TriBITS/issues/299#issuecomment-1011558738 using the approach described in https://github.com/TriBITSPub/TriBITS/issues/299#issuecomment-1012363825.

I added a new example/test project `TribitsOldSimpleExampleApp` that uses the old TriBITS interface pull in info and should work with old and new TriBITS.

As shown [here](https://testing.sandia.gov/cdash/test/112405041), the new test ` TriBITS_TribitsOldSimpleExampleApp_STATIC_USE_DEPRECATED_TARGETS` generates the deprecated warning message:

```
-- Configuring done
CMake Warning (dev) at CMakeLists.txt:33 (target_link_libraries):
  The library that is being linked to, pws_b, is marked as being deprecated
  by the owner.  The message provided by the developer is:

  WARNING: The non-namespaced target 'pws_b' is deprecated! If always using
  newer versions of the project 'TribitsExProj', then use the new namespaced
  target 'WithSubpackagesB::pws_b', or better yet,
  'WithSubpackagesB::all_libs' to be less sensitive to changes in the
  definition of targets in the package 'WithSubpackagesB'.  Or, to maintain
  compatibility with older or newer versions the project 'TribitsExProj',
  instead link against the libraries specified by the variable
  'WithSubpackagesB_LIBRARIES'.

This warning is for project developers.  Use -Wno-dev to suppress it.

-- Generating done
```

Hopefully that will be enough to guide users for how to refactor their build systems based on their needs.

See the commits for more details.

 
## How was this tested?

I ran the TriBITS tests locally of course and the GitHub Actions tests will/have run.

I also ran the new `TribitsOldSimpleExampleApp` tests against and older version of `TribitsExampleProject` and TriBITS and it passed the build and ran the executables as shown below.

<details>

<summary><b>Details of TribitsOldSimpleExampleApp tests with older version of TribitsExampleProject  and TriBITS with non-namespaced targts</b> (Click to expand)</summary>

.

Using the older TriBITS version for TribitsExampleProject:

```
$ cd ${HOME}/TriBITS.base/TriBITS/

$ git log-short --name-status -1
881ad33 "Merge pull request #423 from bartlettroscoe/snl-kitware-183-test-measurement"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Wed Sep 29 18:26:07 2021 -0400 (4 months ago)
```

Using the files:

**load-env.sh:**
```
# Env for testing TriBITS on crf450 using Python 2.7.5 (the default on RHEL-7)

module purge

export PATH=${PATH_ORIG}

# From ~/load_dev_env.sh

source ~/load_vera_dev_env.gcc-4.8.3.crf450.sh
module load sems-env
module load sems-git/2.10.1
module load sems-cmake/3.17.1
module load sems-ninja_fortran/1.10.0

# Extra stuff for TriBITS

#export PATH=/home/vera_env/common_tools/cmake-3.17.0/bin:${PATH}
export PATH=/home/vera_env/common_tools/ccache-3.7.9/bin:${PATH}

# Make default install permissions 700 so that we can test that TriBITS will
# use recursive chmod to open up permissions.
umask g-rwx,o-rwx

export TribitsExMetaProj_GIT_URL_REPO_BASE=git@github.com:tribits/
```

**do-configure:**
```
#!/bin/bash

if [ -d CMakeFiles ] ; then
  rm -r CMakeFiles
fi
if [ -e CMakeCache.txt ] ; then
  rm CMakeCache.txt
fi

if [ "$TRIBITS_BASE_DIR" == "" ] ; then
  _ABS_FILE_PATH=`readlink -f $0`
  _SCRIPT_DIR=`dirname $_ABS_FILE_PATH`
  TRIBITS_BASE_DIR=$_SCRIPT_DIR/../../..
fi

${TRIBITS_BASE_DIR}/dev_testing/generic/do-configure-mpi-debug \
-DDART_TESTING_TIMEOUT=85 \
-DCTEST_PARALLEL_LEVEL=16 \
-DTriBITS_CTEST_DRIVER_COVERAGE_TESTS=TRUE \
-DTriBITS_CTEST_DRIVER_MEMORY_TESTS=TRUE \
-DTriBITS_ENABLE_CONFIGURE_TIMING=ON \
-DTriBITS_ENABLE_PACKAGE_CONFIGURE_TIMING=ON \
-DTribitsExProj_INSTALL_BASE_DIR=/tmp/tribits_install_tests \
-DTribitsExProj_INSTALL_OWNING_GROUP=wg-sems-users-son \
-DTriBITS_ENABLE_REAL_GIT_CLONE_TESTS=ON \
-DTriBITS_SHOW_TEST_START_END_DATE_TIME=ON \
"$@"
```

I ran:

```
$ cd ${HOME}/Trilinos.base/BUILDS/GCC-4.8.3/TRIBITS_MPI_DEBUG/

$  . load-env.sh

$ ./do-configure \
  -DTribitsOldSimpleExampleApp_TribitsExampleProject_TRIBITS_DIR=${HOME}/TriBITS/tribits

$ make && ctest -j16 -R TribitsOldSimpleExampleApp

...

0% tests passed, 2 tests failed out of 2

Subproject Time Summary:
TriBITS    =  57.36 sec*proc (2 tests)

Total Test time (real) =  28.87 sec

The following tests FAILED:
        247 - TriBITS_TribitsOldSimpleExampleApp_STATIC_USE_DEPRECATED_TARGETS (Failed)
        248 - TriBITS_TribitsOldSimpleExampleApp_SHARED_USE_NEW_TARGETS (Failed)
```

but only the regex checks at the end failed, the build of the APP passed as shown by:

```
$ grep "\[FAILED\]" Testing/Temporary/LastTest.log 
TEST_4: Pass criteria = Match REGEX {Full Deps: WithSubpackages:B A SimpleCxx simpletpl headeronlytpl SimpleCxx simpletpl headeronlytpl A SimpleCxx simpletpl headeronlytpl[;] MixedLang:Mixed Language[;] SimpleCxx:simpletpl headeronlytpl} [FAILED]
TEST_4: Pass criteria = Match REGEX {util_test [.]+   Passed} [FAILED]
TEST_4: Pass criteria = Match REGEX {app_test [.]+   Passed} [FAILED]
TEST_4: Pass criteria = Match REGEX {100% tests passed, 0 tests failed out of 2} [FAILED]
TEST_4: Pass criteria = ALWAYS_FAIL_ON_NONZERO_RETURN [FAILED]
```

</details>

So this shows that new TriBITS satisfies the old TriBITS interface using the variables and even the non-namespaced targets and and downstream clients can work with both old and new versions by using the variables.

I also tested against the older version of Albany before the merge of https://github.com/sandialabs/Albany/pull/778 as described in [internal tribitsrefactoring#1](https://cee-gitlab.sandia.gov/rabartl/tribitsrefactoring/-/issues/1#note_2131472).  And it showed the deprecation warning:

```
CMake Warning (dev) at src/CMakeLists.txt:199 (target_link_libraries):
  The library that is being linked to, teuchosparameterlist, is marked as
  being deprecated by the owner.  The message provided by the developer is:

  WARNING: The non-namespaced target 'teuchosparameterlist' is deprecated! If
  always using newer versions of the project 'Trilinos', then use the new
  namespaced target 'TeuchosParameterList::teuchosparameterlist', or better
  yet, 'TeuchosParameterList::all_libs' to be less sensitive to changes in
  the definition of targets in the package 'TeuchosParameterList'.  Or, to
  maintain compatibility with older or newer versions the project 'Trilinos',
  instead link against the libraries specified by the variable
  'TeuchosParameterList_LIBRARIES'.

This warning is for project developers.  Use -Wno-dev to suppress it.
```



