### PR TITLE
Give TribitsSimpleExampleApp the utils program to match TribitsOldSimpleExampleApp (#299)

### DIFF
--- a/test/core/ExamplesUnitTests/TribitsSimpleExampleApp_Tests.cmake
+++ b/test/core/ExamplesUnitTests/TribitsSimpleExampleApp_Tests.cmake
@@ -123,9 +123,11 @@ function(TribitsSimpleExampleApp_ALL_ST_test sharedOrStatic)
       SKIP_CLEAN_WORKING_DIRECTORY
       CMND ${CMAKE_CTEST_COMMAND} ARGS -VV
       PASS_REGULAR_EXPRESSION_ALL
+        "Util Deps: B A SimpleCxx simpletpl headeronlytpl SimpleCxx simpletpl headeronlytpl"
         "Full Deps: WithSubpackages:B A SimpleCxx simpletpl headeronlytpl SimpleCxx simpletpl headeronlytpl A SimpleCxx simpletpl headeronlytpl[;] MixedLang:Mixed Language[;] SimpleCxx:simpletpl headeronlytpl"
+        "util_test [.]+   Passed"
         "app_test [.]+   Passed"
-        "100% tests passed, 0 tests failed out of 1"
+        "100% tests passed, 0 tests failed out of 2"
       ALWAYS_FAIL_ON_NONZERO_RETURN
 
     ${LD_LIBRARY_PATH_HACK_FOR_SIMPLETPL_${sharedOrStatic}_ENVIRONMENT_ARG}

--- a/tribits/examples/TribitsOldSimpleExampleApp/CMakeLists.txt
+++ b/tribits/examples/TribitsOldSimpleExampleApp/CMakeLists.txt
@@ -58,12 +58,12 @@ else()
   set(simpleCxxDeps "headeronlytpl")
 endif()
 
-add_test(util_test util)
+add_test(NAME util_test COMMAND util)
 set_tests_properties(util_test PROPERTIES
   PASS_REGULAR_EXPRESSION "Util Deps: B A SimpleCxx ${simpleCxxDeps} SimpleCxx ${simpleCxxDeps}"
   )
 
-add_test(app_test app)
+add_test(NAME app_test COMMAND app)
 set_tests_properties(app_test PROPERTIES
   PASS_REGULAR_EXPRESSION "Full Deps: WithSubpackages:B A SimpleCxx ${simpleCxxDeps} SimpleCxx ${simpleCxxDeps} A SimpleCxx ${simpleCxxDeps}[;] MixedLang:Mixed Language[;] SimpleCxx:${simpleCxxDeps}"
   )

--- a/tribits/examples/TribitsOldSimpleExampleApp/CMakeLists.txt
+++ b/tribits/examples/TribitsOldSimpleExampleApp/CMakeLists.txt
@@ -27,7 +27,7 @@ if (CMAKE_Fortran_COMPILER)
   enable_language(Fortran)
 endif()
 
-# Build a utility and link to libraries from SimpleCxx package
+# Build a utility and link to libraries from WithSubpackagesB
 add_executable(util util.cpp)
 if (${PROJECT_NAME}_USE_DEPRECATED_TARGETS)
   target_link_libraries(util PRIVATE pws_b)

--- a/tribits/examples/TribitsOldSimpleExampleApp/README.md
+++ b/tribits/examples/TribitsOldSimpleExampleApp/README.md
@@ -1,15 +1,16 @@
 # TribitsOldSimpleExampleApp
 
-Simple example project `TribitsOldSimpleExampleApp` is a raw CMake project
-that pulls in libraries from a few packages from `TribitsExampleProject` using
-just `find_package(TribitsExProj REQUIRED COMPONENTS ...)` but uses the old
+This simple example project `TribitsOldSimpleExampleApp` is a raw CMake
+project that pulls in libraries from a few packages from
+[`TribitsExampleProject`](../TribitsExampleProject/README.md) using just
+`find_package(TribitsExProj REQUIRED COMPONENTS ...)` but uses the old
 specification for using an installed TriBITS project (i.e. through CMake
 variables `<Project>_LIBRARIES`, `<Project>_INCLUDE_DIRS`, and
 `<Project>_TPL_INCLUDE_DIRS`).
 
 After building and installing TribitsExampleProject under
 `<upstreamInstallDir>`, then configure, build, and test
-`TribitsSimpleExampleApp` with:
+`TribitsOldSimpleExampleApp` with:
 
 ```
   cmake \
@@ -21,11 +22,21 @@ After building and installing TribitsExampleProject under
   ctest
 ```
 
-This project can be instructed to use the old deprecated targets by adding the
-CMake cache var:
+This project can be instructed to use the non-namespaced old deprecated
+targets by adding the CMake cache var:
 
 ```
   -D TribitsOldSimpleExApp_USE_DEPRECATED_TARGETS=ON
 ```
 
-This will generated deprecated warnings with newer versions of TriBITS.
+This will generated deprecated warnings with newer versions of TriBITS.  (This
+is to demonstrate and test these deprecated non-namespaced targets and to
+demonstrate how to remove the deprecated warnings in a downstream customer
+CMake project.)
+
+NOTE: The modern version of this project using the modern CMake targets
+produced by `TribitsExampleProject` is
+[`TribitsSimpleExampleApp`](../TribitsSimpleExampleApp/README.md).  Comparing
+the `CMakeLists.txt` files in these two projects (e.g. [here](CMakeLists.txt)
+and [here](../TribitsSimpleExampleApp/CMakeLists.txt)) demonstrates the
+simplifications afforded by the namespaced modern CMake targets.

--- a/tribits/examples/TribitsSimpleExampleApp/CMakeLists.txt
+++ b/tribits/examples/TribitsSimpleExampleApp/CMakeLists.txt
@@ -27,6 +27,10 @@ if (CMAKE_Fortran_COMPILER)
   enable_language(Fortran)
 endif()
 
+# Build a utility and link to libraries from WithSubpackagesB
+add_executable(util util.cpp)
+target_link_libraries(util PRIVATE WithSubpackagesB::all_libs)
+
 # Build the APP and link to libraries from TribitsExProj packages
 add_executable(app app.cpp)
 target_link_libraries(app PRIVATE TribitsExProj::all_selected_libs)
@@ -41,9 +45,12 @@ else()
   set(simpleCxxDeps "headeronlytpl")
 endif()
 
-add_test(app_test app)
+add_test(NAME util_test COMMAND util)
+set_tests_properties(util_test PROPERTIES
+  PASS_REGULAR_EXPRESSION "Util Deps: B A SimpleCxx ${simpleCxxDeps} SimpleCxx ${simpleCxxDeps}"
+  )
 
-add_test(app_test app)
+add_test(NAME app_test COMMAND app)
 set_tests_properties(app_test PROPERTIES
   PASS_REGULAR_EXPRESSION "Full Deps: WithSubpackages:B A SimpleCxx ${simpleCxxDeps} SimpleCxx ${simpleCxxDeps} A SimpleCxx ${simpleCxxDeps}[;] MixedLang:Mixed Language[;] SimpleCxx:${simpleCxxDeps}"
   )

--- a/tribits/examples/TribitsSimpleExampleApp/README.md
+++ b/tribits/examples/TribitsSimpleExampleApp/README.md
@@ -1,10 +1,13 @@
 # TribitsSimpleExampleApp
 
-Simple example project `TribitsSimpleExampleApp` is a raw CMake project that
-pulls in libraries from a few packages from `TribitsExampleProject` using just
-`find_package(TribitsExProj REQUIRED COMPONENTS ...)`.
+This simple example project `TribitsSimpleExampleApp` is a raw CMake project
+that pulls in libraries from a few packages from
+[`TribitsExampleProject`](../TribitsExampleProject/README.md) using just
+`find_package(TribitsExProj REQUIRED COMPONENTS ...)` and also links a smaller
+program using a subset of the libraries from one of the packages from
+`TribitsExampleProject`.
 
-After building and installing TribitsExampleProject under
+After building and installing `TribitsExampleProject` under
 `<upstreamInstallDir>`, then configure, build, and test
 `TribitsSimpleExampleApp` with:
 
@@ -17,3 +20,7 @@ After building and installing TribitsExampleProject under
 
   ctest
 ```
+
+NOTE: The version of this project that demonstrates using the old interface
+using variables that works with much older versions of TriBITS is given in
+[`TribitsOldSimpleExampleApp`](../TribitsOldSimpleExampleApp/README.md).

--- a/tribits/examples/TribitsSimpleExampleApp/util.cpp
+++ b/tribits/examples/TribitsSimpleExampleApp/util.cpp
@@ -1,0 +1,10 @@
+#include "B.hpp"
+
+#include <iostream>
+#include <string>
+
+int main(int argc, char *argv[]) {
+  std::string depsStr = WithSubpackages::getB()+" "+WithSubpackages::depsB();
+  std::cout << "Util Deps: " << depsStr << "\n";
+  return 0;
+}


### PR DESCRIPTION
This makes the TribitsSimpleExampleApp and TribitsOldSimpleExampleApp identical except the former uses the new targets namespaced modern TriBITS targets and the latter uses the old backward-compatible variables that work with new and old TriBITS-based TribitsExampleProject.

See the individual commits and commit logs for more details.
