### PR TITLE
Indicated the role of target_link_libraries in 8.7 section

### DIFF
--- a/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
+++ b/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
@@ -3738,7 +3738,7 @@ CMake project's ``CMakeLists.txt`` file as usual using, for example::
     PRIVATE <Package2>::all_libs
     )
 
-Note that in this case, ``<target_link_libraries>`` ensures that the include
+Note that in this case, ``target_link_libraries()`` ensures that the include
 directories and other imported compiler options from the source tree and the
 build tree are automatically injected into the build targets associated with
 the ``<downstream-target>`` object compile lines and link lines.

--- a/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
+++ b/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
@@ -3738,10 +3738,10 @@ CMake project's ``CMakeLists.txt`` file as usual using, for example::
     PRIVATE <Package2>::all_libs
     )
 
-Note that in this case, the include directories and other imported compiler
-options from the source tree and the build tree are automatically injected
-into the build targets associated with the ``<downstream-target>`` object
-compile lines and link lines.
+Note that in this case, ``<target_link_libraries>`` ensures that the include
+directories and other imported compiler options from the source tree and the
+build tree are automatically injected into the build targets associated with
+the ``<downstream-target>`` object compile lines and link lines.
 
 Also note that package config files for all of the enabled external
 packages/TPLs will also be written into the build tree under


### PR DESCRIPTION
Modification of  TribitsBuildReferenceBody.rst section 8.7 to indicat the role of target_link_libraries