### PR TITLE
Improve TribitsExampleProject and TribitsExampleApp readme

### DIFF
--- a/tribits/examples/TribitsExampleApp/README.md
+++ b/tribits/examples/TribitsExampleApp/README.md
@@ -1,10 +1,11 @@
 # TribitsExampleApp
 
 The example project `TribitsExampleApp` is a raw CMake project that pulls in
-libraries from packages from `TribitsExampleProject`. If subpackage C of 
-`TribitsExampleProject` was build, then Fortran compiler is required to build
-`TribitsExampleApp`. To build against all of the installed packages from an 
-upstream `TribitsExampleProject`, configure, build, and run the tests with:
+libraries from packages from `TribitsExampleProject`. If `WithSubpackageC` 
+subpackage or the `MixedLang` packages are built, then a Fortran compiler 
+is required to build `TribitsExampleApp`. To build against all of the 
+installed packages from an upstream `TribitsExampleProject`, configure, 
+build, and run the tests with:
 
 ```
   cmake \

--- a/tribits/examples/TribitsExampleApp/README.md
+++ b/tribits/examples/TribitsExampleApp/README.md
@@ -1,9 +1,10 @@
 # TribitsExampleApp
 
 The example project `TribitsExampleApp` is a raw CMake project that pulls in
-libraries from packages from `TribitsExampleProject`.  To build against all of
-the installed packages from an upstream `TribitsExampleProject`, configure,
-build, and run the tests with:
+libraries from packages from `TribitsExampleProject`. If subpackage C of 
+`TribitsExampleProject` was build, then Fortran compiler is required to build
+`TribitsExampleApp`. To build against all of the installed packages from an 
+upstream `TribitsExampleProject`, configure, build, and run the tests with:
 
 ```
   cmake \

--- a/tribits/examples/TribitsExampleProject/README.md
+++ b/tribits/examples/TribitsExampleProject/README.md
@@ -18,6 +18,7 @@ with:
   
   cmake \
     -DTribitsExProj_TRIBITS_DIR=<tribits-dir> \
+    -DCMAKE_INSTALL_PREFIX=<TribitsExampleProject-install-dir>
     -DTribitsExProj_ENABLE_TESTS=ON \
     -DTribitsExProj_ENABLE_ALL_PACKAGES=ON
     -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON \
@@ -34,12 +35,12 @@ then build and test with:
 and then install:
 
 ```
-  make DESTDIR=<path-to-install-dir> install
+  make install
 ```
 
 `TribitsExampleProject` will be installed to 
-`<path-to-install-dir>/usr/local/` and this path should be then used 
-to point `-DCMAKE_PREFIX_PATH=<path-to-install-dir>/usr/local/` when
+`<TribitsExampleProject-install-dir>` and this path should be then used 
+to point `-DCMAKE_PREFIX_PATH=<TribitsExampleProject-install-dir>` when
 building e.g. `TribitsExampleApp`
 
 The layout of a TriBITS project is described in:

--- a/tribits/examples/TribitsExampleProject/README.md
+++ b/tribits/examples/TribitsExampleProject/README.md
@@ -3,7 +3,7 @@
 The project `TribitsExampleProject` defines a TriBITS CMake project designed to
 provide a simple example to demonstrate how to use the TriBITS system to
 create a CMake build, test, and deployment system using a package-based
-architecture.
+architecture. To build `TribitsExampleProject` Fortran compiler is needed.
 
 To build and test the project, one must first create a build directory and
 configure by pointing to the TriBITS source dir `<tribits-dir>`
@@ -19,15 +19,27 @@ with:
     -DTribitsExProj_TRIBITS_DIR=<tribits-dir> \
     -DTribitsExProj_ENABLE_TESTS=ON \
     -DTribitsExProj_ENABLE_ALL_PACKAGES=ON
+    -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON \
     -DCMAKE_CXX_COMPILER=g++ \
     <path-to-TribitsExampleProject>
 ```
 
-and then build and test with:
+then build and test with:
 
 ```
   make -j4 && ctest -j4
 ```
+
+and then install:
+
+```
+  make DESTDIR=<path-to-install-dir> install
+```
+
+`TribitsExampleProject` will be installed to 
+`<path-to-install-dir>/usr/local/` and this path should be then used 
+to point `-DCMAKE_PREFIX_PATH=<path-to-install-dir>/usr/local/` when
+building e.g. `TribitsExampleApp`
 
 The layout of a TriBITS project is described in:
 

--- a/tribits/examples/TribitsExampleProject/README.md
+++ b/tribits/examples/TribitsExampleProject/README.md
@@ -3,7 +3,8 @@
 The project `TribitsExampleProject` defines a TriBITS CMake project designed to
 provide a simple example to demonstrate how to use the TriBITS system to
 create a CMake build, test, and deployment system using a package-based
-architecture. To build `TribitsExampleProject` Fortran compiler is needed.
+architecture. To build all of the packages from `TribitsExampleProject`,
+a Fortran compiler is needed.
 
 To build and test the project, one must first create a build directory and
 configure by pointing to the TriBITS source dir `<tribits-dir>`


### PR DESCRIPTION
- added `TribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON` as default
- added installation description
- added information regarding Fortran