### PR TITLE
Make install DESTINATION relative for stuff

### DIFF
--- a/tribits/examples/TribitsExampleProject/packages/with_subpackages/b/CMakeLists.txt
+++ b/tribits/examples/TribitsExampleProject/packages/with_subpackages/b/CMakeLists.txt
@@ -26,7 +26,7 @@ global_set(EXPECTED_B_DEPS
 tribits_add_test_directories(tests)
 
 install( DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/stuff"
-  DESTINATION "${CMAKE_INSTALL_PREFIX}/share/${PACKAGE_NAME}"
+  DESTINATION "share/${PACKAGE_NAME}"
   USE_SOURCE_PERMISSIONS PATTERN "*~" EXCLUDE )
 # Above, we must use 'USE_SOURCE_PERMISSIONS' to preserve the executable
 # permission on the scripts in that directory.  (TriBITS will add commands to


### PR DESCRIPTION
This makes:

```
cmake --install . --prefix <install-prefix>
```

work correctly.

Turns out that install rules should be defined carefully so that `install(  ... DESTINATION <dest> ... )` is relative when possible (unless someone overrides this explicitly).

I tested this manually and with this change, everything in TribitsExampleProject seemed to install under the new `<install-prefix>` correctly.

