### PR TITLE
Some more fixups for snapshot-dir.py (#160)

### DIFF
--- a/test/python_utils/SnapshotDir_UnitTests.py
+++ b/test/python_utils/SnapshotDir_UnitTests.py
@@ -37,6 +37,7 @@
 # ************************************************************************
 # @HEADER
 
+
 ########################################
 # Unit testing code for SnapshotDir.py #
 ########################################
@@ -111,7 +112,11 @@ g_gitDiffHead = "IT: git diff --name-status HEAD -- \.; 0;''\n"
 
 g_gitRevParse = "IT: git rev-parse --abbrev-ref --symbolic-full-name ..u.; 0; 'remotename/remotebranch'\n"
 
+g_gitRevParseDetailedHead = "IT: git rev-parse --abbrev-ref --symbolic-full-name ..u.; 1; ''\n"
+
 g_gitRemote = "IT: git remote -v; 0; 'remotename\tsome-url-location (fetch)'\n"
+
+g_gitDescribe = "IT: git describe; 0; 'v1.2.3-225-g9877045'\n"
 
 g_gitLog = "IT: git log  --pretty=.*; 0; 'one commit msg'\n"
 
@@ -184,6 +189,7 @@ class test_snapshot_dir(unittest.TestCase):
         g_gitDiffHead,
         g_gitRevParse,
         g_gitRemote,
+        g_gitDescribe,
         g_gitLog,
         g_rsync,
         g_gitLogSha1,
@@ -197,8 +203,40 @@ class test_snapshot_dir(unittest.TestCase):
         "origin remote name = 'remotename'",
         "origin remote branch = 'remotebranch'",
         "origin remote URL = 'some-url-location'",
+        "Git describe = 'v1.2.3-225-g9877045'",
         "Automatic snapshot commit from orig-dir at abc123",
         "Origin repo remote tracking branch: 'remotename/remotebranch'",
+        "Origin repo remote repo URL: 'remotename = some-url-location'",
+        "one commit msg"
+        ]
+     )
+
+
+  def test_snapshot_detached_head(self):
+    runSnapshotDirTestCase(
+      self,
+      ["--orig-dir=dummy/orig-dir/", "--dest-dir=dummy/dest-dir/"],
+      [
+        g_gitDiffHead,
+        g_gitDiffHead,
+        g_gitRevParseDetailedHead,
+        g_gitRemote,
+        g_gitDescribe,
+        g_gitLog,
+        g_rsync,
+        g_gitLogSha1,
+        g_gitAdd,
+        g_gitCommit,
+        ],
+      [
+        "Script: snapshot-dir\.py",
+        "--orig-dir='dummy/orig-dir/'",
+        "--dest-dir='dummy/dest-dir/'",
+        "origin remote name = 'remotename'",
+        "origin remote branch = ''",
+        "origin remote URL = 'some-url-location'",
+        "Git describe = 'v1.2.3-225-g9877045'",
+        "Automatic snapshot commit from orig-dir at abc123",
         "Origin repo remote repo URL: 'remotename = some-url-location'",
         "one commit msg"
         ]
@@ -214,6 +252,7 @@ class test_snapshot_dir(unittest.TestCase):
         g_gitDiffHead,
         g_gitRevParse,
         g_gitRemote,
+        g_gitDescribe,
         g_gitLog,
         g_rsync,
         g_gitLogSha1,
@@ -238,6 +277,7 @@ class test_snapshot_dir(unittest.TestCase):
         g_gitDiffHead,
         g_gitRevParse,
         g_gitRemote,
+        g_gitDescribe,
         g_gitLog,
         g_rsync,
         g_gitLogSha1,
@@ -271,6 +311,7 @@ class test_snapshot_dir(unittest.TestCase):
         g_gitClean,
         g_gitRevParse,
         g_gitRemote,
+        g_gitDescribe,
         g_gitLog,
         g_rsync,
         g_gitLogSha1,
@@ -293,6 +334,7 @@ class test_snapshot_dir(unittest.TestCase):
         g_gitDiffHead,
         g_gitRevParse,
         g_gitRemote,
+        g_gitDescribe,
         g_gitLog,
         g_rsync,
         g_gitLogSha1,

--- a/test/python_utils/SnapshotDir_UnitTests.py
+++ b/test/python_utils/SnapshotDir_UnitTests.py
@@ -383,6 +383,27 @@ class test_snapshot_dir(unittest.TestCase):
      )
 
 
+  def test_snapshot_skip_commit(self):
+    runSnapshotDirTestCase(
+      self,
+      ["--orig-dir=dummy/orig-dir/", "--dest-dir=dummy/dest-dir/",
+        "--skip-commit"],
+      [
+        g_gitDiffHead,
+        g_gitDiffHead,
+        g_gitRevParse,
+        g_gitRemote,
+        g_gitDescribe,
+        g_gitLog,
+        g_rsync,
+        g_gitLogSha1,
+        ],
+      [
+        "Skipping commit on request"
+        ]
+     )
+
+
   # ToDo: Test assert failure of clean origDir ...
 
   # ToDo: Test skipping test of clean origDir ...
@@ -395,13 +416,7 @@ class test_snapshot_dir(unittest.TestCase):
 
   # ToDo: Test failure to acquire origin commit ...
 
-  # ToDo: Test skipping getting origin info ...
-
-  # ToDo: Test failing rsync ...
-
   # ToDo: Test failing to create commit in dest repo ...
-
-  # ToDo: Test skipping creation of commit in dest repo ...
 
 
 if __name__ == '__main__':

--- a/test/python_utils/SnapshotDir_UnitTests.py
+++ b/test/python_utils/SnapshotDir_UnitTests.py
@@ -91,6 +91,7 @@ def runSnapshotDirTestCase(testObject, cmndLineArgsList, cmndInterceptList,
   sout = WriteToString()
 
   rtn = snapshotDirMainDriver(cmndLineArgsList, defaultOptions, sout)
+  g_sysCmndInterceptor.assertAllCommandsRun()
   ostr = sout.getStr()
   #print("ostr =", ostr)
   for passRegexExpr in passRegexExpressionsList:

--- a/test/python_utils/SnapshotDir_UnitTests.py
+++ b/test/python_utils/SnapshotDir_UnitTests.py
@@ -75,6 +75,9 @@ def getDummyDefaultOptions():
   return dummyDefaultOptions
 
 
+# Run a snapshot-dir.py test case using mock commands all in memory without
+# actually doing anyting on the disk or the filesystem.
+#
 def runSnapshotDirTestCase(testObject, cmndLineArgsList, cmndInterceptList,
   passRegexExpressionsList, defaultOptions=None \
   ):

--- a/test/python_utils/SnapshotDir_UnitTests.py
+++ b/test/python_utils/SnapshotDir_UnitTests.py
@@ -212,6 +212,38 @@ class test_snapshot_dir(unittest.TestCase):
      )
 
 
+  def test_snapshot_default_no_op(self):
+    runSnapshotDirTestCase(
+      self,
+      ["--orig-dir=dummy/orig-dir/", "--dest-dir=dummy/dest-dir/", "--no-op"],
+      [
+        g_gitDiffHead,
+        g_gitDiffHead,
+        g_gitRevParse,
+        g_gitRemote,
+        g_gitDescribe,
+        g_gitLog,
+        g_gitLogSha1,
+        ],
+      [
+        "Script: snapshot-dir\.py",
+        "--orig-dir='dummy/orig-dir/'",
+        "--dest-dir='dummy/dest-dir/'",
+        "origin remote name = 'remotename'",
+        "origin remote branch = 'remotebranch'",
+        "origin remote URL = 'some-url-location'",
+        "Git describe = 'v1.2.3-225-g9877045'",
+        "Would be running: rsync -cav --delete --exclude=\\\[.]git dummy/orig-dir/ dummy/dest-dir/",
+        "Automatic snapshot commit from orig-dir at abc123",
+        "Origin repo remote tracking branch: 'remotename/remotebranch'",
+        "Origin repo remote repo URL: 'remotename = some-url-location'",
+        "one commit msg",
+        "Would be running: git add .",
+        "Would be running: git commit -m \"<commit-msg>\"",
+        ]
+     )
+
+
   def test_snapshot_detached_head(self):
     runSnapshotDirTestCase(
       self,

--- a/tribits/python_utils/SnapshotDir.py
+++ b/tribits/python_utils/SnapshotDir.py
@@ -235,7 +235,7 @@ WARNINGS:
 * Make sure that the top commit in orig-dir has been pushed (or will be
   pushed) to the listed remote git repo showed in the output line 'origin
   remote name' or 'origin remote URL'.  Otherwise, others will not be able to
-  trace that exact version by cloning that repo and tracability is lost.
+  trace that exact version by cloning that repo and traceability is lost.
 
 * Make sure that dest-dir is a non-ignored subdir of the destination git repo
   and does not contain any ignored subdirs or files that you don't care if
@@ -244,13 +244,22 @@ WARNINGS:
   files in dest-dir are not under version control, they will not be
   recoverable.)
 
+* As a corollary to the above warnings about ignored files and directories, do
+  not snapshot from an orig-dir or to a dest-dir that contain build
+  directories or other generated files that you want to keep!  Even if those
+  files and directories are ignored in copied-over .gitignore files, the copy
+  of those ignored files will still occur. (Just another reason to keep your
+  build directories completely outside of the source tree!)
+
 """
 
 
-#
 # Direct script driver (taking in command-line arguments)
 #
-
+# This runs given a set of command-line arguments and a stream to do
+# outputting to.  This allows running an a unit testing environment very
+# efficiently.
+#
 def snapshotDirMainDriver(cmndLineArgs, defaultOptionsIn = None, stdout = None):
 
   oldstdout = sys.stdout
@@ -699,3 +708,5 @@ def getLastCommitMsg(gitDir):
     +" -1 -- .",
     workingDir=gitDir
     )
+
+#  LocalWords:  traceability TriBITS Snapshotting snapshotting

--- a/tribits/python_utils/SnapshotDir.py
+++ b/tribits/python_utils/SnapshotDir.py
@@ -85,37 +85,47 @@ class DefaultOptions:
 #
 
 usageHelp = r"""
-This tool snapshots the contents of an origin directory ('orig-dir') to
-destination directory ('dest-dir') and logs version information between the
-two git repos in the commit message in the 'dest-dir' git commit.  The command
-'git' must be in the path for this script to be used.
 
-To sync between any two arbitrary directories invoking this script from any
-directory location, one can do:
+This tool uses rsync and some git commands to snapshot the contents of an
+origin directory ('orig-dir') in one Git repo to destination directory
+('dest-dir') in another Git repo and logs version information in a new Git
+commit message.
+
+WARNING: Because this tool uses 'rsync --delete', it can be quite destructive
+to the contents of dest-dir if one is not careful and selects the wrong
+orig-dir or wrong dest-dir!  Therefore, please carefully read this entire help
+message and especially the warnings given below and always start by running
+with --no-op!
+
+To sync between any two arbitrary directories between two different git repos
+invoking this script from any directory location, one can do:
 
   $ <some-base-dir>/snapshot-dir.py \
-    --orig-dir=<some-orig-dir> \
-    --dest-dir=<some-dest-dir>
+    --orig-dir=<dest-dir> \
+    --dest-dir=<dest-dir> \
+    [--no-op]
+
+(where --no-op should be used on the initial trial run to check that the
+correct rsync and other commands will be run, see below).
 
 To describe how this script is used, consider the desire to snapshot the
-directory tree:
+directory tree from one git repo:
 
   <some-orig-base-dir>/orig-dir/
 
-and duplicate it in the directory tree
+and exactly duplicate it in another git repo under:
 
   <some-dest-base-dir>/dest-dir/
 
 Here, the directories can be any two directories from local git repos with any
-names. (Note if the paths don't end with '/', then it will be added or rsync
-will copy the contents from 'orig-dir' into a subdir of 'dest-dir' which is
-usually not what you want.)
+names. (Note if the paths don't end with '/', then '/' will be added.
+Otherwise, rsync will copy the contents from 'orig-dir' into a subdir of
+'dest-dir' which is usually not what you want.)
 
 A typical case is to have snapshot-dir.py soft linked into orig-dir/ to allow
-a simple sync process.  This is the case, for example, with the 'tribits'
-source tree.  The linked-in location of snapshot-dir.py gives the default
-'orig-dir' directory automatically (but can be overridden with --orig-dir
-option).
+a simple sync process.  The linked-in location of snapshot-dir.py gives the
+default 'orig-dir' directory automatically (but can be overridden with
+--orig-dir=<orig-dir> option).
 
 When snapshot-dir.py is soft-linked into the 'orig-dir' directory base, the
 way to run this script would be:
@@ -130,56 +140,72 @@ provide tractability for the versions (see below).
 
 By default, this script does the following:
 
-1) Assert that the git repo for 'orig-dir' is clean (i.e. no uncommitted
-   files, no unknown files, etc.).  (Can be disabled by passing in
-   --allow-dirty-orig-dir.)
+1) Assert that 'orig-dir' in its git repo is clean (i.e. no uncommitted
+   files).  (Can be disabled by passing in --allow-dirty-orig-dir.)
 
-2) Assert that the git repo for <some-dest-dir>/ is clean (see above).  (Can
-   be disabled by passing in --allow-dirty-dest-dir.  Also, this must be
-   skipped on the initial snaphsot where <some-dist-dir>/ does not exist.)
+2) Assert that <dest-dir>/ in its git repo is clean (same checks as for
+   'orig-dir' above).  (Can be disabled by passing in --allow-dirty-dest-dir.
+   Also, this must be skipped on the initial snapshot where <some-dist-dir>/
+   does not exist yet.)
 
 3) Clean out the ignored files from <some-source-dir>/orig-dir using 'git
    clean -xdf' run in that directory.  (Only if --clean-ignored-files-orig-dir
-   is specified.)
+   is passed.)
 
-4) Run 'rsync -cav --delete' to copy the contents from 'orig-dir' to
-   'dest-dir', excluding the '.git/' directory if it exists in either git repo
-   dir.  After this runs, <some-dest-dir>/ should be an exact duplicate of
-   <some-orig-dir>/ (except for otherwise noted excluded files).  This rsync
-   will delete any files in 'dest-dir' that are not in 'orig-dir'.  Note that
-   if there are ignored untracked files, then the copied .gitignore files
-   should avoid showing them as tracked or unknown files in the 'dest-dir' git
-   repo as well.
+4) Run 'rsync -cav --delete [other options] <orig-dir>/ <dest-dir>/' to copy
+   the contents from 'orig-dir' to 'dest-dir', excluding the '.git/' directory
+   if it exists in either git repo dir.  After this runs, <dest-dir>/ should
+   be an exact duplicate of <orig-dir>/ (except for otherwise noted excluded
+   files).  This rsync will delete any files in 'dest-dir' that are not in
+   'orig-dir'.  Note that if there are any ignored untracked files in
+   'orig-dir' that get copied over, then the copied .gitignore files should
+   avoid treating them as tracked files in the 'dest-dir' git repo.  (The
+   rsync command is skipped if the argument --no-op is passed.)
 
-5) Run 'git add .' in <some-dest-dir>/ to stage any new files.  Note that git
-   will automatically stage deletes for any files removed by the 'rsync -cav
-   --delete' command!
+5) Run 'git add .' in <dest-dir>/ to stage any files copied over.  (Note that
+   git will automatically stage deletes for any files removed by the 'rsync
+   -cav --delete' command.  Also note that any untracked, unknown or ignored
+   files in 'orig-dir' that get copied over and are not ignored in 'dist-dir'
+   in the copied-over '.gitignore' files, or other git ignore files in
+   'dist-dir', then they will be added to the new commit in 'dist-dir'.)
 
 6) Get the git remote URL from the orig-dir git repo, and the git log for the
-   last commit for the directory from orig-dir.  This information is used to
-   define perfect tracing of the version info when doing the snapshot.
+   last commit for the directory orig-dir from its git repo.  (If the orig-dir
+   repo is on a tracking branch, then this remote will be guaranteed to be
+   correct.  However, if the orig-dir repo not on a tracking branch, then the
+   first remote returned from 'git remote -v' will be used. This information
+   is used to provide tractability of the version info back to the originating
+   git repo in the commit created in the dest-dir repo.)
 
 7) Commit the updated dest-dir directory using a commit message with the
-   orig-dir repo URL and log info.  This will only commit files in 'dest-dir'
-   and not in other directories in the destination git repo!
+   orig-dir snapshot version info.  (This will only commit files in 'dest-dir'
+   and not in other directories in the destination git repo!)  (The 'git
+   commit' will be skipped if the options --skip-commit or --no-op are
+   passed.)
 
 NOTES:
 
-* On the first creation of <some-dest-dir>/, one must pass in
-  --allow-dirty-dest-dir to avoid checks of <some-dest-dir>/.  This will allow
-  the creation of <some-dest-dir>/ by rsync.
+* When first running this tool, use the --no-op option to see what commands
+  would be run without actually performing any mutable operations.  Especially
+  pay attention to the rsync command that would be run and make sure it is
+  operating on the desired directories.
+
+* On the first creation of <dest-dir>/, one must pass in
+  --allow-dirty-dest-dir to avoid checks of <dest-dir>/ (because it does not yet
+  exist).
 
 * This script allows the syncing between base git repos or subdirs within git
   repos.  This is allowed because the rsync command is told to ignore the
   .git/ directory when syncing.
 
-* The cleaning of the orig-dir/ using 'git clean -xdf' may be somewhat
-  dangerous but it is recommended that it be performed by passing in
-  --clean-ignored-files-orig-dir to avoid copying locally-ignored files in
-  orig-dir/ (e.g. ignored in .git/info/excludes but not in a committed
-  .gitignore file) that get copied to and then committed in the dest-dir/
-  repo.  Therefore, be sure you don't have any ignored files in orig-dir/ that
-  you want to keep before you run this script!
+* The cleaning of orig-dir/ using 'git clean -xdf' may be somewhat dangerous
+  but it is recommended by passing in --clean-ignored-files-orig-dir to avoid
+  copying locally-ignored files in orig-dir/ (e.g. ignored in
+  .git/info/excludes and not ignored in a committed .gitignore file in
+  orig-dir/) that get copied to and then committed in the dest-dir/ repo.
+  Therefore, be sure you don't have any of these type of ignored files in
+  orig-dir/ that you want to keep before you run this tool with the option
+  --clean-ignored-files-orig-dir!
 
 * Snapshotting with this script will create an exact duplicate of 'orig-dir'
   in 'dest-dir' and therefore if there are any local changes to the files or
@@ -188,7 +214,36 @@ NOTES:
   branch into the main branch (e.g. 'master') in 'dest-dir' repo.  As long as
   there are no merge conflicts, this will preserve local changes for the
   mirrored directories and files.  This strategy can work well as a way to
-  allow for local modifications but still do the snapshotting.
+  allow for local modifications but still do snapshotting.
+
+WARNINGS:
+
+* Make sure that orig-dir is a non-ignored subdir of the origin git repo and
+  that it does not contain any ignored subdirs and files that are ignored by
+  listing them in the .git/info/exclude file instead of .gitignore files that
+  would get copied over to dist-dir.  (If ignored files are ignored using
+  .gitignore files within orig-dir, then those files will be copied by the
+  rsync command along with the rest of the files from orig-dir and those files
+  will also be ignored after being copied to dest-dir.  However, if these
+  files and dirs are ignored because of being listed in the .git/info/exclude
+  file in orig-dir, then those files will not be ignored when copied over to
+  dest-dir and will therefore be added to the git commit in the dist-dir git
+  repo.  That is why it is recommended to run with
+  --clean-ignored-files-orig-dir to ensure that all ignore files are removed
+  from orig-dir before doing the rsync.)
+
+* Make sure that the top commit in orig-dir has been pushed (or will be
+  pushed) to the listed remote git repo showed in the output line 'origin
+  remote name' or 'origin remote URL'.  Otherwise, others will not be able to
+  trace that exact version by cloning that repo and tracability is lost.
+
+* Make sure that dest-dir is a non-ignored subdir of the destination git repo
+  and does not contain any ignored subdirs or files that you don't care if
+  they are deleted.  (Otherwise, the 'rsync --delete' command will delete any
+  files in dest-dir that are not also in orig-dir and since these non-ignored
+  files in dest-dir are not under version control, they will not be
+  recoverable.)
+
 """
 
 
@@ -275,14 +330,6 @@ def snapshotDirMainDriver(cmndLineArgs, defaultOptionsIn = None, stdout = None):
       help="Do not clean out orig-dir/ ignored files before snapshotting. [default]" )
 
     clp.add_argument(
-      "--do-rsync", dest="doRsync", action="store_true",
-      default=True,
-      help="Actually do the rsync. [default]" )
-    clp.add_argument(
-      "--skip-rsync", dest="doRsync", action="store_false",
-      help="Skip the rsync (testing only?)." )
-
-    clp.add_argument(
       "--do-commit", dest="doCommit", action="store_true",
       default=True,
       help="Actually do the commit. [default]" )
@@ -297,7 +344,13 @@ def snapshotDirMainDriver(cmndLineArgs, defaultOptionsIn = None, stdout = None):
     clp.add_argument(
       "--no-verify-commit", dest="noVerifyCommit", action="store_true",
       help="Pass --no-verify to git commit." )
-    
+
+    clp.add_argument(
+      "--no-op", dest="noOp", action="store_true",
+      default=False,
+      help="Don't actaully run any commands that would change the state other"
+      +" (other than the natural side-effects of running git query commands)" )
+
     options = clp.parse_args(cmndLineArgs)
   
     #
@@ -324,10 +377,6 @@ def snapshotDirMainDriver(cmndLineArgs, defaultOptionsIn = None, stdout = None):
       print("  --clean-ignored-files-orig-dir \\")
     else:
       print("  --no-clean-ignored-files-orig-dir \\")
-    if options.doRsync:
-      print("  --do-rsync \\")
-    else:
-      print("  --skip-rsync \\")
     if options.doCommit:
       print("  --do-commit \\")
     else:
@@ -336,6 +385,8 @@ def snapshotDirMainDriver(cmndLineArgs, defaultOptionsIn = None, stdout = None):
       print("  --no-verify-commit \\")
     else:
       print("  --verify-commit \\")
+    if options.noOp:
+      print("  --no-op \\")
   
     if options.showDefaults:
       return  # All done!
@@ -384,12 +435,12 @@ def snapshotDir(inOptions):
   #
 
   if inOptions.cleanIgnoredFilesOrigDir:
-    cleanIgnoredFilesFromGitDir(inOptions.origDir, "origin")
+    cleanIgnoredFilesFromGitDir(inOptions.origDir, inOptions.noOp, "origin")
   else:
     print("Skipping on request!")
 
   #
-  print("\nD) Get info for git commit from origDir [optional]\n")
+  print("\nD) Get info for git commit from orig-dir [optional]\n")
   #
 
   # Get the repo for origin
@@ -403,42 +454,40 @@ def snapshotDir(inOptions):
 
   # Get the last commit message
   originLastCommitMsg = getLastCommitMsg(inOptions.origDir)
-  print("\norigin commit message:\n\n" + originLastCommitMsg + "\n")
+  print("\norigin commit message:")
+  print("---------------------------------------")
+  print(originLastCommitMsg)
+  print("---------------------------------------")
 
   #
   print("\nE) Run rsync to add and remove files and dirs between two directories\n")
   #
 
-  if inOptions.doRsync:
+  excludes = r"""--exclude=\.git"""
+  if inOptions.exclude:
+      excludes += " " + " ".join(map(lambda ex: "--exclude="+ex,
+                                     inOptions.exclude))
+      print("Excluding files/directories/globs: " +
+            " ".join(inOptions.exclude))
+  # Note that when syncing one git repo to another, we want to sync the
+  # .gitingore and other hidden files as well.
 
-    excludes = r"""--exclude=\.git"""
-    if inOptions.exclude:
-        excludes += " " + " ".join(map(lambda ex: "--exclude="+ex,
-                                       inOptions.exclude))
-        print("Excluding files/directories/globs: " +
-              " ".join(inOptions.exclude))
-    # Note that when syncing one git repo to another, we want to sync the
-    # .gitingore and other hidden files as well.
-  
-    # When we support syncing from hg repos, add these excludes as well:
-    #    --exclude=\.hg --exclude=.hgignore --exclude=.hgtags
-  
-    rtn = echoRunSysCmnd(
-      r"rsync -cav --delete "+excludes+" "+inOptions.origDir+" "+inOptions.destDir,
-      throwExcept=False,
-      timeCmnd=True
-      )
-  
+  # When we support syncing from hg repos, add these excludes as well:
+  #    --exclude=\.hg --exclude=.hgignore --exclude=.hgtags
+
+  rsyncCmnd = \
+    r"rsync -cav --delete "+excludes+" "+inOptions.origDir+" "+inOptions.destDir
+
+  if not inOptions.noOp:
+    rtn = echoRunSysCmnd(rsyncCmnd,  throwExcept=False,  timeCmnd=True)
     if rtn != 0:
       print("Rsync failed, aborting!")
       return False
-
   else:
-
-    print("\nSkipping rsync on request!")
+    print("Would be running: "+rsyncCmnd)
 
   #
-  print("\nE) Create a new commit in destination directory [optional]")
+  print("\nE) Create a new commit in dest-dir [optional]")
   #
 
   origDirLast = inOptions.origDir.split("/")[-2]
@@ -463,31 +512,57 @@ def snapshotDir(inOptions):
     "\n"+\
     originLastCommitMsg
 
-  print("\nGeneratting commit with commit message:\n")
-  print("---------------------------------------"    )
-  print(commitMessage                                )
-  print("---------------------------------------"    )
+  print("\nGenerating commit in dest-dir with commit message:\n")
+  print("---------------------------------------")
+  print(commitMessage)
+  print("---------------------------------------")
 
   if inOptions.doCommit:
 
-    echoRunSysCmnd(
-      "git add .",
-      workingDir=inOptions.destDir
-      )
+    gitAddCmnd = "git add ."
+    if not inOptions.noOp:
+      echoRunSysCmnd(gitAddCmnd, workingDir=inOptions.destDir)
+    else:
+      print("\nWould be running: "+gitAddCmnd+"\n" \
+        +"\n    in directory '"+inOptions.destDir+"'" )
 
     if inOptions.noVerifyCommit:
       noVerifyCommitArgStr = " --no-verify"
     else:
       noVerifyCommitArgStr = ""
 
-    echoRunSysCmnd(
-      "git commit"+noVerifyCommitArgStr+" -m \""+commitMessage+"\" -- .",
-      workingDir=inOptions.destDir
-      )
+    gitCommitCmndBegin = "git commit"+noVerifyCommitArgStr+" -m "
+    if not inOptions.noOp:
+      echoRunSysCmnd(gitCommitCmndBegin+"\""+commitMessage+"\"",
+        workingDir=inOptions.destDir)
+    else:
+      print("\nWould be running: "+gitCommitCmndBegin+"\"<commit-msg>\"\n"
+        +"\n    in directory '"+inOptions.destDir+"'" )
 
   else:
 
     print("\nSkipping commit on request!\n")
+
+  if inOptions.noOp:
+
+    print(
+      "\n***\n"
+      "*** NOTE: No modifying operations were performed!\n"
+      "***\n"
+      "*** Run again removing the option --no-op to make modifying\n"
+      "*** changes.\n"
+      "***\n"
+      "*** But first, carefully look at the orig-dir, dest-dir and the\n"
+      "*** various operations performed above to make sure that\n"
+      "*** everything is as it should be before removing the option --no-op.\n"
+      "***\n"
+      "*** In particular,  look carefully at the 'git clean' and  'rsync' commands\n"
+      "*** on the lines that begin with 'Would be running:'\n"
+      "***\n"
+      "***\n"
+      "***\n"
+      "***\n"
+      )
 
   #
   # F) Success! (if you get this far)
@@ -533,19 +608,17 @@ def assertCleanGitDir(dirPath, dirName, explanation):
   # not a huge risk for the use cases that I am concerned with.
 
 
-def cleanIgnoredFilesFromGitDir(dirPath, dirName):
-
-  rtn = echoRunSysCmnd(
-    r"git clean -xdf",
-    workingDir=dirPath,
-    throwExcept=False,
-    timeCmnd=True
-    )
-  
-  if rtn != 0:
-    raise Exception(
-      "Error, cleaning of origin `"+dirPath+"` failed!"
-      )
+def cleanIgnoredFilesFromGitDir(dirPath, noOp, dirName):
+  gitCleanCmnd = r"git clean -xdf"
+  if not noOp:
+    rtn = echoRunSysCmnd(gitCleanCmnd,  workingDir=dirPath,
+      throwExcept=False, timeCmnd=True)
+    if rtn != 0:
+      raise Exception(
+        "Error, cleaning of origin `"+dirPath+"` failed!")
+  else:
+    print("Would be running: "+gitCleanCmnd+"\n" \
+      +"\n    in directory '"+dirPath+"'" )
 
 
 def getCommitSha1(gitDir):


### PR DESCRIPTION
See the commits for details.

This was done to support the snapshotting of googletest for SPARC (see [internal MR](https://cee-gitlab.sandia.gov/sparc/sparc-ear99/-/merge_requests/890)) as part #433.
