### PR TITLE
Support list for TAAT() PASS_REGULAR_EXPRESSION and FAIL_REGULAR_EXPRESSION (#464)

### DIFF
--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -49,7 +49,7 @@ tribits_add_advanced_test( TestingFunctionMacro_UnitTests
       -D${PROJECT_NAME}_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
       -P "${CMAKE_CURRENT_SOURCE_DIR}/TestingFunctionMacro_UnitTests.cmake"
     PASS_REGULAR_EXPRESSION_ALL
-      "Final UnitTests Result: num_run = 686"
+      "Final UnitTests Result: num_run = 695"
       "Final UnitTests Result: PASSED"
   )
 

--- a/test/core/CTestScriptsUnitTests/CMakeLists.txt
+++ b/test/core/CTestScriptsUnitTests/CMakeLists.txt
@@ -76,9 +76,16 @@ tribits_add_test( GenericDriver
   )
 
 tribits_add_test( GenericDriver
-  NAME CTestScripts_simple_pass_regex
+  NAME CTestScripts_simple_pass_regex_1
   ARGS "\"This is a crazy test!\" 1"
   PASS_REGULAR_EXPRESSION "[^=]This is a crazy test"
+  NUM_MPI_PROCS 1
+  )
+
+tribits_add_test( GenericDriver
+  NAME CTestScripts_simple_pass_regex_2
+  POSTFIX_AND_ARGS_0 test1 "This is a crazy test!" 1
+  PASS_REGULAR_EXPRESSION "does not match" "This is a crazy test"
   NUM_MPI_PROCS 1
   )
 
@@ -143,6 +150,14 @@ tribits_add_test( GenericDriver
   # "failed".  If you comment out FAIL_REGULAR_EXPRESSION, the final result
   # will be "failed".
 
+tribits_add_test( GenericDriver
+  NAME CTestScripts_pass_regular_expression_fail_regular_exprssion_2_will_fail
+  POSTFIX_AND_ARGS_0 test1 "This says PASS!  This says FAIL!" 1
+  PASS_REGULAR_EXPRESSION "This says PASS"
+  FAIL_REGULAR_EXPRESSION "Does not match" "This says FAIL"
+  WILL_FAIL
+  NUM_MPI_PROCS 1
+  )
 
 function(ctestscripts_fail_regular_exprssion_w_circular_ref_detection_tests)
 
@@ -206,10 +221,28 @@ tribits_add_advanced_test(
   )
 
 tribits_add_advanced_test(
-  CTestScripts_cmnd_1_args_1_print_msg_out_file
+  CTestScripts_cmnd_1_args_1_print_msg_out_file_pass_regex_1
   TEST_0 EXEC GenericDriver ARGS "This is a crazy test!" 5
     OUTPUT_FILE cmnd_1_args_1_print_msg_out_file_outputFile.out
     PASS_REGULAR_EXPRESSION "This is a crazy test"
+  OVERALL_NUM_MPI_PROCS 1
+  )
+
+tribits_add_advanced_test(
+  CTestScripts_cmnd_1_args_1_print_msg_out_file_pass_regex_2
+  TEST_0 EXEC GenericDriver ARGS "This is a crazy test!" 5
+    OUTPUT_FILE cmnd_1_args_1_print_msg_out_file_outputFile.out
+    PASS_REGULAR_EXPRESSION "does not match" "This is a crazy test"
+  OVERALL_NUM_MPI_PROCS 1
+  )
+
+tribits_add_advanced_test(
+  CTestScripts_cmnd_1_args_1_print_msg_out_file_fail_regex_2_will_fail
+  TEST_0 EXEC GenericDriver ARGS "This is a crazy test!" 0
+    OUTPUT_FILE cmnd_1_args_1_print_msg_out_file_outputFile.out
+    PASS_REGULAR_EXPRESSION "This is a crazy test"
+    FAIL_REGULAR_EXPRESSION "Does not match" "This is a crazy test"
+    WILL_FAIL
   OVERALL_NUM_MPI_PROCS 1
   )
 
@@ -346,7 +379,7 @@ tribits_add_advanced_test(
     ARGS "This is a crazy test\n\nThis is not the best test" 5
     OUTPUT_FILE cmnd_1_args_1_pass_regular_expression_all_compare_1_outputFile.out
     PASS_REGULAR_EXPRESSION_ALL "This is a crazy test" "This is not the best test"
-  FINAL_PASS_REGULAR_EXPRESSION "TEST_0: Pass criteria = Match REGEX {This is a crazy test} [^a]PASSED[^a]"
+  FINAL_PASS_REGULAR_EXPRESSION "TEST_0: Pass criteria = Match all REGEX {This is a crazy test} [^a]PASSED[^a]"
   OVERALL_NUM_MPI_PROCS 1
   )
 
@@ -356,7 +389,7 @@ tribits_add_advanced_test(
     ARGS "This is a crazy test\n\nThis is not the best test" 5
     OUTPUT_FILE cmnd_1_args_1_pass_regular_expression_all_compare_2_outputFile.out
     PASS_REGULAR_EXPRESSION_ALL "This is a crazy test" "This is not the best test"
-  FINAL_PASS_REGULAR_EXPRESSION "TEST_0: Pass criteria = Match REGEX {This is not the best test} [^a]PASSED[^a]"
+  FINAL_PASS_REGULAR_EXPRESSION "TEST_0: Pass criteria = Match all REGEX {This is not the best test} [^a]PASSED[^a]"
   OVERALL_NUM_MPI_PROCS 1
   )
 
@@ -805,7 +838,7 @@ tribits_add_advanced_test(
       "TEST_1: Result = PASSED"
       "This is Test File A"
       "TEST_2: Return code = 0"
-      "TEST_2: Pass criteria = Match REGEX .This is Test File A. .PASSED."
+      "TEST_2: Pass criteria = Match any REGEX .This is Test File A. .PASSED."
       "TEST_2: Result = PASSED"                                
       "OVERALL FINAL RESULT: TEST FAILED [(]TAATDriver_TAAT_COPY_FILES_TO_TEST_DIR_bad_file_name[)]"
   )
@@ -841,7 +874,7 @@ tribits_add_advanced_test(
       "TEST_3: Result = PASSED"
       "This is Test File A"
       "TEST_4: Return code = 0"
-      "TEST_4: Pass criteria = Match REGEX .This is Test File A. .PASSED."
+      "TEST_4: Pass criteria = Match any REGEX .This is Test File A. .PASSED."
       "TEST_4: Result = PASSED"                                
       "OVERALL FINAL RESULT: TEST FAILED [(]TAATDriver_TAAT_COPY_FILES_TO_TEST_DIR_bad_dest_dir[)]"
   )

--- a/test/core/TestingFunctionMacro_UnitTests.cmake
+++ b/test/core/TestingFunctionMacro_UnitTests.cmake
@@ -2214,6 +2214,32 @@ function(unittest_tribits_add_test_properties)
   unittest_has_substr_const(TRIBITS_SET_TEST_PROPERTIES_INPUT
     "PackageA_SomeExec;APPEND;PROPERTY;LABELS")
 
+  message("Test setting PASS_REGULAR_EXPRESSION")
+  tribits_add_test(${EXEN} PASS_REGULAR_EXPRESSION
+     "[^a-zA-Z0-9_]My first pass Regex" "*/second pass regex")
+  unittest_compare_const(MESSAGE_WRAPPER_INPUT
+    "-- ${PACKEXEN}: Added test (BASIC, PROCESSORS=1)!" )
+  unittest_has_substr_const(TRIBITS_SET_TEST_PROPERTIES_INPUT
+    "PackageA_SomeExec;PROPERTIES;PASS_REGULAR_EXPRESSION;[^a-zA-Z0-9_]My first pass Regex;*/second pass regex;")
+
+  message("Test setting FAIL_REGULAR_EXPRESSION")
+  tribits_add_test(${EXEN} FAIL_REGULAR_EXPRESSION
+     "[^a-zA-Z0-9_]My first fail Regex" "*/second fail regex")
+  unittest_compare_const(MESSAGE_WRAPPER_INPUT
+    "-- ${PACKEXEN}: Added test (BASIC, PROCESSORS=1)!" )
+  unittest_has_substr_const(TRIBITS_SET_TEST_PROPERTIES_INPUT
+    "PackageA_SomeExec;APPEND;PROPERTY;FAIL_REGULAR_EXPRESSION;[^a-zA-Z0-9_]My first fail Regex;*/second fail regex;")
+
+  message("Test setting WILL_FAIL")
+  tribits_add_test(${EXEN} WILL_FAIL FAIL_REGULAR_EXPRESSION
+     "[^a-zA-Z0-9_]1ST fail Regex" "*/2nd fail regex")
+  unittest_compare_const(MESSAGE_WRAPPER_INPUT
+    "-- ${PACKEXEN}: Added test (BASIC, PROCESSORS=1)!" )
+  unittest_has_substr_const(TRIBITS_SET_TEST_PROPERTIES_INPUT
+    "PackageA_SomeExec;PROPERTIES;WILL_FAIL;ON;")
+  unittest_has_substr_const(TRIBITS_SET_TEST_PROPERTIES_INPUT
+    "PackageA_SomeExec;APPEND;PROPERTY;FAIL_REGULAR_EXPRESSION;[^a-zA-Z0-9_]1ST fail Regex;*/2nd fail regex;")
+
   message("Test setting integer TIMEOUT with no scaling (not even defined)")
   tribits_add_test(${EXEN} TIMEOUT 200)
   unittest_compare_const(MESSAGE_WRAPPER_INPUT
@@ -3539,6 +3565,21 @@ function(unittest_tribits_add_advanced_test_properties)
   # tribits_add_advanced_test() that looks for it.  Otherwise, the outer
   # tribits_add_advanced_test() always thinks these unit tests pass!
 
+  message("Test setting FINAL_PASS_REGULAR_EXPRESSION")
+  tribits_add_advanced_test_unittest_reset()
+  tribits_add_advanced_test( TAAT_final_pass_regular_expression
+    TEST_0 CMND ${CMNDN} FINAL_PASS_REGULAR_EXPRESSION
+     "[^a-zA-Z0-9_]My first pass Regex" "*/second pass regex")
+  unittest_has_substr_const(TRIBITS_SET_TEST_PROPERTIES_INPUT
+    "PackageA_TAAT_final_pass_regular_expression;PROPERTIES;PASS_REGULAR_EXPRESSION;[^a-zA-Z0-9_]My first pass Regex;*/second pass regex")
+
+  message("Test setting FINAL_FAIL_REGULAR_EXPRESSION")
+  tribits_add_advanced_test( TAAT_final_fail_regular_expression
+    TEST_0 CMND ${CMNDN} FINAL_FAIL_REGULAR_EXPRESSION
+     "[^a-zA-Z0-9_]My first fail Regex" "*/second fail regex")
+  unittest_has_substr_const(TRIBITS_SET_TEST_PROPERTIES_INPUT
+    "PackageA_TAAT_final_fail_regular_expression;PROPERTIES;FAIL_REGULAR_EXPRESSION;[^a-zA-Z0-9_]My first fail Regex;*/second fail regex")
+
   message("Test setting non-integer TIMEOUT with no scaling (not even defined)")
   tribits_add_advanced_test_unittest_reset()
   tribits_add_advanced_test( TAAT_basic_cmnd_1_args_0
@@ -4514,4 +4555,4 @@ message("*** Determine final result of all unit tests")
 message("***\n")
 
 # Pass in the number of expected tests that must pass!
-unittest_final_result(686)
+unittest_final_result(695)

--- a/tribits/CHANGELOG.md
+++ b/tribits/CHANGELOG.md
@@ -2,11 +2,27 @@
 ChangeLog for TriBITS
 ----------------------------------------
 
+## 2022-05-16:
+
+* **Added:** The function `tribits_add_advanced_test(`) now correctly accepts
+  a list of regexes for `PASS_REGULAR_EXPRESSION` and
+  `FAIL_REGULAR_EXPRESSION` and behave the same as the raw CTest properties of
+  the same names.
+
 ## 2022-03-10:
 
 * **Changed:** The `tribits_add_advanced_test()` command now correctly reports
   unparsed/unrecognized arguments.  This will break some sloppy usages. (One
   TriBITS test had to be fixed.)
+
+* **Changed:** The `tribits_add_test()` and `tribits_add_advanced_test()`
+  behave differently with data passed in with explicit colon arguments.  For
+  example, before `PASS_REGULAR_EXPRESSION "<regex0>;<regex1>"` could be used
+  to pass in a list of regular expressions but with the new handling of
+  function arguments, this now gets set as a single regex
+  `"<regex0>\\;<regex1>"` which is not the same.  The fix (that also works
+  with older versions of TriBITS) is to pass in multiple regexes as separate
+  arguments as `PASS_REGULAR_EXPRESSION "<regex0>" "<regex1>"`.
 
 * **Added:** The `tribits_add_test()`, `tribits_add_advanced_test()`, and
   `tribits_add_executable_and_test()` functions now allow handling semi-colons

--- a/tribits/core/package_arch/TribitsAddTest.cmake
+++ b/tribits/core/package_arch/TribitsAddTest.cmake
@@ -68,8 +68,8 @@ include(TribitsAddTestHelpers)
 #     [EXCLUDE_IF_NOT_TRUE <varname0> <varname1> ...]
 #     [DISABLED <messageWhyDisabled>]
 #     [STANDARD_PASS_OUTPUT
-#       | PASS_REGULAR_EXPRESSION "<regex0>;<regex1>;..."]
-#     [FAIL_REGULAR_EXPRESSION "<regex0>;<regex1>;..."]
+#       | PASS_REGULAR_EXPRESSION "<regex0>" "<regex1>" ...]
+#     [FAIL_REGULAR_EXPRESSION "<regex0>" "<regex1>" ...]
 #     [WILL_FAIL]
 #     [ENVIRONMENT <var0>=<value0> <var1>=<value1> ...]
 #     [TIMEOUT <maxSeconds>]
@@ -337,7 +337,7 @@ include(TribitsAddTestHelpers)
 #     MPI executables is unreliable.  This is set using the built-in CTest
 #     property ``PASS_REGULAR_EXPRESSION``.
 #
-#   ``PASS_REGULAR_EXPRESSION "<regex0>;<regex1>;..."``
+#   ``PASS_REGULAR_EXPRESSION "<regex0>" "<regex1>" ...``
 #
 #     If specified, then the test will be assumed to pass only if one of the
 #     regular expressions ``<regex0>``, ``<regex1>`` etc. match the output
@@ -347,7 +347,7 @@ include(TribitsAddTestHelpers)
 #     CMake will interpret this as an array element boundary.  To match '.',
 #     use '[.]'.
 #
-#   ``FAIL_REGULAR_EXPRESSION "<regex0>;<regex1>;..."``
+#   ``FAIL_REGULAR_EXPRESSION "<regex0>" "<regex1>" ...``
 #
 #     If specified, then a test will be assumed to fail if one of the regular
 #     expressions ``<regex0>``, ``<regex1>`` etc. match the output send to


### PR DESCRIPTION
See the commit log for commit https://github.com/TriBITSPub/TriBITS/commit/fd681d2823116a813e85f4a39478bc2750011b8e for details.

I noticed this as part of working on testing PR #479 with Trilinos as part of #299.  This should have been addressed as part of PR #464.
