### PR TITLE
Fix TriBITS tests to work if no 'ninja' is found and set up GHA build with no 'ninja'

### DIFF
--- a/.github/workflows/tribits_testing.yml
+++ b/.github/workflows/tribits_testing.yml
@@ -21,8 +21,8 @@ jobs:
         config:
           - { os: ubuntu-latest, cmake: "3.17.5", generator: "makefiles", python: "2.7", cc: gcc-8,  cxx: g++-8,  fc: gfortran-8  }
           - { os: ubuntu-latest, cmake: "3.17.5", generator: "makefiles", python: "3.8", cc: gcc-10, cxx: g++-10, fc: gfortran-10 }
-          - { os: ubuntu-latest, cmake: "3.17.5", generator: "makefiles", python: "3.8", cc: gcc-11, cxx: g++-11                  }
-          - { os: ubuntu-latest, cmake: "3.21.2", generator: "makefiles", python: "3.8", cc: gcc-9,  cxx: g++-9,  fc: gfortran-9  }
+          - { os: ubuntu-latest, cmake: "3.17.5", generator: "makefiles", python: "3.8", cc: gcc-11, cxx: g++-11 }
+          - { os: ubuntu-latest, cmake: "3.21.2", generator: "makefiles", python: "3.8", cc: gcc-9,  cxx: g++-9, fc: gfortran-9, no_have_ninja: no-ninja }
           - { os: ubuntu-latest, cmake: "3.23.1", generator: "makefiles", python: "3.8", cc: gcc-9,  cxx: g++-9,  fc: gfortran-9  }
 
     runs-on: ${{ matrix.config.os }}
@@ -54,7 +54,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/fortrann fortrann /usr/bin/gfortran 20
           sudo update-alternatives --set fortrann /usr/bin/gfortran
           sudo apt-get -y install valgrind
-          sudo apt-get -y install ninja-build
+          if [[ "${{ matrix.config.no_have_ninja }}" != "no-ninja" ]] ; then sudo apt-get -y install ninja-build ; fi
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -67,9 +67,7 @@ jobs:
           echo "Checking cmake path and version"
           which cmake
           cmake --version
-          echo "Checking ninja path and version"
-          which ninja
-          ninja --version
+          if [[ "${{ matrix.config.no_have_ninja }}" != "no-ninja" ]] ; then echo "Checking ninja path and version" ; which ninja ; ninja --version ; fi
           echo "Checking gcc path and version"
           which ${{ matrix.config.cc }}
           ${{ matrix.config.cc }} --version
@@ -89,6 +87,7 @@ jobs:
             --python-ver ${{ matrix.config.python }} \
             --cxx-compiler-and-ver ${{ matrix.config.cxx }} \
             --fortran-compiler-and-ver ${{ matrix.config.fc }} \
+            --no-have-ninja ${{ matrix.config.no_have_ninja }} \
             --github-repo-match-to-submit TriBITSPub/TriBITS
       - name: URL to results on CDash
         run: |

--- a/cmake/ctest/github_actions/run_github_actions_ctest_driver.sh
+++ b/cmake/ctest/github_actions/run_github_actions_ctest_driver.sh
@@ -14,6 +14,7 @@
 #     --python-ver <python-ver> \
 #     --cxx-compiler-and-ver <cxx-compiler-and-ver> \
 #     [ --fortran-compiler-and-ver <fortran-comiler-and-ver> ]
+#     [ --no-have-ninja <no-have-ninja> ]
 #     [ --github-repo-match-to-submit <github-repo-match-to-submit> ]
 #
 # This is called by the GitHub Actions script:
@@ -95,6 +96,7 @@ cmake_generator=
 python_ver=
 cxx_compiler_and_ver=
 fortran_compiler_and_ver=
+no_have_ninja=
 github_repo_match_to_submit=
 
 while (( "$#" )); do
@@ -132,6 +134,14 @@ while (( "$#" )); do
         shift 1
       fi
       ;;
+    --no-have-ninja)
+      if [[ -n "$2" ]] && [[ ${2:0:1} != "-" ]]; then
+        no_have_ninja=$2
+        shift 2
+      else
+        shift 1
+      fi
+      ;;
     --github-repo-match-to-submit)
       if [[ -n "$2" ]] && [[ ${2:0:1} != "-" ]]; then
         github_repo_match_to_submit=$2
@@ -153,7 +163,7 @@ assert_required_option_set --generator "${cmake_generator}"
 assert_required_option_set --python-ver "${python_ver}"
 assert_required_option_set --cxx-compiler-and-ver "${cxx_compiler_and_ver}"
 # NOTE: Fortran is not required!
-
+# NOTE: Ninja is not required
 
 #
 # B) Set up options for running build
@@ -171,6 +181,9 @@ echo "CTEST_SITE = '${CTEST_SITE}'"
 CTEST_BUILD_NAME=tribits_cmake-${cmake_ver}_${cmake_generator}_python-${python_ver}_${cxx_compiler_and_ver}
 if [[ "${fortran_compiler_and_ver}" == "" ]] ; then
   CTEST_BUILD_NAME=${CTEST_BUILD_NAME}_nofortran
+fi
+if [[ "${no_have_ninja}" == "no-ninja" ]] ; then
+  CTEST_BUILD_NAME=${CTEST_BUILD_NAME}_noninja
 fi
 export CTEST_BUILD_NAME
 echo "CTEST_BUILD_NAME = '${CTEST_BUILD_NAME}'"

--- a/test/core/ExamplesUnitTests/TribitsExampleApp2_Tests.cmake
+++ b/test/core/ExamplesUnitTests/TribitsExampleApp2_Tests.cmake
@@ -55,6 +55,7 @@ set(testDir ${CMAKE_CURRENT_BINARY_DIR}/${testName})
 tribits_add_advanced_test( ${testBaseName}
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE  NINJA_EXE
   XHOSTTYPE Darwin
 
   TEST_0
@@ -129,6 +130,7 @@ function(TribitsExampleApp2  tribitsExProj2TestNameBaseBase
   tribits_add_advanced_test( ${testBaseName}
     OVERALL_WORKING_DIRECTORY TEST_NAME
     OVERALL_NUM_MPI_PROCS 1
+    EXCLUDE_IF_NOT_TRUE  NINJA_EXE
     XHOSTTYPE Darwin
 
     TEST_0


### PR DESCRIPTION
With this, people that clone the TriBITS repo and don't have 'ninja' should get a valid passing test suite.  (All you should need to build and run the bulk of the TriBITS tests is a recent-enough version of CMake, Make, and a C and C++ compiler.)
