### PR TITLE
Remove line containing '#' before all @MACRO and @FUNCTION blocks

### DIFF
--- a/tribits/core/package_arch/TribitsAddExecutableAndTest.cmake
+++ b/tribits/core/package_arch/TribitsAddExecutableAndTest.cmake
@@ -78,7 +78,7 @@ macro(tribits_add_test_wrapper)
   endif()
 endmacro()
 
-#
+
 # @FUNCTION: tribits_add_executable_and_test()
 #
 # Add an executable and a test (or several tests) all in one shot (just calls

--- a/tribits/core/package_arch/TribitsAddOptionAndDefine.cmake
+++ b/tribits/core/package_arch/TribitsAddOptionAndDefine.cmake
@@ -40,7 +40,6 @@
 include(GlobalSet)
 
 
-#
 # @MACRO: tribits_add_option_and_define()
 #
 # Add an option and a define variable in one shot.

--- a/tribits/core/package_arch/TribitsAddTest.cmake
+++ b/tribits/core/package_arch/TribitsAddTest.cmake
@@ -40,7 +40,6 @@
 include(TribitsAddTestHelpers)
 
 
-#
 # @FUNCTION: tribits_add_test()
 #
 # Add a test or a set of tests for a single executable or command using CTest

--- a/tribits/core/package_arch/TribitsCopyFilesToBinaryDir.cmake
+++ b/tribits/core/package_arch/TribitsCopyFilesToBinaryDir.cmake
@@ -42,7 +42,6 @@ include(TribitsAddTestHelpers)
 include(CMakeParseArguments)
 
 
-#
 # @FUNCTION: tribits_copy_files_to_binary_dir()
 #
 # Function that copies a list of files from a source directory to a

--- a/tribits/core/package_arch/TribitsFindMostRecentFileTimestamp.cmake
+++ b/tribits/core/package_arch/TribitsFindMostRecentFileTimestamp.cmake
@@ -40,7 +40,6 @@
 include(CMakeParseArguments)
 
 
-#
 # @FUNCTION: tribits_find_most_recent_file_timestamp()
 #
 # Find the most modified file in a set of base directories and return its
@@ -294,7 +293,6 @@ function(tribits_find_most_recent_file_timestamp)
 endfunction()
 
 
-#
 # @FUNCTION: tribits_find_most_recent_source_file_timestamp()
 #
 # Find the most modified source file in a set of base directories and return
@@ -381,7 +379,6 @@ function(tribits_find_most_recent_source_file_timestamp)
 endfunction()
 
 
-#
 # @FUNCTION: tribits_find_most_recent_binary_file_timestamp()
 #
 # Find the most modified binary file in a set of base directories and return
@@ -471,7 +468,6 @@ function(tribits_find_most_recent_binary_file_timestamp)
 endfunction()
 
 
-#
 # @FUNCTION: tribits_determine_if_current_package_needs_rebuilt()
 #
 # Determine at configure time if any of the upstream dependencies for a

--- a/tribits/core/package_arch/TribitsGetVersionDate.cmake
+++ b/tribits/core/package_arch/TribitsGetVersionDate.cmake
@@ -2,7 +2,6 @@ include("${${PROJECT_NAME}_TRIBITS_DIR}/core/utils/MessageWrapper.cmake")
 include("${${PROJECT_NAME}_TRIBITS_DIR}/core/utils/TribitsStripQuotesFromStr.cmake")
 
 
-#
 # @FUNCTION: tribits_get_raw_git_commit_utc_time()
 #
 # Get the git commit date of a repo at a given commit in UTC in the format
@@ -58,7 +57,6 @@ function(tribits_get_raw_git_commit_utc_time  repo_base_dir  commit_ref
 endfunction()
 
 
-#
 # @FUNCTION: tribits_get_version_date_from_raw_git_commit_utc_time()
 #
 # Takes input of the form "YYYY-MM-DD hh:mm:ss +0000" from the git command::

--- a/tribits/core/package_arch/TribitsIncludeDirectories.cmake
+++ b/tribits/core/package_arch/TribitsIncludeDirectories.cmake
@@ -40,7 +40,6 @@
 include(CMakeParseArguments)
 
 
-#
 # @MACRO: tribits_include_directories()
 #
 # This function is to override the standard behavior of the built-in CMake

--- a/tribits/core/package_arch/TribitsInstallHeaders.cmake
+++ b/tribits/core/package_arch/TribitsInstallHeaders.cmake
@@ -41,7 +41,6 @@
 include(CMakeParseArguments)
 
 
-#
 # @FUNCTION: tribits_install_headers()
 #
 # Function used to (optionally) install header files using ``install()``

--- a/tribits/core/package_arch/TribitsListHelpers.cmake
+++ b/tribits/core/package_arch/TribitsListHelpers.cmake
@@ -81,7 +81,6 @@ macro(tribits_set_package_to_ex  PACKAGE_NAME)
 endmacro()
 
 
-#
 # @MACRO: tribits_disable_package_on_platforms()
 #
 # Disable a package automatically for a list of platforms.

--- a/tribits/core/package_arch/TribitsProcessEnabledTpl.cmake
+++ b/tribits/core/package_arch/TribitsProcessEnabledTpl.cmake
@@ -48,7 +48,6 @@ include(AppendStringVar)
 include(TribitsStandardizePaths)
 
 
-#
 # @FUNCTION: tribits_process_enabled_tpl()
 #
 # Process an enabled TPL's FindTPL${TPL_NAME}.cmake module.

--- a/tribits/core/package_arch/TribitsProcessExtraRepositoriesList.cmake
+++ b/tribits/core/package_arch/TribitsProcessExtraRepositoriesList.cmake
@@ -47,7 +47,6 @@ include(MessageWrapper)
 include(TribitsSortListAccordingToMasterList)
 
 
-#
 # @MACRO: tribits_project_define_extra_repositories()
 #
 # Declare a set of extra repositories for the `TriBITS Project`_ (i.e. in the

--- a/tribits/core/package_arch/TribitsProcessTplsLists.cmake
+++ b/tribits/core/package_arch/TribitsProcessTplsLists.cmake
@@ -44,7 +44,7 @@ include(TribitsListHelpers)
 include(PrintVar)
 include(Split)
 
-#
+
 # @MACRO: tribits_repository_define_tpls()
 #
 # Define the list of `TriBITS TPLs`_ for a given `TriBITS Repository`_ which

--- a/tribits/core/package_arch/TribitsProject.cmake
+++ b/tribits/core/package_arch/TribitsProject.cmake
@@ -70,7 +70,6 @@ include(TribitsCMakePolicies)
 include(TribitsProjectImpl)
 
 
-#
 # @MACRO: tribits_project()
 #
 # Processes a `TriBITS Project`_'s files and configures its software which is

--- a/tribits/core/package_arch/TribitsProjectImpl.cmake
+++ b/tribits/core/package_arch/TribitsProjectImpl.cmake
@@ -323,7 +323,6 @@ macro(tribits_project_impl)
 endmacro()
 
 
-#
 # @MACRO: tribits_project_enable_all()
 #
 # Process a project where you enable all of the packages by default.

--- a/tribits/core/package_arch/TribitsVerbosePrintVar.cmake
+++ b/tribits/core/package_arch/TribitsVerbosePrintVar.cmake
@@ -40,7 +40,7 @@
 
 if (${PROJECT_NAME}_VERBOSE_CONFIGURE)
 
-#
+
 # @FUNCTION: tribits_verbose_print_var()
 #
 # print a variable giving its name then value if

--- a/tribits/core/utils/AddSubdirectories.cmake
+++ b/tribits/core/utils/AddSubdirectories.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @MACRO: add_subdirectories()
 #
 # Macro that adds a list of subdirectories all at once (removes boiler-plate

--- a/tribits/core/utils/AdvancedOption.cmake
+++ b/tribits/core/utils/AdvancedOption.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @MACRO: advanced_option()
 #
 # Macro that sets an option and marks it as advanced (removes boiler-plate and

--- a/tribits/core/utils/AdvancedSet.cmake
+++ b/tribits/core/utils/AdvancedSet.cmake
@@ -38,7 +38,6 @@
 # @HEADER
 
 
-#
 # @MACRO: advanced_set()
 #
 # Macro that sets a variable and marks it as advanced (removes boiler-plate

--- a/tribits/core/utils/AppendCmndlineArgs.cmake
+++ b/tribits/core/utils/AppendCmndlineArgs.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @FUNCTION: append_cmndline_args()
 #
 # Utility function that appends command-line arguments to a variable of

--- a/tribits/core/utils/AppendGlob.cmake
+++ b/tribits/core/utils/AppendGlob.cmake
@@ -39,7 +39,7 @@
 
 include(AppendSet)
 
-#
+
 # @MACRO: append_glob()
 #
 # Utility macro that does a ``file(GLOB ...)`` and appends to an existing list

--- a/tribits/core/utils/AppendGlobalSet.cmake
+++ b/tribits/core/utils/AppendGlobalSet.cmake
@@ -40,7 +40,7 @@
 include(GlobalSet)
 include(AssertDefined)
 
-#
+
 # @FUNCTION: append_global_set()
 #
 # Utility macro that appends arguments to a global variable (reduces

--- a/tribits/core/utils/AppendSet.cmake
+++ b/tribits/core/utils/AppendSet.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @MACRO: append_set()
 #
 # Utility function to append elements to a variable (reduces boiler-plate

--- a/tribits/core/utils/AppendStringVar.cmake
+++ b/tribits/core/utils/AppendStringVar.cmake
@@ -40,7 +40,7 @@
 include(ConcatStrings)
 include(PrintVar)
 
-#
+
 # @FUNCTION: append_string_var()
 #
 # Append strings to an existing string variable (reduces boiler-place code and
@@ -68,7 +68,6 @@ function(append_string_var STRING_VAR_OUT)
 endfunction()
 
 
-#
 # @FUNCTION: append_string_var_ext()
 #
 # Append a single string to an existing string variable, ignoring ';' (reduces

--- a/tribits/core/utils/AppendStringVarWithSep.cmake
+++ b/tribits/core/utils/AppendStringVarWithSep.cmake
@@ -39,7 +39,7 @@
 
 include(ConcatStrings)
 
-#
+
 # @FUNCTION: append_string_var_with_sep()
 #
 # Append strings to a given string variable, joining them using a separator

--- a/tribits/core/utils/AssertDefined.cmake
+++ b/tribits/core/utils/AssertDefined.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @FUNCTION: assert_defined()
 #
 # Assert that a variable is defined and if not call ``message(SEND_ERROR

--- a/tribits/core/utils/CombinedOption.cmake
+++ b/tribits/core/utils/CombinedOption.cmake
@@ -42,7 +42,6 @@ include(MultilineSet)
 include(ConcatStrings)
 
 
-#
 # @FUNCTION: combined_option()
 #
 # Set up a ``BOOL`` cache variable (i.e. an option) based on a set of

--- a/tribits/core/utils/ConcatStrings.cmake
+++ b/tribits/core/utils/ConcatStrings.cmake
@@ -40,7 +40,6 @@
 include(PrintVar)
 
 
-#
 # @FUNCTION: concat_strings()
 #
 # Concatenate a set of string arguments.

--- a/tribits/core/utils/DualScopeAppendCmndlineArgs.cmake
+++ b/tribits/core/utils/DualScopeAppendCmndlineArgs.cmake
@@ -40,7 +40,7 @@
 include(AppendCmndlineArgs)
 include(DualScopeSet)
 
-#
+
 # @MACRO: dual_scope_append_cmndline_args()
 #
 # Utility function that appends command-line arguments to a variable of

--- a/tribits/core/utils/DualScopePrependCmndlineArgs.cmake
+++ b/tribits/core/utils/DualScopePrependCmndlineArgs.cmake
@@ -40,7 +40,7 @@
 include(PrependCmndlineArgs)
 include(DualScopeSet)
 
-#
+
 # @MACRO: dual_scope_prepend_cmndline_args()
 #
 # Utility function that prepends command-line arguments to a variable of

--- a/tribits/core/utils/DualScopeSet.cmake
+++ b/tribits/core/utils/DualScopeSet.cmake
@@ -38,7 +38,6 @@
 # @HEADER
 
 
-#
 # @MACRO: dual_scope_set()
 #
 # Macro that sets a variable name both in the current scope and the

--- a/tribits/core/utils/GlobalNullSet.cmake
+++ b/tribits/core/utils/GlobalNullSet.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @MACRO: global_null_set()
 #
 # Set a variable as a null internal global (cache) variable (removes

--- a/tribits/core/utils/GlobalSet.cmake
+++ b/tribits/core/utils/GlobalSet.cmake
@@ -38,7 +38,6 @@
 # @HEADER
 
 
-#
 # @MACRO: global_set()
 #
 # Set a variable as an internal global (cache) variable (removes boiler-plate

--- a/tribits/core/utils/Join.cmake
+++ b/tribits/core/utils/Join.cmake
@@ -38,7 +38,6 @@
 # @HEADER
 
 
-#
 # @FUNCTION: join()
 #
 # Join a set of strings into a single string using a join string.

--- a/tribits/core/utils/MultilineSet.cmake
+++ b/tribits/core/utils/MultilineSet.cmake
@@ -38,7 +38,6 @@
 # @HEADER
 
 
-#
 # @FUNCTION: multiline_set()
 #
 # Function to set a single string by concatenating a list of separate strings

--- a/tribits/core/utils/PrependCmndlineArgs.cmake
+++ b/tribits/core/utils/PrependCmndlineArgs.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @FUNCTION: prepend_cmndline_args()
 #
 # Utility function that prepends command-line arguments to a variable of

--- a/tribits/core/utils/PrependGlobalSet.cmake
+++ b/tribits/core/utils/PrependGlobalSet.cmake
@@ -40,7 +40,7 @@
 include(GlobalSet)
 include(AssertDefined)
 
-#
+
 # @MACRO: prepend_global_set()
 #
 # Utility macro that prepends arguments to a global variable (reduces

--- a/tribits/core/utils/PrependSet.cmake
+++ b/tribits/core/utils/PrependSet.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @MACRO: prepend_set()
 #
 # Utility macro to prepend elements to a variable (reduces boiler-plate code).

--- a/tribits/core/utils/PrintNonemptyVar.cmake
+++ b/tribits/core/utils/PrintNonemptyVar.cmake
@@ -41,7 +41,6 @@ include(AssertDefined)
 include(PrintVar)
 
 
-#
 # @FUNCTION: print_nonempty_var()
 #
 # Print a defined variable giving its name then value only if it is not empty.

--- a/tribits/core/utils/PrintNonemptyVarWithSpaces.cmake
+++ b/tribits/core/utils/PrintNonemptyVarWithSpaces.cmake
@@ -40,7 +40,7 @@
 include(AssertDefined)
 include(AppendStringVarWithSep)
 
-#
+
 # @FUNCTION: print_nonempty_var_with_spaces()
 #
 # Print a defined variable giving its name then value printed with spaces

--- a/tribits/core/utils/PrintVarWithSpaces.cmake
+++ b/tribits/core/utils/PrintVarWithSpaces.cmake
@@ -40,7 +40,7 @@
 include(AssertDefined)
 include(AppendStringVarWithSep)
 
-#
+
 # @FUNCTION: print_var_with_spaces()
 #
 # Print a defined variable giving its name then value printed with spaces

--- a/tribits/core/utils/RemoveGlobalDuplicates.cmake
+++ b/tribits/core/utils/RemoveGlobalDuplicates.cmake
@@ -40,7 +40,7 @@
 include(AssertDefined)
 include(GlobalSet)
 
-#
+
 # @FUNCTION: remove_global_duplicates()
 #
 # Remove duplicate elements from a global list variable (removes boiler-plate

--- a/tribits/core/utils/SetAndIncDirs.cmake
+++ b/tribits/core/utils/SetAndIncDirs.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @MACRO: set_and_inc_dirs()
 #
 # Set a variable to an include directory and call ``include_directories()``

--- a/tribits/core/utils/SetCacheOnOffEmpty.cmake
+++ b/tribits/core/utils/SetCacheOnOffEmpty.cmake
@@ -38,7 +38,6 @@
 # @HEADER
 
 
-#
 # @FUNCTION: set_cache_on_off_empty()
 #
 # Usage::

--- a/tribits/core/utils/SetDefault.cmake
+++ b/tribits/core/utils/SetDefault.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @MACRO: set_default()
 #
 # Give a local variable a default value if a non-empty value is not already

--- a/tribits/core/utils/SetDefaultAndFromEnv.cmake
+++ b/tribits/core/utils/SetDefaultAndFromEnv.cmake
@@ -38,11 +38,10 @@
 # @HEADER
 
 
-
 include(SetDefault)
 include(PrintVar)
 
-#
+
 # @MACRO: set_default_and_from_env()
 #
 # Set a default value for a local variable and override from an environment

--- a/tribits/core/utils/Split.cmake
+++ b/tribits/core/utils/Split.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @FUNCTION: split()
 #
 # Split a string variable into a string array/list variable.

--- a/tribits/core/utils/TimingUtils.cmake
+++ b/tribits/core/utils/TimingUtils.cmake
@@ -46,7 +46,7 @@
 
 include(Split)
 
-#
+
 # @FUNCTION: timer_get_raw_seconds()
 #
 # Return the raw time in seconds (nano-second accuracy) since epoch, i.e.,
@@ -76,7 +76,6 @@ function(timer_get_raw_seconds   SECONDS_DEC_OUT)
 endfunction()
 
 
-#
 # @FUNCTION: timer_get_rel_seconds()
 #
 # Return the relative time between start and stop seconds.
@@ -114,7 +113,6 @@ function(timer_get_rel_seconds  ABS_SECONDS_DEC_START
 endfunction()
 
 
-#
 # @FUNCTION: timer_print_rel_time()
 #
 # Print the relative time between start and stop timers in ``<min>m<sec>s``

--- a/tribits/core/utils/TribitsFilepathHelpers.cmake
+++ b/tribits/core/utils/TribitsFilepathHelpers.cmake
@@ -1,7 +1,7 @@
 include(MessageWrapper)
 include(Split)
 
-#
+
 # @FUNCTION: tribits_dir_is_basedir()
 #
 # Function to determine if a given path is a base dir of another path.
@@ -49,7 +49,6 @@ function(tribits_dir_is_basedir  absBaseDir  absFullDir  isBaseDirVarOut)
 endfunction()
 
 
-#
 # @FUNCTION: tribits_get_dir_array_below_base_dir()
 #
 # Returns the array of directories below a base directory.

--- a/tribits/core/utils/TribitsStandardizePaths.cmake
+++ b/tribits/core/utils/TribitsStandardizePaths.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-#
+
 # @FUNCTION: tribits_standardize_abs_paths()
 #
 # Function uses get_filename_component() to standardize a list of paths to be

--- a/tribits/core/utils/TribitsStripQuotesFromStr.cmake
+++ b/tribits/core/utils/TribitsStripQuotesFromStr.cmake
@@ -1,4 +1,3 @@
-#
 # @FUNCTION: tribits_strip_quotes_from_str()
 #
 # Remove one set of quotes from the outside of a string if they exist.

--- a/tribits/ctest_driver/TribitsCTestDriverCore.cmake
+++ b/tribits/ctest_driver/TribitsCTestDriverCore.cmake
@@ -210,7 +210,6 @@ site_name(CTEST_SITE_DEFAULT)
 include(TribitsCTestDriverCoreHelpers)
 
 
-#
 # @FUNCTION: tribits_ctest_driver()
 #
 # Universal platform-independent CTest/CDash driver function for CTest -S


### PR DESCRIPTION
I did this as part of addressing post-merge review comments for PR #485 but I did not want to include this glut of files in the follow-up PR #486.