### PR TITLE
Fix some spelling errors

### DIFF
--- a/tribits/core/package_arch/TribitsGitRepoVersionInfo.cmake
+++ b/tribits/core/package_arch/TribitsGitRepoVersionInfo.cmake
@@ -153,7 +153,7 @@ function(tribits_generate_single_repo_version_string  gitRepoDir
 
 endfunction()
 # NOTE: Above, it is fine if ${maxSummaryLen} > len(${gitCmndOutput}) as
-# string(SUBSTRING ...) will just shorten this to the lenght of the string.
+# string(SUBSTRING ...) will just shorten this to the length of the string.
 
 
 function(tribits_assert_git_executable)

--- a/tribits/core/package_arch/TribitsGlobalMacros.cmake
+++ b/tribits/core/package_arch/TribitsGlobalMacros.cmake
@@ -542,7 +542,7 @@ macro(tribits_define_global_options_and_define_extra_repos)
   advanced_set(${PROJECT_NAME}_IMPORTED_NO_SYSTEM
     ${${PROJECT_NAME}_IMPORTED_NO_SYSTEM_DEFAULT}
     CACHE BOOL
-    "If set TRUE, then set IMPORTED_NO_SYSTEM proeprty on all exported libraries.")
+    "If set TRUE, then set IMPORTED_NO_SYSTEM property on all exported libraries.")
 
   if (CMAKE_VERSION VERSION_LESS 3.23 AND ${PROJECT_NAME}_IMPORTED_NO_SYSTEM)
     message(FATAL_ERROR "Error, setting ${PROJECT_NAME}_IMPORTED_NO_SYSTEM='${${PROJECT_NAME}_IMPORTED_NO_SYSTEM}' for CMake version '${CMAKE_VERSION}' < 3.23 is not allowed!")
@@ -2035,7 +2035,7 @@ endfunction()
 
 # Configure the enabled packages
 #
-# This macro actally calls add_subdirectory(<packageDir>) on the enabled
+# This macro actually calls add_subdirectory(<packageDir>) on the enabled
 # TriBITS packages.
 #
 macro(tribits_configure_enabled_packages)

--- a/tribits/core/utils/TribitsGetImportedLocationProperty.cmake
+++ b/tribits/core/utils/TribitsGetImportedLocationProperty.cmake
@@ -42,7 +42,7 @@ include_guard()
 include(CMakeBuildTypesList)
 
 
-# Return the value of the target proeprty IMPORTED_LOCATION_<CONFIG> for every
+# Return the value of the target property IMPORTED_LOCATION_<CONFIG> for every
 # known <CONFIG> and returns the fist non-null value.  Otherwise, returns
 # empty.
 #

--- a/tribits/ctest_driver/TribitsCTestDriverCoreHelpers.cmake
+++ b/tribits/ctest_driver/TribitsCTestDriverCoreHelpers.cmake
@@ -1262,7 +1262,7 @@ endmacro()
 # ${PROJECT_NAME}_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON but the target
 # <thePackage>_libs is attempted to be built anyway and we expect it to build
 # nothing and result in no error.  (The outer ctest -S driver is not smart
-# enough to know all the lgoic for if a package will actaully be enabled or
+# enough to know all the lgoic for if a package will actually be enabled or
 # not.  That is the job of the inner TriBITS dependency logic and
 # ${PROJECT_NAME}_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON.) Otherwise, with
 # CMake 3.19+, cmake_build() catches errors in undefined global build targets

--- a/tribits/doc/guides/TribitsCoreDetailedReference.rst
+++ b/tribits/doc/guides/TribitsCoreDetailedReference.rst
@@ -369,7 +369,7 @@ These options are described below.
 
   This default can be set in `<projectDir>/ProjectName.cmake`_ or `<projectDir>/CMakeLists.txt`_.
 
-  On WIN32 sytems, the default for ``${PROJECT_NAME}_ENABLE_Fortran_DEFAULT``
+  On WIN32 systems, the default for ``${PROJECT_NAME}_ENABLE_Fortran_DEFAULT``
   is set to ``OFF`` since it can be difficult to get a Fortran compiler for
   native Windows.
 

--- a/tribits/python_utils/SnapshotDir.py
+++ b/tribits/python_utils/SnapshotDir.py
@@ -357,7 +357,7 @@ def snapshotDirMainDriver(cmndLineArgs, defaultOptionsIn = None, stdout = None):
     clp.add_argument(
       "--no-op", dest="noOp", action="store_true",
       default=False,
-      help="Don't actaully run any commands that would change the state other"
+      help="Don't actually run any commands that would change the state other"
       +" (other than the natural side-effects of running git query commands)" )
 
     options = clp.parse_args(cmndLineArgs)


### PR DESCRIPTION
Just fixing a few random spelling errors.  Nothing that affects the execution although there is one that appears in an error/warning message visible to users.