### PR TITLE
Remove assert for TPL_<tplName>_LIBRARIES (#299)

### DIFF
--- a/tribits/core/package_arch/TribitsProcessEnabledTpl.cmake
+++ b/tribits/core/package_arch/TribitsProcessEnabledTpl.cmake
@@ -148,9 +148,6 @@ function(tribits_process_enabled_tpl  TPL_NAME)
         "ERROR: TPL_${TPL_NAME}_NOT_FOUND=${TPL_${TPL_NAME}_NOT_FOUND}, aborting!")
     endif()
 
-    # Assert that the TPL correctly defined all of these variables
-    assert_defined(TPL_${TPL_NAME}_LIBRARIES)
-
     # Generate the <tplName>ConfigVersion.cmake file if it has not been
     # created yet and add install targets for <tplName>Config[Version].cmake
     set(buildDirExternalPkgsDir


### PR DESCRIPTION
With the new TriBITS TPl implementation, the is no need for a FindTPL<tplName>.cmake file to set the var TPL_<tplName>_LIBRARIES so there is no need to assert it.

This came up when refactoring the FindTPLCUBLAS.cmake, FindTPLCUSPARSE.cmake and FindTPLCUSOLVE.cmake files in Trilinos as part of the PR trilinos/Trilinos#10614.