### PR TITLE
Add, use, and document new function tribits_external_package_create_imported_all_libs_target_and_config_file() (#299)

### DIFF
--- a/test/core/ExamplesUnitTests/TribitsExampleApp2_Tests.cmake
+++ b/test/core/ExamplesUnitTests/TribitsExampleApp2_Tests.cmake
@@ -103,16 +103,8 @@ function(TribitsExampleApp2  tribitsExProj2TestNameBaseBase
   if (fullOrComponents STREQUAL "FULL")
     set(tribitsExProjUseComponentsArg "")
   elseif (fullOrComponents STREQUAL "COMPONENTS")
-    if (tribitsExProj2TestNameBaseBase STREQUAL "TribitsExampleProject2_find_package")
-      # ToDo: Remove this special case once the test
-      # TribitsExampleProject2_find_package enables all the packages!
-      set(tribitsExProjUseComponentsArg
-        -DTribitsExApp2_USE_COMPONENTS="Package1")
-      set(fullDepsRegex "Full Deps: Package1{tpl1}")
-    else()
-      set(tribitsExProjUseComponentsArg
-        -DTribitsExApp2_USE_COMPONENTS="Package1,Package2,Package3")
-    endif()
+    set(tribitsExProjUseComponentsArg
+      -DTribitsExApp2_USE_COMPONENTS="Package1,Package2,Package3")
   else()
     message(FATAL_ERROR "Invalid value of fullOrComponents='${fullOrComponents}'!")
   endif()
@@ -141,6 +133,7 @@ function(TribitsExampleApp2  tribitsExProj2TestNameBaseBase
         ${tribitsExProjUseComponentsArg}
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleApp2
       PASS_REGULAR_EXPRESSION_ALL
+        "TribitsExProj2_PACKAGE_LIST = Package3[;]Package2[;]Package1"
         "-- Configuring done"
         "-- Generating done"
         "-- Build files have been written to: .*/${testName}/app_build"

--- a/test/core/ExamplesUnitTests/TribitsExampleProject2_Tests.cmake
+++ b/test/core/ExamplesUnitTests/TribitsExampleProject2_Tests.cmake
@@ -88,7 +88,7 @@ endmacro()
 ########################################################################
 
 
-function(TribitsExampleProject2_find_tpl_parts sharedOrStatic findingTplsMethod)
+function(TribitsExampleProject2_find_tpl_parts  sharedOrStatic  findingTplsMethod)
 
   TribitsExampleProject2_test_setup_header()
 
@@ -282,7 +282,7 @@ TribitsExampleProject2_find_tpl_parts(SHARED  CMAKE_PREFIX_PATH_ENV)
 ########################################################################
 
 
-function(TribitsExampleProject2_find_tpl_parts_no_optional_packages_tpls sharedOrStatic)
+function(TribitsExampleProject2_find_tpl_parts_no_optional_packages_tpls  sharedOrStatic)
 
   TribitsExampleProject2_test_setup_header()
 
@@ -395,7 +395,7 @@ TribitsExampleProject2_find_tpl_parts_no_optional_packages_tpls(SHARED)
 ########################################################################
 
 
-function(TribitsExampleProject2_explicit_tpl_vars sharedOrStatic)
+function(TribitsExampleProject2_explicit_tpl_vars  sharedOrStatic)
 
   TribitsExampleProject2_test_setup_header()
 

--- a/test/core/ExamplesUnitTests/TribitsExampleProject2_Tests.cmake
+++ b/test/core/ExamplesUnitTests/TribitsExampleProject2_Tests.cmake
@@ -531,10 +531,9 @@ function(TribitsExampleProject2_find_package  sharedOrStatic)
         ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject2
       ALWAYS_FAIL_ON_NONZERO_RETURN
       PASS_REGULAR_EXPRESSION_ALL
-        "Using find_package[(]Tpl1 [.][.][.][)] [.][.][.]"
-        "Found Tpl1_DIR='.*TribitsExampleProject2_Tpls_install_${sharedOrStatic}/install_tpl1/lib/cmake/Tpl1'"
-        "TPL_Tpl1_LIBRARIES='Tpl1::all_libs'"
-        "TPL_Tpl1_INCLUDE_DIRS=''"
+        "-- Using find_package[(]Tpl1 [.][.][.][)] [.][.][.]"
+        "-- Found Tpl1_DIR='.*TribitsExampleProject2_Tpls_install_${sharedOrStatic}/install_tpl1/lib/cmake/Tpl1'"
+        "-- Generating Tpl1::all_libs and Tpl1Config.cmake"
         "-- Configuring done"
         "-- Generating done"
 

--- a/test/core/ExamplesUnitTests/TribitsExampleProject2_Tests.cmake
+++ b/test/core/ExamplesUnitTests/TribitsExampleProject2_Tests.cmake
@@ -504,11 +504,11 @@ TribitsExampleProject2_explicit_tpl_vars(SHARED)
 ########################################################################
 
 
-function(TribitsExampleProject2_find_package_test sharedOrStatic)
+function(TribitsExampleProject2_find_package  sharedOrStatic)
 
   TribitsExampleProject2_test_setup_header()
 
-  set(testNameBase TribitsExampleProject2_find_package_${sharedOrStatic})
+  set(testNameBase ${CMAKE_CURRENT_FUNCTION}_${sharedOrStatic})
   set(testName ${PACKAGE_NAME}_${testNameBase})
   set(testDir "${CMAKE_CURRENT_BINARY_DIR}/${testName}")
 
@@ -578,8 +578,8 @@ function(TribitsExampleProject2_find_package_test sharedOrStatic)
 endfunction()
 
 
-TribitsExampleProject2_find_package_test(STATIC)
-TribitsExampleProject2_find_package_test(SHARED)
+TribitsExampleProject2_find_package(STATIC)
+TribitsExampleProject2_find_package(SHARED)
 
 
 ########################################################################

--- a/tribits/core/package_arch/TribitsExternalPackageFindTplHelpers.cmake
+++ b/tribits/core/package_arch/TribitsExternalPackageFindTplHelpers.cmake
@@ -64,6 +64,9 @@
 # ``find_dependency(<externalPkg>)`` (with no other argument) and then, again,
 # defines the correct imported library dependency.
 #
+# For more details, see `Creating FindTPL*.cmake using find_package() with
+# IMPORTED targets`_.
+#
 function(tribits_external_package_create_imported_all_libs_target_and_config_file
     tplName
   )

--- a/tribits/core/package_arch/TribitsExternalPackageFindTplHelpers.cmake
+++ b/tribits/core/package_arch/TribitsExternalPackageFindTplHelpers.cmake
@@ -1,0 +1,129 @@
+# @HEADER
+# ************************************************************************
+#
+#            TriBITS: Tribal Build, Integrate, and Test System
+#                    Copyright 2013 Sandia Corporation
+#
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the Corporation nor the names of the
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# ************************************************************************
+# @HEADER
+
+
+# @FUNCTION: tribits_external_package_create_imported_all_libs_target_and_config_file()
+#
+# Call from a ``FindTPL<tplName>.cmake`` module that calls inner
+# ``find_package(<externalPkg>)`` for external package that uses modern CMake
+# IMPORTED targets.
+#
+# Usage::
+#
+#   tribits_external_package_create_imported_all_libs_target_and_config_file(
+#     <tplName>
+#     INNER_FIND_PACKAGE_NAME <externalPkg>
+#     IMPORTED_TARGETS_FOR_ALL_LIBS <importedTarget0> <importedTarget1> ... )
+#
+# This function is called in a TriBITS ``FindTPL<tplName>.cmake`` wrapper
+# module after it calls ``find_package(<externalPkg>)`` and then creates the
+# IMPORTED target ``<tplName>::all_libs`` from the list of IMPORTED targets
+# ``<importedTarget0> <importedTarget1> ...`` which are defined from the call
+# ``find_package(<externalPkg>)``.  This function also takes care of
+# generating the correct ``<tplName>Config.cmake`` file under the directory::
+#
+#   ${${PROJECT_NAME}_BINARY_DIR}/${${PROJECT_NAME}_BUILD_DIR_EXTERNAL_PKGS_DIR}
+#
+# The generated ``<tplName>Config.cmake`` file calls
+# ``find_dependency(<externalPkg>)`` (with no other argument) and then, again,
+# defines the correct imported library dependency.
+#
+function(tribits_external_package_create_imported_all_libs_target_and_config_file
+    tplName
+  )
+
+  # Parse arguments
+  cmake_parse_arguments(
+     PARSE_ARGV 1
+     PARSE "" "" # prefix, options, one_value_keywords
+     "INNER_FIND_PACKAGE_NAME;IMPORTED_TARGETS_FOR_ALL_LIBS"  #multi_value_keywords
+     )
+  tribits_check_for_unparsed_arguments(PARSE)
+  tribits_assert_parse_arg_one_value(PARSE  INNER_FIND_PACKAGE_NAME)
+  tribits_assert_parse_arg_one_or_more_values(PARSE IMPORTED_TARGETS_FOR_ALL_LIBS)
+
+  # Create imported target <tplName>::all_libs
+  add_library(${tplName}::all_libs  INTERFACE  IMPORTED  GLOBAL)
+  foreach (importedTarget  IN LISTS  PARSE_IMPORTED_TARGETS_FOR_ALL_LIBS)
+    target_link_libraries(${tplName}::all_libs  INTERFACE  ${importedTarget})
+  endforeach()
+
+  # Create <tplName>Config.cmake file
+  tribits_external_package_create_package_config_file_with_imported_targets(
+    ${tplName}
+    INNER_FIND_PACKAGE_NAME ${PARSE_INNER_FIND_PACKAGE_NAME}
+    IMPORTED_TARGETS_FOR_ALL_LIBS ${PARSE_IMPORTED_TARGETS_FOR_ALL_LIBS} )
+
+endfunction()
+
+
+function(tribits_external_package_create_package_config_file_with_imported_targets
+    tplName
+  )
+
+  # Parse arguments
+  cmake_parse_arguments(
+     PARSE_ARGV 1
+     PARSE "" "" # prefix, options, one_value_keywords
+     "INNER_FIND_PACKAGE_NAME;IMPORTED_TARGETS_FOR_ALL_LIBS"  #multi_value_keywords
+     )
+  tribits_check_for_unparsed_arguments(PARSE)
+  tribits_assert_parse_arg_one_value(PARSE  INNER_FIND_PACKAGE_NAME)
+  tribits_assert_parse_arg_one_or_more_values(PARSE IMPORTED_TARGETS_FOR_ALL_LIBS)
+  set(externalPkg ${PARSE_INNER_FIND_PACKAGE_NAME})
+
+  # Create <tplName>Config.cmake file
+  set(configFileStr "")
+  string(APPEND configFileStr
+    "include(CMakeFindDependencyMacro)\n"
+    "set(${externalPkg}_DIR \"${${externalPkg}_DIR}\")\n"
+    "find_dependency(${externalPkg})\n"
+    "add_library(${tplName}::all_libs  INTERFACE  IMPORTED  GLOBAL)\n"
+    )
+  foreach (importedTarget  IN LISTS  PARSE_IMPORTED_TARGETS_FOR_ALL_LIBS)
+    string(APPEND configFileStr
+      "target_link_libraries(${tplName}::all_libs  INTERFACE  ${importedTarget})\n")
+  endforeach()
+  set(buildDirExternalPkgsDir
+    "${${PROJECT_NAME}_BINARY_DIR}/${${PROJECT_NAME}_BUILD_DIR_EXTERNAL_PKGS_DIR}")
+  set(tplConfigFile
+    "${buildDirExternalPkgsDir}/${tplName}/${tplName}Config.cmake")
+  file(WRITE "${tplConfigFile}" "${configFileStr}")
+
+endfunction()

--- a/tribits/core/package_arch/TribitsExternalPackageWriteConfigFile.cmake
+++ b/tribits/core/package_arch/TribitsExternalPackageWriteConfigFile.cmake
@@ -61,9 +61,9 @@ cmake_policy(SET CMP0057 NEW) # Support if ( ... IN_LIST ... )
 #   ``<tplConfigFile>``: Full file path for the ``<tplName>Config.cmake``
 #   file that will be written out.
 #
-# This function just calls
-# ``tribits_external_package_write_config_file_str()`` and writes that text to
-# the file ``<tplConfigFile>`` so see that function for more details.
+# This function just calls `tribits_external_package_write_config_file_str()`_
+# and writes that text to the file ``<tplConfigFile>`` so see that function
+# for more details.
 #
 function(tribits_external_package_write_config_file  tplName  tplConfigFile)
   tribits_external_package_write_config_file_str(${tplName} tplConfigFileStr)
@@ -172,30 +172,81 @@ endfunction()
 #   tribits_external_package_write_config_file_str(
 #     <tplName> <tplConfigFileStrOut> )
 #
-# The arguments are:
+# The function arguments are:
 #
 #   ``<tplName>``: Name of the external package/TPL
 #
 #   ``<tplConfigFileStrOut>``: Name of variable that will contain the string
 #   for the config file on output.
 #
-# This function reads from the variables ``TPL_<tplName>_INCLUDE_DIRS``
-# ``TPL_<tplName>_LIBRARIES``, and ``<tplName>_LIB_ENABLED_DEPENDENCIES``
+# This function reads from the (cache) variables
+#
+#   * ``TPL_<tplName>_INCLUDE_DIRS``
+#   * ``TPL_<tplName>_LIBRARIES``
+#   * ``<tplName>_LIB_ENABLED_DEPENDENCIES``
+#
 # (which must already be set) and uses that information to produce the
 # contents of the ``<tplName>Config.cmake`` which is returned as a string
 # variable that contains IMPORTED targets to represent these libraries and
 # include directories as well as ``find_dependency()`` calls for upstream
-# packages listed in ``<tplName>_LIB_ENABLED_DEPENDENCIES``
+# packages listed in ``<tplName>_LIB_ENABLED_DEPENDENCIES``.
 #
-# ToDo: Flesh out more documentation for behavior as more features are added
-# for handling:
+# The arguments in ``TPL_<tplName>_LIBRARIES`` are handled in special ways in
+# order to create the namespaced IMPORTED targets ``<tplName>::<libname>`` and
+# the ``<tplName>::all_libs`` target that depends on these.  The types of
+# arguments that are handled and how the are interpreted:
 #
-# * ``TPL_<tplName>_LIBRARIES`` containing ``-l`` and ``-L`` arguments ...
+#   ``<abs-base-path>/[lib]<libname>.<longest-ext>``
 #
-# * ``TPL_<tplName>_LIBRARIES`` containing arguments other than library files
-# * or ``-l`` and ``-L`` arguments and files.
+#     Arguments that are absolute file paths are treated as libraries and an
+#     imported target name ``<libname>`` is derived from the file name (of the
+#     form ``lib<libname>.<longest-ext>`` removing beginning ``lib`` and file
+#     extension ``.<longest-ext>``).  The IMPORTED target
+#     ``<tplName>::<libname>`` is created and the file path is set using the
+#     ``IMPORTED_LOCATION`` target property.
 #
-function(tribits_external_package_write_config_file_str tplName tplConfigFileStrOut)
+#   ``-l<libname>``
+#
+#     Arguments of the form ``-l<libname>`` are used to create IMPORTED
+#     targets with the name ``<tplName>::<libname>`` using the
+#     ``IMPORTED_LIBNAME`` target property.
+#
+#   ``<libname>``
+#
+#     Arguments that are a raw name that matches the regex
+#     ``^[a-zA-Z_][a-zA-Z0-9_-]*$`` are interpreted to be a library name
+#     ``<libname>`` and is used to create an IMPORTED targets
+#     ``<tplName>::<libname>`` using the ``IMPORTED_LIBNAME`` target property.
+#
+#   ``-L<dir>``
+#
+#     Link directories.  These are pulled off and added to the
+#     ``<tplName>::all_libs`` using ``target_link_options()``.  (The order of
+#     these options is maintained.)
+#
+#   ``-<any-option>``
+#
+#     Any other option that starts with ``-`` is assumed to
+#     be a link argument where the order does not matter in relation to the
+#     libraries (but the order of these extra options are maintained w.r.t. each
+#     other).
+#
+#   ``<unrecognized>``
+#
+#     Any other argument that does not match one of the above patterns is
+#     regarded as an error.
+#
+# For more details on the handling of individual ``TPL_<tplName>_LIBRARIES``
+# arguments, see `tribits_tpl_libraries_entry_type()`_.
+#
+# The list of directories given in ``TPL_<tplName>_INCLUDE_DIRS`` is added to
+# the ``<tplName>::all_libs`` target using ``target_include_directories()``.
+#
+# Finally, for every ``<upstreamTplName>`` listed in
+# ``<tplName>_LIB_ENABLED_DEPENDENCIES``, a link dependency is created using
+# ``target_link_library(<tplName>::all_libs INTERFACE <upstreamTplName>)``.
+#
+function(tribits_external_package_write_config_file_str  tplName  tplConfigFileStrOut)
 
   # A) Set up beginning of config file text
   set(configFileStr "")
@@ -402,30 +453,36 @@ function(tribits_external_package_process_libraries_list  tplName)
 endfunction()
 
 
+# @FUNCTION: tribits_tpl_libraries_entry_type()
+#
 # Returns the type of the library entry in the list TPL_<tplName>_LIBRARIES
+#
+# Usage::
+#
+#   tribits_tpl_libraries_entry_type(<libentry>  <libEntryTypeOut>)
 #
 # Arguments:
 #
-#   ``libentry`` [in]: Element of ``TPL_<tplName>_LIBRARIES``
+#   ``<libentry>`` [in]: Element of ``TPL_<tplName>_LIBRARIES``
 #
-#   ``libEntryTypeOut`` [out]: Variable set on output to the type of entry.
+#   ``<libEntryTypeOut>`` [out]: Variable set on output to the type of entry.
 #
 # The types of entries set on ``libEntryTypeOut`` include:
 #
-#   ``FULL_LIB_PATH``: A full library path
+#   * ``FULL_LIB_PATH``: A full library path
 #
-#   ``LIB_NAME_LINK_OPTION``: A library name link option of the form
-#   ``-l<libname>``
+#   * ``LIB_NAME_LINK_OPTION``: A library name link option of the form
+#     ``-l<libname>``
 #
-#   ``LIB_NAME``: A library name of the form ``<libname>``
+#   * ``LIB_NAME``: A library name of the form ``<libname>``
 #
-#   ``LIB_DIR_LINK_OPTION``: A library directory search option of the form
-#   ``-L<dir>``
+#   * ``LIB_DIR_LINK_OPTION``: A library directory search option of the form
+#     ``-L<dir>``
 #
-#   ``GENERAL_LINK_OPTION``: Some other general link option that starts with
-#   ``-`` but is not ``-l`` or ``-L``.
+#   * ``GENERAL_LINK_OPTION``: Some other general link option that starts with
+#     ``-`` but is not ``-l`` or ``-L``.
 #
-#   ``UNSUPPORTED_LIB_ENTRY``: An unsupported lib option
+#   * ``UNSUPPORTED_LIB_ENTRY``: An unsupported lib option
 #
 function(tribits_tpl_libraries_entry_type  libentry  libEntryTypeOut)
   string(SUBSTRING "${libentry}" 0 1 firstCharLibEntry)

--- a/tribits/core/package_arch/TribitsProcessEnabledTpl.cmake
+++ b/tribits/core/package_arch/TribitsProcessEnabledTpl.cmake
@@ -39,6 +39,7 @@
 
 
 # Standard TriBITS Includes
+include(TribitsExternalPackageFindTplHelpers)
 include(TribitsExternalPackageWriteConfigFile)
 include(TribitsTplFindIncludeDirsAndLibraries)
 include(TribitsGeneralMacros)

--- a/tribits/core/package_arch/TribitsTplFindIncludeDirsAndLibraries.cmake
+++ b/tribits/core/package_arch/TribitsTplFindIncludeDirsAndLibraries.cmake
@@ -99,8 +99,9 @@ include(Split)
 # to disable the prefind call to ``find_package()`` even if it would be
 # allowed otherwise.
 #
-# See `How to use find_package() for a TriBITS TPL`_ for details in how to use
-# this function to create a ``FindTPL<tplName>.cmake`` module file.
+# See `Creating FindTPL*.cmake using find_package() without IMPORTED targets`_
+# for details in how to use this function to create a
+# ``FindTPL<tplName>.cmake`` module file.
 #
 function(tribits_tpl_allow_pre_find_package  TPL_NAME  ALLOW_PACKAGE_PREFIND_OUT)
 
@@ -157,10 +158,12 @@ endfunction()
 
 # @FUNCTION: tribits_tpl_find_include_dirs_and_libraries()
 #
-# Function that sets up cache variables for users to specify where to find a
-# `TriBITS TPL`_'s headers and libraries.  This function is typically called
-# inside of a ``FindTPL<tplName>.cmake`` module file (see
-# `${TPL_NAME}_FINDMOD`_).
+# This function reads (cache) variables that specify where to find a `TriBITS
+# TPL`_'s headers and libraries and then creates IMPORTED targets, the
+# ``<tplName>::all_libs`` target, and writes the file
+# ``<tplName>Config.cmake`` into the standard location in the build directory.
+# This function is typically called inside of a ``FindTPL<tplName>.cmake``
+# module file (see `${TPL_NAME}_FINDMOD`_).
 #
 # Usage::
 #
@@ -190,22 +193,23 @@ endfunction()
 #   ``MUST_FIND_ALL_HEADERS``
 #
 #     If set, then all of the header files listed in ``REQUIRED_HEADERS`` must
-#     be found in order for ``TPL_<tplName>_INCLUDE_DIRS`` to be defined.
+#     be found (unless ``TPL_<tplName>_INCLUDE_DIRS`` is already set).
 #
 #   ``REQUIRED_LIBS_NAMES``
 #
 #     List of libraries that are searched for when looking for the TPL's
 #     libraries using ``find_library()``.  This list can be overridden by the
-#     user by setting ``<tplName>_LIBRARY_DIRS`` (see below).
+#     user by setting ``<tplName>_LIBRARY_NAMES`` (see below).
 #
 #   ``MUST_FIND_ALL_LIBS``
 #
 #     If set, then all of the library files listed in ``REQUIRED_LIBS_NAMES``
-#     must be found or the TPL is considered not found!  If the global cache
-#     var ``<Project>_MUST_FIND_ALL_TPL_LIBS`` is set to ``TRUE``, then this
-#     is turned on as well.  WARNING: The default is not to require finding
-#     all of the listed libs.  This is to maintain backward compatibility with
-#     some older ``FindTPL<tplName>.cmake`` modules.
+#     must be found or the TPL is considered not found (unless
+#     ``TPL_<tplName>_LIBRARIES`` is already set).  If the global cache var
+#     ``<Project>_MUST_FIND_ALL_TPL_LIBS`` is set to ``TRUE``, then this is
+#     turned on as well.  WARNING: The default is not to require finding all
+#     of the listed libs.  (This is to maintain backward compatibility with
+#     some older ``FindTPL<tplName>.cmake`` modules.)
 #
 #   ``NO_PRINT_ENABLE_SUCCESS_FAIL``
 #
@@ -214,50 +218,69 @@ endfunction()
 # This function implements the TPL find behavior described in `Enabling
 # support for an optional Third-Party Library (TPL)`_.
 #
-# The following (cache) variables, if set, will be used by that this function:
+# The following (cache) variables, if set, will be used by this function:
 #
 #   ``<tplName>_INCLUDE_DIRS`` (type ``PATH``)
 #
 #     List of paths to search first for header files defined in
-#     ``REQUIRED_HEADERS``.
+#     ``REQUIRED_HEADERS <header1> <header2> ...``.
 #
 #   ``<tplName>_LIBRARY_DIRS`` (type ``PATH``)
 #
 #     The list of directories to search first for libraries defined in
-#     ``REQUIRED_LIBS_NAMES``.  If, for some reason, no libraries should be
-#     linked in for this particular configuration, then setting
-#     ``<tplName>_LIBRARY_DIRS=OFF`` will 
+#     ``REQUIRED_LIBS_NAMES <libname1> <libname2> ...``.  If, for some reason,
+#     no libraries should be linked in for this particular configuration, then
+#     setting ``<tplName>_LIBRARY_DIRS=OFF`` or is empty will no special paths
+#     will be searched.
 #
 #   ``<tplName>_LIBRARY_NAMES`` (type ``STRING``)
 #
 #     List of library names to be looked for instead of what is specified in
-#     ``REQUIRED_LIBS_NAMES``.
+#     ``REQUIRED_LIBS_NAMES <libname1> <libname2> ...``.
 #
-# This function sets global variables to return state so it can be called from
-# anywhere in the call stack.  The following cache variables are defined that
-# are intended for the user to set and/or use:
+#   ``<tplName>_LIB_ENABLED_DEPENDENCIES``
+#
+#     List of direct upstream external package/TPL dependencies that also
+#     define ``<upstreamTplName>::all_libs`` targets.
+#
+# An addition, the function will avoid calling the find operations if the
+# following (cache) variables are set on input:
 #
 #   ``TPL_<tplName>_INCLUDE_DIRS`` (type ``PATH``)
 #
 #     A list of common-separated full directory paths that contain the TPL's
-#     header files.  If this variable is set before calling this function,
-#     then no headers are searched for and this variable will be assumed to
-#     have the correct list of header paths.
+#     header files.
 #
 #   ``TPL_<tplName>_LIBRARIES`` (type ``FILEPATH``)
 #
 #     A list of commons-separated full library names (i.e. output from
-#     ``find_library()``) for all of the libraries found for the TPL.  If this
-#     variable is set before calling this function, then no libraries are
-#     searched for and this variable will be assumed to have the correct list
-#     of libraries to link to.
+#     ``find_library()``) for all of the libraries for the TPL.
+#
+# This function produces the following:
 #
 #   ``TPL_<tplName>_NOT_FOUND`` (type ``BOOL``)
 #
 #     Will be set to ``ON`` if all of the parts of the TPL could not be found.
 #
-# ToDo: Document the behavior of this function for finding headers and
-# libraries and when a find is successful and when it is not.
+#   ``<tplName>::<libname>``
+#
+#     Namespaced IMPORTED target for every library found or specified in
+#     ``TPL_<tplName>_LIBRARIES``.  These IMPORTED targets will have the
+#     ``<upstreamTplName>::all_libs`` for the upstream external packages/TPLs
+#     listed in ``<tplName>_LIB_ENABLED_DEPENDENCIES``.
+#
+#   ``<tplName>::all_libs``
+#
+#     INTERFACE target that depends on all of the created IMPORTED targets.
+#
+#   ``<buildDir>/external_packages/<tplName>/<tplName>Config.cmake``
+#
+#     A package configure file that contains all of the generated IMPORTED
+#     targets ``<tplName>::<libname>`` and the ``<tplName>::all_libs`` target.
+#     This fill will also call ``find_dependency()`` to pull in
+#     ``<upstreamTplName>Config.cmake`` files for upstream TPLs that are
+#     listed in ``<tplName>_LIB_ENABLED_DEPENDENCIES``.  (For more
+#     information, see `tribits_external_package_write_config_file()`_.)
 #
 # Note, if ``TPL_TENTATIVE_ENABLE_<tplName>=ON``, then if all of the parts of
 # the TPL can't be found, then ``TPL_ENABLE_<tplName>`` will be (forced) set
@@ -358,7 +381,7 @@ function(tribits_tpl_find_include_dirs_and_libraries TPL_NAME)
 
   else()
 
-    set(${TPL_NAME}_LIBRARY_DIRS) # Just to ignore below!
+    set(${TPL_NAME}_LIBRARY_DIRS "") # Just to ignore below!
 
   endif()
 

--- a/tribits/doc/guides/TribitsGuidesBody.rst
+++ b/tribits/doc/guides/TribitsGuidesBody.rst
@@ -2,12 +2,12 @@ Background
 ==========
 
 In order to easily find the most appropriate documentation, see the `TriBITS
-Developer and User Roles`_ guide.  This guide describes the different roles 
+Developer and User Roles`_ guide.  This guide describes the different roles
 that users of TriBITS may play and offers links to relevant sections of the
-documentation.  Additionally, the reader may wish to review the `CMake Language 
-Overview and Gotchas`_ section which is meant for users that are new to both 
+documentation.  Additionally, the reader may wish to review the `CMake Language
+Overview and Gotchas`_ section which is meant for users that are new to both
 CMake and TriBITS. This section gives a brief overview of getting started with
-CMake and provides some warnings about non-obvious CMake behavior that often 
+CMake and provides some warnings about non-obvious CMake behavior that often
 trips up new users of TriBITS.
 
 
@@ -21,7 +21,7 @@ Project User`_, 2) `TriBITS Project Developer`_, 3) `TriBITS Project
 Architect`_, 4) `TriBITS System Developer`_, and 5) `TriBITS System
 Architect`_.  Each of these roles builds on the necessary knowledge of the
 lower-level roles.
- 
+
 .. _TriBITS Project User:
 .. _TriBITS Project Users:
 
@@ -119,12 +119,12 @@ project.  As a result, many people can come into a project that uses TriBITS
 and quickly start to contribute by adding new source files, adding new
 libraries, adding new tests, and even adding new TriBITS packages and TPLs;
 all without really having learned anything about CMake.  Often one can use existing
-example CMake code as a guide and be successful using basic functionality. As long 
-as nothing out of the ordinary happens, many people can get along just fine in this 
+example CMake code as a guide and be successful using basic functionality. As long
+as nothing out of the ordinary happens, many people can get along just fine in this
 mode for a time.
 
-However, we have observed that most mistakes and problems that people run into when 
-using TriBITS are due to lack of basic knowledge of the CMake language.  One can find 
+However, we have observed that most mistakes and problems that people run into when
+using TriBITS are due to lack of basic knowledge of the CMake language.  One can find
 basic tutorials and references on the CMake language in various locations online for free.
 One can also purchase the `official CMake reference book`_.  Also, documentation
 for any built-in CMake command is available locally by running::
@@ -143,15 +143,15 @@ greater understanding of how TriBITS works.
 .. _Official CMake reference book: http://www.cmake.org/cmake/help/book.html
 
 The CMake language is used to write CMake projects with TriBITS. In fact the
-core TriBITS functionality itself is implemented in the CMake language (see 
-`TriBITS System Project Dependencies`_). CMake is a fairly simple programming 
-language with relatively simple rules (for the most part).  However, compared 
-to other programming languages, there are a few peculiar aspects to the CMake 
-language that can make working with it difficult if you don't understand these 
-rules.  For example there are unexpected variable scoping rules and how arguments 
-are passed to macros and functions can be tricky. Also, CMake has some interesting 
-gotchas.  In order to effectively use TriBITS (or just raw CMake) to construct 
-and maintain a project's CMake files, one must know the basic rules of CMake 
+core TriBITS functionality itself is implemented in the CMake language (see
+`TriBITS System Project Dependencies`_). CMake is a fairly simple programming
+language with relatively simple rules (for the most part).  However, compared
+to other programming languages, there are a few peculiar aspects to the CMake
+language that can make working with it difficult if you don't understand these
+rules.  For example there are unexpected variable scoping rules and how arguments
+are passed to macros and functions can be tricky. Also, CMake has some interesting
+gotchas.  In order to effectively use TriBITS (or just raw CMake) to construct
+and maintain a project's CMake files, one must know the basic rules of CMake
 and be aware of these gotchas.
 
 The first thing to understand about the CMake language is that nearly every
@@ -217,9 +217,9 @@ control structures (i.e. see ``cmake --help-command if`` and ``cmake
 CMake offers a rich assortment of built-in commands for doing all sorts of
 things.  Two of these are the built-in ``macro()`` and the ``function()``
 commands which allow you to create user-defined macros and functions. TriBITS
-is actually built on CMake functions and macros.  All of the built-in and 
-user-defined macros, and some functions take an  array of string arguments.  
-Some functions take in positional arguments. In fact,  most functions take a 
+is actually built on CMake functions and macros.  All of the built-in and
+user-defined macros, and some functions take an  array of string arguments.
+Some functions take in positional arguments. In fact,  most functions take a
 combination of positional and keyword arguments.
 
 Variable names are translated into their stored values using
@@ -598,7 +598,7 @@ ${PROJECT_SOURCE_DIR}``) are::
      project-checkin-test-config.py # [Optional] checkin-test.py config
      cmake/
        NativeRepositoriesList.cmake    # [Optional] Rarely used
-       ExtraRepositoriesList.cmake     # [Optional] Lists repos and VC URLs 
+       ExtraRepositoriesList.cmake     # [Optional] Lists repos and VC URLs
        ProjectCiFileChangeLogic.py     # [Optional] CI global change/test logic
        ProjectCompilerPostConfig.cmake # [Optional] Override/tweak build flags
        ProjectDependenciesSetup.cmake  # [Optional] Project deps overrides
@@ -903,16 +903,16 @@ are set.  This file in Trilinos looked like::
     ...
 
     include(${Kokkos_GEN_DIR}/kokkos_generated_settings.cmake)
-  
+
     if (NOT KOKKOS_ARCH STREQUAL "None")
-    
+
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KOKKOS_CXX_FLAGS}")
-    
+
       message("-- " "Skip adding flags for OpenMP because Kokkos flags does that ...")
       set(OpenMP_CXX_FLAGS_OVERRIDE " ")
-    
+
     endif()
-  
+
   endif()
 
 The exact context where this file is processed (if it exists) is described in
@@ -1942,7 +1942,7 @@ A TriBITS Subpackage:
   ``${PARENT_PACKAGE_NAME}_ENABLE_TESTS=ON``.
 
 The contents of a TriBITS Subpackage are almost identical to those of a
-TriBITS Package.  The differences are described below and in `How is a TriBITS 
+TriBITS Package.  The differences are described below and in `How is a TriBITS
 Subpackage different from a TriBITS Package?`_.
 
 For more details on the definition of a TriBITS Package (or subpackage), see:
@@ -2337,7 +2337,7 @@ proceeds through the call to `tribits_project()`_.
 |   5)  ``include(`` `<projectDir>/Version.cmake`_ ``)``
 |   6)  Define primary TriBITS options and read in the list of extra repositories
 |       (calls ``tribits_define_global_options_and_define_extra_repos()``)
-|       * ``include(`` `<projectDir>/cmake/ExtraRepositoriesList.cmake`_ ``)``      
+|       * ``include(`` `<projectDir>/cmake/ExtraRepositoriesList.cmake`_ ``)``
 |   7)  For each ``<repoDir>`` in all defined TriBITS repositories:
 |       * ``include(`` `<repoDir>/cmake/CallbackSetupExtraOptions.cmake`_ ``)``
 |       * Call macro ``tribits_repository_setup_extra_options()``
@@ -2381,7 +2381,7 @@ project, repository, package, and subpackage files should be clear.  All of
 this information should also be clear when enabling `File Processing
 Tracing`_ and watching the output from the ``cmake`` configure STDOUT.
 
-Reduced Package Dependency Processing 
+Reduced Package Dependency Processing
 ++++++++++++++++++++++++++++++++++++++
 
 In addition to the full processing that occurs as part of the `Full TriBITS
@@ -2667,7 +2667,7 @@ without having to define its own ``QT`` TPL in its repository's
    TriBITS, it can be difficult to know where the right place is to set a given
    set of variables.  The primary considerations for where to set a variable
    depend on:
- 
+
 .. ToDo: Describe considerations on where to set variables ...
 
 
@@ -3176,7 +3176,7 @@ enable/disable cache variables (with the initial default values)::
 
   Trilinos_ENABLE_Teuchos=""
   Trilinos_ENABLE_RTOp""
-  Trilinos_ENABLE_Epetra=""      
+  Trilinos_ENABLE_Epetra=""
   Trilinos_ENABLE_Triutils=""
   Trilinos_ENABLE_EpetraExt=""
   Trilinos_ENABLE_ThyraCore=""
@@ -3443,7 +3443,7 @@ In more detail, these rules/behaviors are:
     variable `${PROJECT_NAME}_DISABLE_ENABLED_FORWARD_DEP_PACKAGES`_:
 
     .. _${PROJECT_NAME}_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON:
- 
+
     * If ``${PROJECT_NAME}_DISABLE_ENABLED_FORWARD_DEP_PACKAGES=ON``, then
       TriBITS will disable the explicit enable and continue on.  In the above
       example, TriBITS will override ``Trilinos_ENABLE_RTOp=ON`` and set
@@ -3475,7 +3475,7 @@ In more detail, these rules/behaviors are:
       Trilinos_ENABLE_ThyraGoodStuff=ON   # Only if enabling ST code!
       Trilinos_ENABLE_ThyraEpetra=ON
       Trilinos_ENABLE_ThyraEpetraExt=ON   # Only if enabling ST code!
-   
+
     (Note that ``Trilinos_ENABLE_ThyraCrazyStuff`` is **not** set to ``ON``
     because it is already set to ``OFF`` by default, see `EX SE packages
     disabled by default`_.)  Likewise, explicitly setting
@@ -3843,12 +3843,12 @@ tests/examples and TPLs can be clearly seen when processing the TPLs and
 top-level packages in the lines::
 
   Getting information for all enabled TPLs ...
-  
+
   -- Processing enabled TPL: BLAS
   -- Processing enabled TPL: LAPACK
-  
+
   Configuring individual enabled Trilinos packages ...
-  
+
   Processing enabled package: Teuchos (Libs)
   Processing enabled package: RTOp (Libs)
   Processing enabled package: Epetra (Libs)
@@ -4681,7 +4681,7 @@ the `checkin-test.py`_ tool in extended pre-push testing.
 
 .. _Performance Testing:
 
-**Performance Testing** 
+**Performance Testing**
 
 *Performance Testing* builds are a special class of builds that have tests
 that are specifically designed to test the run-time performance of a particular
@@ -5158,26 +5158,26 @@ the commands::
 
   $ git clone git@someurl.com:MetaProject
   $ cd MetaProject/
-  $ ./cmake/tribits/ci_support/clone_extra_repos.py 
+  $ ./cmake/tribits/ci_support/clone_extra_repos.py
 
 which produces the output like::
 
-  ...  
-  
+  ...
+
   ***
   *** Clone the selected extra repos:
   ***
-  
+
   Cloning repo ExtraRepo1 ...
-  
+
   Running: git clone git@someurl.com:ExtraRepo1 ExtraRepo1
-  
+
   Cloning repo ExtraRepo2 ...
-  
+
   Running: git clone git@someurl.com:ExtraRepo2 ExtraRepo1/ExtraRepo2
-  
+
   Cloning repo ExtraRepo3 ...
-  
+
   Running: git clone git@someurl.com:ExtraRepo3 ExtraRepo3
 
 See `clone_extra_repos.py --help`_ for more details.
@@ -5224,7 +5224,7 @@ Some of the aggregate commands that one would typically run under the base
 
 The tool ``gitdist`` is provided under TriBITS directory::
 
-  cmake/tribits/python_utils/gitidst   
+  cmake/tribits/python_utils/gitidst
 
 and can be installed by the `install_devtools.py`_ tool (see `TriBITS
 Development Toolset`_).  See `gitdist documentation`_ for more details.
@@ -5744,7 +5744,7 @@ as follows:
 
      #if HAVE_<PACKAGE_NAME_UC>_<OPTIONAL_DEP_PACKAGE_NAME_UC>
      #  include "<upstreamPackageName>_<fileName>"
-     #endif 
+     #endif
 
 4) **For an optional dependency, use CMake if() statements based on
    ${PACKAGE_NAME}_ENABLE_${OPTIONAL_DEP_PACKAGE_NAME}:** When a package
@@ -5761,7 +5761,7 @@ as follows:
      endif()
 
   .. ToDo: Find an example to point to in TribitsExampleProject.
-  
+
 NOTE: TriBITS will automatically add the include directories for the upstream
 package to the compile lines for the downstream package source builds and will
 add the libraries for the upstream package to the link lines to the downstream
@@ -5824,7 +5824,7 @@ follows:
 
      #if HAVE_<PACKAGE_NAME_UC>_<OPTIONAL_DEP_TPL_NAME_UC>
      #  include "<upstreamPackageName>_<fileName>"
-     #endif 
+     #endif
 
 4) **For an optional dependency, use CMake if() statements based on
    ${PACKAGE_NAME}_ENABLE_${OPTIONAL_DEP_TPL_NAME}:** When a package
@@ -5841,7 +5841,7 @@ follows:
      endif()
 
   .. ToDo: Find an example to point to in TribitsExampleProject.
-  
+
 NOTE: TriBITS will automatically add the include directories for the upstream
 TPL to the compile lines for the downstream package source builds and will add
 the libraries for the upstream TPL to the link lines to the downstream package
@@ -6296,7 +6296,7 @@ The following steps describe how to submit results to a CDash site using the
     <baseDir>/TribitsExamplProject
 
   and then run ``make dashboard``.
-     
+
 4) Add custom CTest -S driver scripts.
 
   For driving different builds and tests, one needs to set up one or more
@@ -6355,7 +6355,7 @@ The following steps describe how to submit results to a CDash site using the
   submit to CDash in a variety of ways:
 
   * Cron jobs can be set up to run them at the same time every day.
- 
+
   * Jenkins jobs can be set up to run them based on various criteria.
 
   * Travis CI can run them to respond to GitHub pushes.
@@ -6404,10 +6404,10 @@ given below.
    <special_group>)`` in the CTest -S ``*.cmake`` driver script itself or can
    set it in the environment when running the ctest -S driver script.  For
    example::
- 
+
      $ env <Project>_TRACK=<special_group> ... \
        ctest -V -S <ctest_driver>.cmake
- 
+
    If the "build type" for the CDash group ``<special_group>`` was set to
    "Daily", then set `CTEST_TEST_TYPE`_ to ``Nightly``.  Otherwise,
    ``CTEST_TEST_TYPE`` can be set to ``Continuous`` or ``Experimental``.
@@ -6891,12 +6891,12 @@ rebase by default) as shown in the following Trilinos commit::
   commit 71ce56bd2d268922fda7b8eca74fad0ffbd7d807
   Author: Roscoe A. Bartlett <bartlettra@ornl.gov>
   Date:   Thu Feb 19 12:04:11 2015 -0500
-  
+
       Define HAVE_TEUCHOSCORE_CXX11 in TeuchosCore_config.h
-      
+
       This makes TeuchosCore a good example for how Trilinos (or any TriBITS)
       subpackages should put in an optional dependency on C++11.
-      
+
       Build/Test Cases Summary
       Enabled Packages: TeuchosCore
       Disabled Packages: [...]
@@ -7045,16 +7045,16 @@ the commands::
   $ cat ../git_bisect_log.log | grep "possible first bad commit" | \
       sed "s/possible first bad commit://g"  | sed "s/[a-z0-9]\{30\}\]/]/g"
   $ git bisect reset
-  
+
 This set of commands yield the output::
 
   Bisecting: 1128 revisions left to test after this (roughly 10 steps)
   [9634d462dba77704b598e89ba69ba3ffa5a71471] Revert "Trilinos: remove _def.hpp [...]"
-  
+
   real	1m22.961s
   user	0m57.157s
   sys	3m40.376s
-  
+
   #  [165067ce53] MueLu: SemiCoarsenPFactory. Use strided maps to properly transfer [...]
   #  [ada21a95a9] MueLu: refurbish LineDetectionFactory
   #  [83f05e8970] MueLu: stop semi-coarsening if no z-layers are left.
@@ -7068,7 +7068,7 @@ bounded in the set of commits ``8b79832..165067c``::
   165067c "MueLu: SemiCoarsenPFactory. Use strided maps to properly [...]."
   Author: Tobias Wiesner <tawiesn@sandia.gov>
   Date:   Thu Jul 2 12:11:24 2015 -0600
-  
+
   8b79832 "Ifpack2: RBILUK: adding additional ETI types"
   Author: Jonathan Hu <jhu@sandia.gov>
   Date:   Thu Jul 2 14:17:40 2015 -0700
@@ -7095,7 +7095,7 @@ intermediate commits are in Trilinos.  All that matters is the usage of the
 ``checkin-test.py`` tool (another motivation for the usage of the
 ``checkin-test.py`` tool, see `Pre-push Testing using checkin-test.py`_ for
 others as well).
- 
+
 Note that above, we grep the output from ``git bisect log`` for the set of
 possible "bad" commits instead of just looking at the output from the ``git
 bisect run <script>`` command (which also lists the set of possible "bad"
@@ -7321,7 +7321,7 @@ The sync driver script for this example should be called something like
 like::
 
   #!/bin/bash -e
-  
+
   # Set up the environment (i.e. PATH; needed for cron jobs)
   ...
 
@@ -7359,15 +7359,15 @@ A description of each option passed into this invocation of the
 details):
 
   ``--extra-pull-from=ExtraRepo1:public:master``
-  
+
     This option instructs the ``checkin-test.py`` tool to pull and merge in
     commits that define the integration.  One could do the pull(s) manually of
     doing so has the disadvantage that if they fail for some reason, they will
     not be seen by the ``checkin-test.py`` tool and no notification email
     would go out.
-  
+
   ``--abort-gracefully-if-no-changes-to-push``
-  
+
     The option ``--abort-gracefully-if-no-changes-to-push`` makes the
     ``checkin-test.py`` tool gracefully terminate without sending out any
     emails if after all the pulls, there are no local changes to push to the
@@ -7423,23 +7423,23 @@ details):
     email will still go out.  However, if one wants to never get the early
     build-case emails, one can turn this off by setting
     ``--send-build-case-email=never``.
- 
+
   ``--send-email-to=base-proj-integrators@url4.gov``
- 
+
     The results of the builds will be sent this email address.  If you only
     want an email sent when a push actually happens, you can set
     ``--send-email-to=''`` and rely on ``--send-email-to-on-push``.
-  
+
   ``--send-email-to-on-push=base-proj-integrators@url4.gov``
-  
+
     A confirmation and summary email will be sent to this address if the push
     happens.  This can be a different email address than set by the
     ``--send-email-to`` option.  It is highly recommended that a mail list be
     used for this email address since this will be the only more permanent
     logging of the ACI process.
-  
+
   ``--no-append-test-results --no-rebase``
-  
+
     These options are needed to stop the ``checkin-test.py`` tool from
     modifying the commits being tested and pushed from one public git repo to
     another.  The option ``--no-append-test-results`` is needed to instruct
@@ -7458,14 +7458,14 @@ details):
     not be a merge commit but just a fast-forward).  There are cases, however,
     where appending the test results in an ACI process might be acceptable but
     they are not discussed here.
-  
+
   ``--do-all --push -j16``
-  
+
     These are standard options that always get used when invoking the
     ``checkin-test.py`` tool and need no further explanation.
-  
+
   ``--wipe-clean``
-  
+
     This option is added if you want to make the sync server more robust to
     changes that might require a clean configure from script.  If you care
     more about using less computer resources and testing that rebuilds work
@@ -7507,12 +7507,12 @@ daily ACI process at 8pm local time every night::
   # |  |  |  |  |
   # *  *  *  *  *  command to be executed
    00 20  *  *  *  ~/sync_base_dir/sync_ExtraRepo1.sh &> ~/sync_base_dir/sync_ExtraRepo1.out
-  
+
 In the above crontab file (set with ``'crontab -e'`` or ``'crontab
 my-crontab-file.txt'``), the script::
 
   ~/sync_base_dir/sync_ExtraRepo1.sh
- 
+
 is assumed to be a soft symbolic link to some version controlled copy of the
 ACI sync script.  For example, it might make sense for this script to be
 version controlled in the ``BaseProj`` repo and therefore the symbolic link
@@ -7890,7 +7890,7 @@ like::
   set_and_inc_dirs(DIR ${CMAKE_CURRENT_SOURCE_DIR})
   append_glob(HEADERS ${DIR}/*.hpp)
   append_glob(SOURCES ${DIR}/*.cpp)
-  
+
   if (NOT ${PACKAGE_NAME}_HIDE_DEPRECATED_CODE)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/deprecated)
     append_set(HEADERS
@@ -7954,7 +7954,7 @@ remove them from the version control repository and local directories
 ``CMakeLists.txt`` file.  For the example in `Hiding entire deprecated header
 and source files`_, one would just remove the files ``SomeOldStuff.hpp`` and
 ``SomeOldStuff.cpp`` from the ``CMakeLists.txt`` file leaving::
-  
+
   if (NOT ${PACKAGE_NAME}_HIDE_DEPRECATED_CODE)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/deprecated)
     append_set(HEADERS
@@ -8111,12 +8111,12 @@ This will create a git commit in the local ``<projectDir>/`` git repo that
 looks like::
 
     Automatic snapshot commit from tribits at f8c1682
-    
+
     Origin repo remote tracking branch: 'casl-dev-collab/tribits_reorg_26'
     Origin repo remote repo URL: 'casl-dev-collab = git@casl-dev:collaboration/TriBITS'
-    
+
     At commit:
-    
+
     f8c1682 Assert TriBITS min CMake version in TriBITS itself
     Author: Roscoe A. Bartlett <bartlettra@ornl.gov>
     Date: Fri Dec 5 05:40:49 2014 -0500
@@ -8187,7 +8187,7 @@ See `install_devtools.py --help`_ for more details.
 .. LocalWords:  TribitsCTestDriverCore
 .. LocalWords:  TribitsExampleProject TribitsExProj DTribitsExProj SimpleCXX MixedLang
 .. LocalWords:  MockTrilinos
-.. LocalWords:  WithSubpackages WithSubpackagesA WithSubpackagesB WithSubpackagesC 
+.. LocalWords:  WithSubpackages WithSubpackagesA WithSubpackagesB WithSubpackagesC
 
 .. General CMake words:
 

--- a/tribits/doc/guides/TribitsMacroFunctionDocTemplate.rst
+++ b/tribits/doc/guides/TribitsMacroFunctionDocTemplate.rst
@@ -20,7 +20,10 @@
 @FUNCTION: tribits_determine_if_current_package_needs_rebuilt() +
 @MACRO:    tribits_disable_package_on_platforms() +
 @MACRO:    tribits_exclude_files() +
+@FUNCTION: tribits_external_package_append_upstream_target_link_libraries_get_name_and_vis() +
 @FUNCTION: tribits_external_package_create_imported_all_libs_target_and_config_file() +
+@FUNCTION: tribits_external_package_write_config_file() +
+@FUNCTION: tribits_external_package_write_config_file_str() +
 @FUNCTION: tribits_find_most_recent_binary_file_timestamp() +
 @FUNCTION: tribits_find_most_recent_file_timestamp() +
 @FUNCTION: tribits_find_most_recent_source_file_timestamp() +
@@ -43,6 +46,7 @@
 @MACRO:    tribits_subpackage_postprocess() +
 @FUNCTION: tribits_tpl_allow_pre_find_package() +
 @FUNCTION: tribits_tpl_find_include_dirs_and_libraries() +
+@FUNCTION: tribits_tpl_libraries_entry_type() +
 @FUNCTION: tribits_tpl_tentatively_enable() +
 @FUNCTION: tribits_write_flexible_package_client_export_files() +
 @FUNCTION: tribits_verbose_print_var() +

--- a/tribits/doc/guides/TribitsMacroFunctionDocTemplate.rst
+++ b/tribits/doc/guides/TribitsMacroFunctionDocTemplate.rst
@@ -20,6 +20,7 @@
 @FUNCTION: tribits_determine_if_current_package_needs_rebuilt() +
 @MACRO:    tribits_disable_package_on_platforms() +
 @MACRO:    tribits_exclude_files() +
+@FUNCTION: tribits_external_package_create_imported_all_libs_target_and_config_file() +
 @FUNCTION: tribits_find_most_recent_binary_file_timestamp() +
 @FUNCTION: tribits_find_most_recent_file_timestamp() +
 @FUNCTION: tribits_find_most_recent_source_file_timestamp() +

--- a/tribits/doc/guides/TribitsSystemMacroFunctionDocTemplate.rst
+++ b/tribits/doc/guides/TribitsSystemMacroFunctionDocTemplate.rst
@@ -15,6 +15,13 @@ understand the internals of TriBITS.
 @MACRO:    tribits_adjust_package_enables() +
 @FUNCTION: tribits_append_forward_dep_packages() +
 @MACRO:    tribits_assert_read_dependency_vars() +
+@FUCNTION: tribits_external_package_append_upstream_target_link_libraries_get_name_and_vis() +
+@FUNCTION: tribits_external_package_add_find_upstream_dependencies_str() +
+@FUNCTION: tribits_external_package_create_all_libs_target() +
+@FUNCTION: tribits_external_package_install_config_file() +
+@FUNCTION: tribits_external_package_install_config_version_file() +
+@FUNCTION: tribits_external_package_process_libraries_list() +
+@FUNCTION: tribits_external_package_write_config_version_file() +
 @FUNCTION: tribits_dump_package_dependencies_info() +
 @FUNCTION: tribits_print_initial_dependency_info() +
 @FUNCTION: tribits_print_tentatively_enabled_tpls() +

--- a/tribits/doc/guides/users_guide/TribitsUsersGuide.rst
+++ b/tribits/doc/guides/users_guide/TribitsUsersGuide.rst
@@ -68,11 +68,11 @@ then discussed which is the backbone of the TriBITS system.  An overview of
 the foundations for `TriBITS Automated Testing`_ is then given.  The topic of
 TriBITS `Multi-Repository Support`_ is examined next.  `Development
 Workflows`_ using TriBITS is then explored.  This is followed by a set of
-detailed `Howtos`_.  Later some `Additional Topics`_ are presented that don't
-fit well into other sections.  Then the main bulk of the detailed reference
-material for TriBITS is given in the section `TriBITS Detailed Reference
-Documentation`_.  Finally, several bits of information are provided in the
-`Appendix`_.
+detailed `Howtos`_.  Later some `Miscellaneous Topics`_ are presented that
+don't fit well into other sections.  Then the main bulk of the detailed
+reference material for TriBITS is given in the section `TriBITS Detailed
+Reference Documentation`_.  Finally, several bits of information are provided
+in the `Appendix`_.
 
 
 .. include:: ../TribitsGuidesBody.rst

--- a/tribits/doc/guides/users_guide/TribitsUsersGuide.rst
+++ b/tribits/doc/guides/users_guide/TribitsUsersGuide.rst
@@ -104,3 +104,5 @@ Appendix
 .. ***
 
 .. _tribits_read_all_project_deps_files_create_deps_graph(): TribitsMaintainersGuide.html#tribits-read-all-project-deps-files-create-deps-graph
+
+.. _${PACKAGE_NAME}_LIB_ALL_DEPENDENCIES: TribitsMaintainersGuide.html#package-name-lib-enabled-dependencies

--- a/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl1.cmake
+++ b/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl1.cmake
@@ -1,34 +1,9 @@
 include(TribitsGetImportedLocationProperty)
+include(TribitsExternalPackageFindTplHelpers)
 
-
-#
-# Functions
-#
-
-function(tpl1_write_config_file tpl1Dir)
-  set(configFileStr "")
-  string(APPEND configFileStr
-    "include(CMakeFindDependencyMacro)\n"
-    "set(Tpl1_DIR \"${tpl1Dir}\")\n"
-    "find_dependency(Tpl1)\n"
-    "add_library(Tpl1::all_libs INTERFACE IMPORTED GLOBAL)\n"
-    "target_link_libraries(Tpl1::all_libs INTERFACE tpl1::tpl1)\n"
-    )
-  set(buildDirExternalPkgsDir
-    "${${PROJECT_NAME}_BINARY_DIR}/${${PROJECT_NAME}_BUILD_DIR_EXTERNAL_PKGS_DIR}")
-  set(tplConfigFile
-    "${buildDirExternalPkgsDir}/${TPL_NAME}/${TPL_NAME}Config.cmake")
-  file(WRITE "${tplConfigFile}" "${configFileStr}")
-
-endfunction()
-
-
-#
-# Executable Code
-#
-
-set(REQUIRED_HEADERS Tpl1.hpp)
-set(REQUIRED_LIBS_NAMES tpl1)
+set(REQUIRED_HEADERS  Tpl1.hpp)
+set(REQUIRED_LIBS_NAMES  tpl1)
+set(IMPORTED_TARGETS_FOR_ALL_LIBS  tpl1::tpl1)
 
 tribits_tpl_allow_pre_find_package(Tpl1  Tpl1_ALLOW_PREFIND)
 
@@ -44,19 +19,10 @@ if (Tpl1_ALLOW_PREFIND)
       set(TPL_Tpl1_INCLUDE_DIRS "${inclDirs}" CACHE PATH "Include dirs for Tpl1")
       set(TPL_Tpl1_LIBRARIES "${libfile}" CACHE PATH "Libraries for Tpl1")
     else()
-      # Create imported target Tpl1::all_libs
-      add_library(Tpl1::all_libs INTERFACE IMPORTED GLOBAL)
-      target_link_libraries(Tpl1::all_libs INTERFACE tpl1::tpl1)
-      set(TPL_Tpl1_LIBRARIES Tpl1::all_libs CACHE STRING
-        "Set in ${CMAKE_CURRENT_LIST_FILE}")
-      set(TPL_Tpl1_INCLUDE_DIRS "" CACHE STRING
-        "Set in ${CMAKE_CURRENT_LIST_FILE}")
-      set(TPL_Tpl1_LIBRARY_DIRS "" CACHE STRING
-        "Set in ${CMAKE_CURRENT_LIST_FILE}")
-      print_var(TPL_Tpl1_LIBRARIES)
-      print_var(TPL_Tpl1_INCLUDE_DIRS)
-      # Write a specialized Tpl1Config.cmake file
-      tpl1_write_config_file("${Tpl1_DIR}")
+      message("-- Generating Tpl1::all_libs and Tpl1Config.cmake")
+      tribits_external_package_create_imported_all_libs_target_and_config_file(Tpl1
+        INNER_FIND_PACKAGE_NAME  Tpl1
+        IMPORTED_TARGETS_FOR_ALL_LIBS  ${IMPORTED_TARGETS_FOR_ALL_LIBS} )
     endif()
   endif()
 endif()
@@ -64,6 +30,5 @@ endif()
 if (NOT TARGET Tpl1::all_libs)
   tribits_tpl_find_include_dirs_and_libraries( Tpl1
     REQUIRED_HEADERS ${REQUIRED_HEADERS}
-    REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES}
-    )
+    REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} )
 endif()

--- a/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl1.cmake
+++ b/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl1.cmake
@@ -1,5 +1,4 @@
 include(TribitsGetImportedLocationProperty)
-include(TribitsExternalPackageFindTplHelpers)
 
 set(REQUIRED_HEADERS  Tpl1.hpp)
 set(REQUIRED_LIBS_NAMES  tpl1)

--- a/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl2.cmake
+++ b/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl2.cmake
@@ -1,4 +1,25 @@
-tribits_tpl_find_include_dirs_and_libraries( Tpl2
-  REQUIRED_HEADERS Tpl2a.hpp  # Only look for one header file to find include dir
-  REQUIRED_LIBS_NAMES tpl2b tpl2a
-  )
+include(TribitsExternalPackageFindTplHelpers)
+
+set(REQUIRED_HEADERS  Tpl2a.hpp) # Only look for one header file to find include dir
+set(REQUIRED_LIBS_NAMES  tpl2b tpl2a)
+set(IMPORTED_TARGETS_FOR_ALL_LIBS  tpl2::tpl2a tpl2::tpl2b)
+
+tribits_tpl_allow_pre_find_package(Tpl2  Tpl2_ALLOW_PREFIND)
+
+if (Tpl2_ALLOW_PREFIND)
+  message("-- Using find_package(Tpl2 ...) ...")
+  find_package(Tpl2)
+  if (Tpl2_FOUND)
+    message("-- Found Tpl2_DIR='${Tpl2_DIR}'")
+    message("-- Generating Tpl2::all_libs and Tpl2Config.cmake")
+    tribits_external_package_create_imported_all_libs_target_and_config_file(Tpl2
+      INNER_FIND_PACKAGE_NAME  Tpl2
+      IMPORTED_TARGETS_FOR_ALL_LIBS  ${IMPORTED_TARGETS_FOR_ALL_LIBS} )
+  endif()
+endif()
+
+if (NOT TARGET Tpl2::all_libs)
+  tribits_tpl_find_include_dirs_and_libraries( Tpl2
+    REQUIRED_HEADERS ${REQUIRED_HEADERS}
+    REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} )
+endif()

--- a/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl2.cmake
+++ b/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl2.cmake
@@ -1,5 +1,3 @@
-include(TribitsExternalPackageFindTplHelpers)
-
 set(REQUIRED_HEADERS  Tpl2a.hpp) # Only look for one header file to find include dir
 set(REQUIRED_LIBS_NAMES  tpl2b tpl2a)
 set(IMPORTED_TARGETS_FOR_ALL_LIBS  tpl2::tpl2a tpl2::tpl2b)

--- a/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl3.cmake
+++ b/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl3.cmake
@@ -1,5 +1,3 @@
-include(TribitsExternalPackageFindTplHelpers)
-
 set(REQUIRED_HEADERS  Tpl3.hpp)
 set(REQUIRED_LIBS_NAMES  tpl3)
 set(IMPORTED_TARGETS_FOR_ALL_LIBS  tpl3::tpl3)

--- a/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl3.cmake
+++ b/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl3.cmake
@@ -1,4 +1,25 @@
-tribits_tpl_find_include_dirs_and_libraries( Tpl3
-  REQUIRED_HEADERS Tpl3.hpp
-  REQUIRED_LIBS_NAMES tpl3
-  )
+include(TribitsExternalPackageFindTplHelpers)
+
+set(REQUIRED_HEADERS  Tpl3.hpp)
+set(REQUIRED_LIBS_NAMES  tpl3)
+set(IMPORTED_TARGETS_FOR_ALL_LIBS  tpl3::tpl3)
+
+tribits_tpl_allow_pre_find_package(Tpl3  Tpl3_ALLOW_PREFIND)
+
+if (Tpl3_ALLOW_PREFIND)
+  message("-- Using find_package(Tpl3 ...) ...")
+  find_package(Tpl3)
+  if (Tpl3_FOUND)
+    message("-- Found Tpl3_DIR='${Tpl3_DIR}'")
+    message("-- Generating Tpl3::all_libs and Tpl3Config.cmake")
+    tribits_external_package_create_imported_all_libs_target_and_config_file(Tpl3
+      INNER_FIND_PACKAGE_NAME  Tpl3
+      IMPORTED_TARGETS_FOR_ALL_LIBS  ${IMPORTED_TARGETS_FOR_ALL_LIBS} )
+  endif()
+endif()
+
+if (NOT TARGET Tpl3::all_libs)
+  tribits_tpl_find_include_dirs_and_libraries( Tpl3
+    REQUIRED_HEADERS ${REQUIRED_HEADERS}
+    REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} )
+endif()

--- a/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl4.cmake
+++ b/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl4.cmake
@@ -1,5 +1,3 @@
-include(TribitsExternalPackageFindTplHelpers)
-
 set(REQUIRED_HEADERS  Tpl4.hpp)
 set(IMPORTED_TARGETS_FOR_ALL_LIBS  tpl4::tpl4)
 

--- a/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl4.cmake
+++ b/tribits/examples/TribitsExampleProject2/cmake/tpls/FindTPLTpl4.cmake
@@ -1,3 +1,23 @@
-tribits_tpl_find_include_dirs_and_libraries( Tpl4
-  REQUIRED_HEADERS Tpl4.hpp
-  )
+include(TribitsExternalPackageFindTplHelpers)
+
+set(REQUIRED_HEADERS  Tpl4.hpp)
+set(IMPORTED_TARGETS_FOR_ALL_LIBS  tpl4::tpl4)
+
+tribits_tpl_allow_pre_find_package(Tpl4  Tpl4_ALLOW_PREFIND)
+
+if (Tpl4_ALLOW_PREFIND)
+  message("-- Using find_package(Tpl4 ...) ...")
+  find_package(Tpl4)
+  if (Tpl4_FOUND)
+    message("-- Found Tpl4_DIR='${Tpl4_DIR}'")
+    message("-- Generating Tpl4::all_libs and Tpl4Config.cmake")
+    tribits_external_package_create_imported_all_libs_target_and_config_file(Tpl4
+      INNER_FIND_PACKAGE_NAME  Tpl4
+      IMPORTED_TARGETS_FOR_ALL_LIBS  ${IMPORTED_TARGETS_FOR_ALL_LIBS} )
+  endif()
+endif()
+
+if (NOT TARGET Tpl4::all_libs)
+  tribits_tpl_find_include_dirs_and_libraries( Tpl4
+    REQUIRED_HEADERS ${REQUIRED_HEADERS} )
+endif()


### PR DESCRIPTION
This adds the new module [TribitsExternalPackageFindTplHelpers.cmake](https://github.com/TriBITSPub/TriBITS/compare/master...bartlettroscoe:TriBITS:299-find-tpl-module-find-package?expand=1#diff-4ce5b4df55755a4e2f8281f0a5f122e02e7356eb3947d31b19716205cac31f81) with the new function tribits_external_package_create_imported_all_libs_target_and_config_file().  This makes it very smooth and easy to use `find_package(<externalPkg>)` that creates proper IMPORTED targets.

Using the new function will fix the problem with `FindTPLGTest.cmake` reported in https://github.com/sandialabs/seacas/pull/317#issuecomment-1170568678.

Things done here:

* Added new module `TribitsExternalPackageFindTplHelpers.cmake` and function `tribits_external_package_create_imported_all_libs_target_and_config_file()` and used it to upgrade the `FindTPL<tplName>.cmake` modules for TribitsExampleProject2 (and updated tests to make sure they work).

* Updated documentation and howto for adding a new TriBITS TPL and write the `FindTPL<tplName>.cmake` file.  (Hopefully this new documentation will be easier to find the code example that a particular `FindTPL<tplName>.cmake` file should follow.)

## Notes to reviewers

Please review the individual commits one-at-a-time and read the commit log messages for details on what was added or changed.
