### PR TITLE
Address review comments from PRs #495 and #481

### DIFF
--- a/test/ci_support/TribitsStripCommentsFromCMakeCacheFile_TestDriver.cmake
+++ b/test/ci_support/TribitsStripCommentsFromCMakeCacheFile_TestDriver.cmake
@@ -37,6 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 #
 # This file is run as a cmake -P script to create a CMakeCache.clean.txt file
 # given a CMakeCache.txt file.

--- a/test/core/CTestScriptsUnitTests/CMakeLists.txt
+++ b/test/core/CTestScriptsUnitTests/CMakeLists.txt
@@ -37,13 +37,13 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
 
 #
 # The tests defined here are used to test the dynamic behavior of the
 # CMake/CTest functions tribits_add_test(...) and
 # tribits_add_advanced_test(...).
 #
-
 
 assert_defined(${PACKAGE_NAME}_ENABLE_MPI)
 if (${PACKAGE_NAME}_ENABLE_MPI)

--- a/test/core/CTestScriptsUnitTests/EchoEnvVarForTest.cmake
+++ b/test/core/CTestScriptsUnitTests/EchoEnvVarForTest.cmake
@@ -37,4 +37,6 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 message("PASS_IN_FROM_ENV_VAR: $ENV{PASS_IN_FROM_ENV_VAR}")

--- a/test/core/CTestScriptsUnitTests/echoEnvVars.cmake
+++ b/test/core/CTestScriptsUnitTests/echoEnvVars.cmake
@@ -11,9 +11,9 @@
 # and it read and print these env vars up to 10
 #
 
-set(maxNumEnvVars 10)
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
 
-cmake_policy(SET CMP0054 NEW)
+set(maxNumEnvVars 10)
 
 foreach(idx RANGE ${maxNumEnvVars})
   set(envVarCacheVarName_idx "ENV_VAR_${idx}")

--- a/test/core/CompilerOptions_UnitTests.cmake
+++ b/test/core/CompilerOptions_UnitTests.cmake
@@ -37,6 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 message("PROJECT_NAME = ${PROJECT_NAME}")
 message("${PROJECT_NAME}_TRIBITS_DIR = ${${PROJECT_NAME}_TRIBITS_DIR}")
 

--- a/test/core/ExamplesUnitTests/RunDummyPackageClientBulid.cmake
+++ b/test/core/ExamplesUnitTests/RunDummyPackageClientBulid.cmake
@@ -37,6 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 #
 # This file is run as a cmake -P script to create a new dummy project
 # to test the generated <Package>Config.cmake export file

--- a/test/core/TestingFunctionMacro_UnitTests.cmake
+++ b/test/core/TestingFunctionMacro_UnitTests.cmake
@@ -37,6 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 message("PROJECT_NAME = ${PROJECT_NAME}")
 message("${PROJECT_NAME}_TRIBITS_DIR = ${${PROJECT_NAME}_TRIBITS_DIR}")
 

--- a/test/core/TribitsAdjustPackageEnables_UnitTests.cmake
+++ b/test/core/TribitsAdjustPackageEnables_UnitTests.cmake
@@ -37,9 +37,9 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
 
 include(${CMAKE_CURRENT_LIST_DIR}/TribitsAdjustPackageEnablesHelpers.cmake)
-
 
 
 #####################################################################

--- a/test/core/TribitsExternalPackageWriteConfigFile_UnitTests.cmake
+++ b/test/core/TribitsExternalPackageWriteConfigFile_UnitTests.cmake
@@ -37,6 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 # Echo input arguments
 message("PROJECT_NAME = '${PROJECT_NAME}'")
 message("${PROJECT_NAME}_TRIBITS_DIR = '${${PROJECT_NAME}_TRIBITS_DIR}'")

--- a/test/core/TribitsPackageDependencies_UnitTests.cmake
+++ b/test/core/TribitsPackageDependencies_UnitTests.cmake
@@ -37,6 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 # Echo input arguments
 message("PROJECT_NAME = '${PROJECT_NAME}'")
 message("${PROJECT_NAME}_TRIBITS_DIR = '${${PROJECT_NAME}_TRIBITS_DIR}'")

--- a/test/core/TribitsProcessExtraRepositoriesList_UnitTests.cmake
+++ b/test/core/TribitsProcessExtraRepositoriesList_UnitTests.cmake
@@ -37,6 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 message("PROJECT_NAME = ${PROJECT_NAME}")
 message("${PROJECT_NAME}_TRIBITS_DIR = ${${PROJECT_NAME}_TRIBITS_DIR}")
 
@@ -45,7 +47,7 @@ set( CMAKE_MODULE_PATH
   "${${PROJECT_NAME}_TRIBITS_DIR}/core/package_arch"
   )
 
-include(TribitsCMakePolicies)
+include(TribitsCMakePolicies  NO_POLICY_SCOPE)
 include(TribitsProcessExtraRepositoriesList)
 include(UnitTestHelpers)
 include(GlobalSet)

--- a/test/core/TribitsProcessPackagesAndDirsLists_UnitTests.cmake
+++ b/test/core/TribitsProcessPackagesAndDirsLists_UnitTests.cmake
@@ -37,6 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 message("PROJECT_NAME = ${PROJECT_NAME}")
 message("${PROJECT_NAME}_TRIBITS_DIR = ${${PROJECT_NAME}_TRIBITS_DIR}")
 

--- a/test/core/TribitsReadAllProjectDepsFilesCreateDepsGraph_UnitTests.cmake
+++ b/test/core/TribitsReadAllProjectDepsFilesCreateDepsGraph_UnitTests.cmake
@@ -44,6 +44,8 @@
 #
 ################################################################################
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 include("${CMAKE_CURRENT_LIST_DIR}/TribitsReadAllProjectDepsFilesCreateDepsGraphHelpers.cmake")
 
 include(TribitsPackageDefineDependencies)

--- a/test/core/TribitsWriteClientExportFiles_UnitTests.cmake
+++ b/test/core/TribitsWriteClientExportFiles_UnitTests.cmake
@@ -37,6 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 message("CURRENT_TEST_DIRECTORY = ${CURRENT_TEST_DIRECTORY}")
 
 include(${CMAKE_CURRENT_LIST_DIR}/TribitsAdjustPackageEnablesHelpers.cmake)

--- a/test/ctest_driver/CTestDriverUnitTests.cmake
+++ b/test/ctest_driver/CTestDriverUnitTests.cmake
@@ -37,6 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 message("PROJECT_NAME = ${PROJECT_NAME}")
 message("${PROJECT_NAME}_TRIBITS_DIR = ${${PROJECT_NAME}_TRIBITS_DIR}")
 

--- a/tribits/ci_support/TribitsDumpDepsXmlScript.cmake
+++ b/tribits/ci_support/TribitsDumpDepsXmlScript.cmake
@@ -50,6 +50,8 @@
 #       -P <tribitsDir>/ci_support/TribitsDumpDepsXmlScript.cmake
 #
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 # A) Echo input options (must be specified with -D arguments to CMake command)
 
 # PROJECT_SOURCE_DIR
@@ -106,7 +108,7 @@ set( CMAKE_MODULE_PATH
 
 include(TribitsConstants)
 tribits_asesrt_minimum_cmake_version()
-include(TribitsCMakePolicies)
+include(TribitsCMakePolicies  NO_POLICY_SCOPE)
 
 include(TribitsGlobalMacros)
 include(TribitsPrintDependencyInfo)

--- a/tribits/ci_support/TribitsGetExtraReposForCheckinTest.cmake
+++ b/tribits/ci_support/TribitsGetExtraReposForCheckinTest.cmake
@@ -86,7 +86,7 @@ set( CMAKE_MODULE_PATH
   "${${PROJECT_NAME}_TRIBITS_DIR}/core/utils"
   "${${PROJECT_NAME}_TRIBITS_DIR}/core/package_arch"
   )
-include(TribitsCMakePolicies)
+include(TribitsCMakePolicies  NO_POLICY_SCOPE)
 include(Split)
 include(AppendStringVar)
 include(SetDefaultAndFromEnv) # Used in ExtraRepositoriesList.cmake file?

--- a/tribits/core/package_arch/TribitsAddAdvancedTest.cmake
+++ b/tribits/core/package_arch/TribitsAddAdvancedTest.cmake
@@ -37,6 +37,7 @@
 # ************************************************************************
 # @HEADER
 
+include(TribitsCMakePolicies  NO_POLICY_SCOPE)
 
 include(TribitsAddAdvancedTestHelpers)
 include(TribitsConstants)
@@ -44,13 +45,6 @@ include(TribitsConstants)
 include(TribitsPrintList)
 include(AppendStringVar)
 include(PrintVar)
-
-
-# Avoid quoted strings lookup variables
-cmake_policy(SET CMP0054 NEW)
-# NOTE: For some reason, setting this policy at the top level with TriBITS
-# in TribitsCMakePolices.cmake does not affect this function.  Therefore, I
-# have to set it again here.
 
 
 # @FUNCTION: tribits_add_advanced_test()

--- a/tribits/core/package_arch/TribitsAddAdvancedTest.cmake
+++ b/tribits/core/package_arch/TribitsAddAdvancedTest.cmake
@@ -521,8 +521,8 @@ include(PrintVar)
 #     **any** of the given regular expressions.  This will be applied and take
 #     precedence over other above pass criteria.  For example, if even if
 #     ``PASS_REGULAR_EXPRESSION`` or ``PASS_REGULAR_EXPRESSION_ALL`` match,
-#     then the test will be marked as failed if this fail regex matches the
-#     output.
+#     then the test will be marked as failed if any of the fail regexes match
+#     the output.
 #
 #   ``ALWAYS_FAIL_ON_NONZERO_RETURN``
 #
@@ -605,7 +605,7 @@ include(PrintVar)
 # The logic given below can be used to determine pass/fail criteria for a test
 # case both based on what is printed in the test output **and** the return
 # code for the test block command.  Raw CTest, as of version 3.23, does not
-# allow that.  With raw CTest, one can only set determine pass/fail based the
+# allow that.  With raw CTest, one can only set pass/fail criteria based the
 # test output **or** the return code, but not both.  This make
 # `tribits_add_advanced_test()`_ more attractive to use than
 # `tribits_add_test()`_ or raw ``add_test()`` in cases where it is important
@@ -682,9 +682,8 @@ include(PrintVar)
 #   ``FINAL_PASS_REGULAR_EXPRESSION "<regex0>" "<regex1>" ...``
 #
 #     If specified, the test will be assumed to pass if the output matches
-#     **any** of the provided regular expressions ``<regexi>``.  Otherwise, it
-#     will be assumed to fail.  (Sets the CTest property
-#     ``PASS_REGULAR_EXPRESSION`` for the overall test.)
+#     **any** of the provided regular expressions ``<regexi>``.  (Sets the
+#     CTest property ``PASS_REGULAR_EXPRESSION`` for the overall test.)
 #
 #   ``FINAL_FAIL_REGULAR_EXPRESSION "<regex0>" "<regex1>" ...``
 #

--- a/tribits/core/package_arch/TribitsAddExecutableTestHelpers.cmake
+++ b/tribits/core/package_arch/TribitsAddExecutableTestHelpers.cmake
@@ -37,6 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+include(TribitsCMakePolicies  NO_POLICY_SCOPE)
+
 include(AdvancedSet)
 include(MessageWrapper)
 

--- a/tribits/core/package_arch/TribitsAddTest.cmake
+++ b/tribits/core/package_arch/TribitsAddTest.cmake
@@ -37,9 +37,8 @@
 # ************************************************************************
 # @HEADER
 
+include(TribitsCMakePolicies  NO_POLICY_SCOPE)
 include(TribitsAddTestHelpers)
-
-cmake_policy(SET CMP0007 NEW) # Don't ignore empty list elements
 
 
 # @FUNCTION: tribits_add_test()

--- a/tribits/core/package_arch/TribitsCMakePolicies.cmake
+++ b/tribits/core/package_arch/TribitsCMakePolicies.cmake
@@ -39,8 +39,9 @@
 
 # Define policies for CMake
 # It is assumed that the project has already called CMAKE_MINIMUM_REQUIRED.
-cmake_policy(SET CMP0003 NEW)
-cmake_policy(SET CMP0007 NEW)
-cmake_policy(SET CMP0011 NEW)
-cmake_policy(SET CMP0053 NEW)
-cmake_policy(SET CMP0082 NEW)
+cmake_policy(SET CMP0003 NEW) # Don't split up full lib paths to linker args
+cmake_policy(SET CMP0007 NEW) # Don't ignore empty list items
+cmake_policy(SET CMP0053 NEW) # Make var references much faster
+cmake_policy(SET CMP0054 NEW) # Avoid quoted strings lookup variables
+cmake_policy(SET CMP0057 NEW) # Support if ( ... IN_LIST ... )
+cmake_policy(SET CMP0082 NEW) # Install rules follow order install() called in subdirs

--- a/tribits/core/package_arch/TribitsExternalPackageWriteConfigFile.cmake
+++ b/tribits/core/package_arch/TribitsExternalPackageWriteConfigFile.cmake
@@ -45,8 +45,6 @@ include(TribitsPackageDependencies)
 
 include(MessageWrapper)
 
-cmake_policy(SET CMP0057 NEW) # Support if ( ... IN_LIST ... )
-
 
 # @FUNCTION: tribits_extpkg_write_config_file()
 #

--- a/tribits/core/package_arch/TribitsPackageDependencies.cmake
+++ b/tribits/core/package_arch/TribitsPackageDependencies.cmake
@@ -50,11 +50,10 @@
 
 include_guard()
 
+include(TribitsCMakePolicies  NO_POLICY_SCOPE)
+
 include(TribitsParseArgumentsHelpers)
 include(MessageWrapper)
-
-cmake_policy(SET CMP0011 NEW) # include() does policy push and pop
-cmake_policy(SET CMP0057 NEW) # Support if ( ... IN_LIST ... )
 
 
 # @MACRO: tribits_extpkg_define_dependencies()

--- a/tribits/core/package_arch/TribitsPackageDependencies.cmake
+++ b/tribits/core/package_arch/TribitsPackageDependencies.cmake
@@ -97,16 +97,19 @@ macro(tribits_extpkg_define_dependencies
   tribits_check_for_unparsed_arguments(PARSE)
   tribits_assert_parse_arg_one_or_more_values(PARSE  DEPENDENCIES)
 
-  set(libAllDependencies "")
-  foreach (upstreamTplDepEntry  IN  LISTS  PARSE_DEPENDENCIES)
-    list(APPEND libAllDependencies ${upstreamTplDepEntry})
-  endforeach()
-
-  set(${tplName}_LIB_ALL_DEPENDENCIES  ${libAllDependencies}  CACHE STRING
+  set(${tplName}_LIB_ALL_DEPENDENCIES  ${PARSE_DEPENDENCIES}  CACHE STRING
     "List of all potential dependencies for external package/TPL '${tplName}'")
   mark_as_advanced(${tplName}_LIB_ALL_DEPENDENCIES)
 
 endmacro()
+#
+# NOTE: Above, we use a cache var for ${tplName}_LIB_ALL_DEPENDENCIES to allow
+# the user to override what dependencies a TPL can depend on.  Since this does
+# not depend on what actual TPLs are enabled, it is okay to set this as a
+# cache var.  As with any genetic change to a CMakeLists.txt file, you always
+# need to blow a way the cache and configure from scratch to get a correct
+# configuration.  (Only some types of changes to CMakeLists.txt files allow
+# for correct reconfiguration.)
 
 
 # @MACRO: tribits_extpkg_setup_enabled_dependencies()
@@ -157,6 +160,12 @@ macro(tribits_extpkg_setup_enabled_dependencies  externalPkgName)
   endforeach()
 
 endmacro()
+#
+# NOTE: Above we set ${externalPkgName}_LIB_ENABLED_DEPENDENCIES as a regular
+# project-level variable, not as a cache var.  That is because we want it to
+# update when the set of enabled TPLs changes without having to reconfigure
+# from scratch.  However, we use the if statement to allow the user to
+# override the default logic on the dependencies for an enabled TPL.
 
 
 # @FUNCTION: tribits_extpkg_get_dep_name_and_vis()

--- a/tribits/core/package_arch/TribitsProject.cmake
+++ b/tribits/core/package_arch/TribitsProject.cmake
@@ -66,7 +66,7 @@ if (${PROJECT_NAME}_VERBOSE_CONFIGURE)
 endif()
 
 # Overrides that we have for CMake functions
-include(TribitsCMakePolicies)
+include(TribitsCMakePolicies  NO_POLICY_SCOPE)
 include(TribitsProjectImpl)
 
 

--- a/tribits/core/package_arch/TribitsProjectImpl.cmake
+++ b/tribits/core/package_arch/TribitsProjectImpl.cmake
@@ -59,7 +59,7 @@ endif()
 
 include(TribitsConstants)
 tribits_asesrt_minimum_cmake_version()
-include(TribitsCMakePolicies)
+include(TribitsCMakePolicies  NO_POLICY_SCOPE)
 
 include(TribitsIncludeDirectories)
 include(TribitsFindPythonInterp)

--- a/tribits/core/package_arch/tribits_get_version_date.cmake
+++ b/tribits/core/package_arch/tribits_get_version_date.cmake
@@ -11,6 +11,8 @@
 #     -P tribits_get_version_date.cmake
 #   
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 # A) Validate input
 
 if ("${PROJECT_NAME}" STREQUAL "")

--- a/tribits/core/utils/UnitTestHelpers.cmake
+++ b/tribits/core/utils/UnitTestHelpers.cmake
@@ -40,7 +40,9 @@
 include(CMakeParseArguments)
 include(GlobalSet)
 
-cmake_policy(SET CMP0007 NEW)
+# Set policy here instead of including TribitCTestPolicis.cmake since we want
+# this to be a standalone module
+cmake_policy(SET CMP0007 NEW)  # Don't ignore empty list items
 
 
 # @MACRO: unittest_initialize_vars()

--- a/tribits/ctest_driver/TribitsCTestDriverCore.cmake
+++ b/tribits/ctest_driver/TribitsCTestDriverCore.cmake
@@ -151,7 +151,7 @@ set( CMAKE_MODULE_PATH
 
 include(TribitsConstants)
 tribits_asesrt_minimum_cmake_version()
-include(TribitsCMakePolicies)
+include(TribitsCMakePolicies  NO_POLICY_SCOPE)
 
 include(Split)
 include(PrintVar)

--- a/tribits/ctest_driver/TribitsGetCTestTestXmlDir.cmake
+++ b/tribits/ctest_driver/TribitsGetCTestTestXmlDir.cmake
@@ -14,6 +14,8 @@
 # then prints the directory <build>/Testing/<buildstarttime> to STDOUT.
 #
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 if ("${PROJECT_NAME}" STREQUAL "")
   message(FATAL_ERROR "Error, PROJECT_NAME must be set!")
 endif()

--- a/tribits/ctest_driver/TribitsReadTagFile.cmake
+++ b/tribits/ctest_driver/TribitsReadTagFile.cmake
@@ -1,3 +1,5 @@
+# Set policy here instead of including TribitCTestPolicis.cmake since we want
+# this to be a standalone module
 cmake_policy(SET CMP0007 NEW)
 
 

--- a/tribits/ctest_driver/tribits_ctest_update_commands.cmake
+++ b/tribits/ctest_driver/tribits_ctest_update_commands.cmake
@@ -18,6 +18,8 @@
 # 3.12) crash in that case.
 #
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 message("\ncmake -P tribits_ctest_update_commands.cmake:")
 message("-- GIT_EXE=${GIT_EXE}")
 message("-- REMOTE_NAME=${REMOTE_NAME}")

--- a/tribits/ctest_driver/tribits_ctest_update_commands_wrapper.cmake
+++ b/tribits/ctest_driver/tribits_ctest_update_commands_wrapper.cmake
@@ -7,6 +7,8 @@
 # the output (and does not send it to CDash).
 #
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
+
 message("\ncmake -P tribits_ctest_update_commands_wrapper.cmake:")
 message("-- OUTPUT_FILE=${OUTPUT_FILE}\n")
 

--- a/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
+++ b/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
@@ -1775,14 +1775,24 @@ must be specified correctly for the compile and links to work correctly.  The
 <Project> Project already defines these dependencies for the average situation
 for all of these TPLs.  However, there may be situations where the
 dependencies may need to be tweaked to match how these TPLs were actually
-installed on some systems.  The dependencies for a TPL can be overridded by
-setting::
+installed on some systems.  To redefine what dependencies a TPL can have (if
+the upstream TPLs are enabled), set::
 
-  -D <TPLNAME>_LIB_ENABLED_DEPENDENCIES="<tpl_1>;<tpl_2>;..."
+  -D <TPLNAME>_LIB_ALL_DEPENDENCIES="<tpl_1>;<tpl_2>;..."
+
+A dependency on an upstream TPL ``<tpl_i>`` will be set if the an upstream TPL
+``<tpl_i>`` is actually enabled.
 
 If any of the specified TPLs are listed after ``<TPLNAME>`` in the
 ``TPLsList.cmake`` file or are not enabled, then a configure-time error will
 occur.
+
+To take complete control over what dependencies an TPL has, set::
+
+  -D <TPLNAME>_LIB_ENABLED_DEPENDENCIES="<tpl_1>;<tpl_2>;..."
+
+If the upstream TPLs listed here are not defined upstream and enabled TPLs,
+then an error will occur.
 
 
 Disabling support for a Third-Party Library (TPL)

--- a/tribits/examples/MockTrilinos/CMakeLists.txt
+++ b/tribits/examples/MockTrilinos/CMakeLists.txt
@@ -37,9 +37,9 @@
 # ************************************************************************
 # @HEADER
 
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
 include(${CMAKE_SOURCE_DIR}/ProjectName.cmake)
 project(${PROJECT_NAME} NONE)
 set(${PROJECT_NAME}_TRIBITS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "")
 include("${${PROJECT_NAME}_TRIBITS_DIR}/TriBITS.cmake")
-cmake_minimum_required(VERSION ${TRIBITS_CMAKE_MINIMUM_REQUIRED})
 tribits_project()

--- a/tribits/examples/ReducedMockTrilinos/CMakeLists.txt
+++ b/tribits/examples/ReducedMockTrilinos/CMakeLists.txt
@@ -1,7 +1,7 @@
+cmake_minimum_required(VERSION 3.17.0 FATAL_ERROR)
 include(${CMAKE_CURRENT_SOURCE_DIR}/ProjectName.cmake)
 project(${PROJECT_NAME} NONE)
 set(${PROJECT_NAME}_TRIBITS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE PATH "")
 set(${PROJECT_NAME}_TRACE_DEPENDENCY_HANDLING_ONLY ON CACHE BOOL "")
 include("${${PROJECT_NAME}_TRIBITS_DIR}/TriBITS.cmake")
-cmake_minimum_required(VERSION ${TRIBITS_CMAKE_MINIMUM_REQUIRED})
 tribits_project()


### PR DESCRIPTION
Address review comments from #495 and #481.

See individual commits for details.

NOTE: For commit https://github.com/TriBITSPub/TriBITS/pull/498/commits/a35437ea91e49e291165e342f0e6e545cfb5191b, I ran the full TriBITS test suite locally and then did the grep:

```
$ grep "CMP00" Testing/Temporary/LastTest.log
```

to verify that I got all of the policy warnings to go away.
