### PR TITLE
Fix abs path issue with TPL dependencies, add CGNS/HDF5 dep (#299, trilinos/Trilinos#10744)

### DIFF
--- a/tribits/common_tpls/FindTPLCGNSDependencies.cmake
+++ b/tribits/common_tpls/FindTPLCGNSDependencies.cmake
@@ -1,0 +1,2 @@
+tribits_extpkg_define_dependencies( CGNS
+  DEPENDENCIES  HDF5)

--- a/tribits/core/package_arch/TribitsProcessTplsLists.cmake
+++ b/tribits/core/package_arch/TribitsProcessTplsLists.cmake
@@ -73,12 +73,12 @@ include(Split)
 #    TPL names typically use mixed case (e.g. ``SomeTpl`` and not
 #    ``SOMETPL``).
 #
-# 1. **FINDMOD** (``<tpli_findmod>``): The relative path for the find module,
-#    usually with the name `FindTPL<tplName>.cmake`_.  This path is relative
-#    to the repository base directory ``<repoDir>``.  If just the base path
-#    for the find module is given, ending with ``"/"``
-#    (e.g. ``"cmake/tpls/"``), then the find module will be assumed to be
-#    under that this directory with the standard name
+# 1. **FINDMOD** (``<tpli_findmod>``): The relative or absolute path for the
+#    find module, usually with the name `FindTPL<tplName>.cmake`_.  If it is a
+#    relative path, it is considered relative to the repository base directory
+#    ``<repoDir>``.  If just the base path for the find module is given,
+#    ending with ``"/"`` (e.g. ``"cmake/tpls/"``), then the find module will
+#    be assumed to be under that this directory with the standard name
 #    ``FindTPL<tplName>.cmake``.  (See `Creating the FindTPL<tplName>.cmake
 #    file`_.)
 #

--- a/tribits/core/package_arch/TribitsReadDepsFilesCreateDepsGraph.cmake
+++ b/tribits/core/package_arch/TribitsReadDepsFilesCreateDepsGraph.cmake
@@ -219,7 +219,11 @@ endmacro()
 # See `Function call tree for constructing package dependency graph`_
 #
 macro(tribits_read_external_package_deps_files_add_to_graph  tplName)
-  set(absTplDepsFile "${${PROJECT_NAME}_SOURCE_DIR}/${${tplName}_DEPENDENCIES_FILE}")
+  if (IS_ABSOLUTE "${${tplName}_DEPENDENCIES_FILE}")
+    set(absTplDepsFile "${${tplName}_DEPENDENCIES_FILE}")
+  else()
+    set(absTplDepsFile "${${PROJECT_NAME}_SOURCE_DIR}/${${tplName}_DEPENDENCIES_FILE}")
+  endif()
   if (EXISTS "${absTplDepsFile}")
     tribits_trace_file_processing(TPL  INCLUDE  "${absTplDepsFile}")
     include(${absTplDepsFile})

--- a/tribits/doc/guides/TribitsGuidesBody.rst
+++ b/tribits/doc/guides/TribitsGuidesBody.rst
@@ -2298,24 +2298,28 @@ defined TPL ``TPL_NAME`` is assigned the following global non-cache variables:
 
   ``${TPL_NAME}_FINDMOD``
 
-    Relative path (w.r.t. `<projectDir>`_) for the external package/TPL's find
-    module (typically named `FindTPL<tplName>.cmake`_): This is set using the
-    ``FINDMOD`` field in the call to `tribits_repository_define_tpls()`_.  The
-    final value of the variable is defined by the *last*
-    `<repoDir>/TPLsList.cmake`_ file that is processed that declares the TPL
-    ``TPL_NAME``.  For example, if ``Repo1/TPLsList.cmake`` and
-    ``Repo2/TPLsList.cmake`` both list the TPL ``SomeTpl``, then if ``Repo2``
-    is processed after ``Repo1``, then ``SomeTpl_FINDMOD`` is determined by
-    ``Repo2/TPLsList.cmake`` and the find module listed in
-    ``Repo1/TPLsList.cmake`` is ignored.
+    Relative path (w.r.t. ``<projectDir>``) or absolute path for the external
+    package/TPL's find module (typically named `FindTPL<tplName>.cmake`_):
+    This is set using the ``FINDMOD`` field in the call to
+    `tribits_repository_define_tpls()`_.  The final value of the variable is
+    defined by the *last* `<repoDir>/TPLsList.cmake`_ file that is processed
+    that declares the TPL ``TPL_NAME``.  For example, if
+    ``Repo1/TPLsList.cmake`` and ``Repo2/TPLsList.cmake`` both list the TPL
+    ``SomeTpl``, then if ``Repo2`` is processed after ``Repo1``, then
+    ``SomeTpl_FINDMOD`` is determined by ``Repo2/TPLsList.cmake`` and the find
+    module listed in ``Repo1/TPLsList.cmake`` is ignored.
 
   .. _<tplName>_DEPENDENCIES_FILE:
   .. _${TPL_NAME}_DEPENDENCIES_FILE:
 
   ``${TPL_NAME}_DEPENDENCIES_FILE``
 
-    Relative path (w.r.t. `<projectDir>`_) for the external package/TPL's
-    dependencies file (typically named `FindTPL<tplName>Dependencies.cmake`_)
+    Relative path (w.r.t. ``<projectDir>``) or absolute path for the external
+    package/TPL's dependencies file (typically named
+    `FindTPL<tplName>Dependencies.cmake`_).  This is always beside the find
+    module `${TPL_NAME}_FINDMOD`_ (and in fact
+    ``${TPL_NAME}_DEPENDENCIES_FILE`` is constructed from
+    ``${TPL_NAME}_FINDMOD``).
 
   .. _${TPL_NAME}_TESTGROUP:
 
@@ -2341,6 +2345,13 @@ defined TPL ``TPL_NAME`` is assigned the following global non-cache variables:
 
     Absolute path of the (last) `<repoDir>/TPLsList.cmake`_ file that declared
     this external package/TPL.
+
+Note, the ``<findmod>`` field path in the call to
+`tribits_repository_define_tpls()`_ is relative to the TriBITS repository dir
+``<repoDir>`` but a relative path in for the varaible `<tplName>_FINDMOD`_ is
+relative to the project dir ``<projectDir>``.  There is a translation of the
+``<findmod>`` field to the variable ``<tplName>_FINDMOD`` that takes place
+when the `<repoDir>/TPLsList.cmake`_ file is processed to make this so.
 
 As noted above, it is allowed for the same TPL to be listed in multiple
 `<repoDir>/TPLsList.cmake`_ files.  In this case, the rules for overrides of

--- a/tribits/examples/TribitsExampleProject2/TPLsList.cmake
+++ b/tribits/examples/TribitsExampleProject2/TPLsList.cmake
@@ -1,6 +1,9 @@
 tribits_repository_define_tpls(
   Tpl1      "cmake/tpls/"      PT
   Tpl2      "cmake/tpls/"      PT
-  Tpl3      "cmake/tpls/"      PT
+  Tpl3      "${CMAKE_CURRENT_LIST_DIR}/cmake/tpls/"      PT
   Tpl4      "cmake/tpls/"      PT
   )
+
+# NOTE: Above we are setting the findmod path to an absolute path just to test
+# that case with TPL dependencies (see trilinos/Trilinos#10774).


### PR DESCRIPTION
This PR updates the TribitsExampleProject2/TPLsList.cmake file to expose a defect with the handling of abs paths for `FindTPL<tplName>Dependencies.cmake` files and then adds code to fix it.  This was exposed as part of Trilinos testing as described in https://github.com/trilinos/Trilinos/issues/10774#issuecomment-1191702159.

This also adds the `FindTPLCGNSDependencies.cmake` file to define the dependency of CGNS on HDF5 which should fix a bunch of ATDM Trilinos builds (again, see  https://github.com/trilinos/Trilinos/issues/10774#issuecomment-1191702159).

# How was this tested?

I initially created these changes in the Trilinos topic branch [`bartlettroscoe/10774-fix-atdm-builds`](https://github.com/bartlettroscoe/Trilinos/tree/10774-fix-atdm-builds) and got the SEACAS build to work for the ATDM Trilinos build `cee-rhel7_intel-19.0.3_intelmpi-2018.4_serial_static_opt`.  (But I will remove those commits once I merge this PR branch to TriBITS 'master' and then update the TriBITS snapshot in the branch `10774-fix-atdm-builds`.)
