### PR TITLE
Change type to IMPORTED STATIC for *.a file (trilinos/Trilinos#10774)

### DIFF
--- a/test/core/TribitsExternalPackageWriteConfigFile_UnitTests.cmake
+++ b/test/core/TribitsExternalPackageWriteConfigFile_UnitTests.cmake
@@ -619,7 +619,7 @@ add_library(SomeTpl::lib1 IMPORTED INTERFACE GLOBAL)
 set_target_properties(SomeTpl::lib1 PROPERTIES
   IMPORTED_LIBNAME "lib1")
 
-add_library(SomeTpl::somelib IMPORTED UNKNOWN GLOBAL)
+add_library(SomeTpl::somelib IMPORTED STATIC GLOBAL)
 set_target_properties(SomeTpl::somelib PROPERTIES
   IMPORTED_LOCATION "/some/other/path/to/libsomelib.a")
 target_link_libraries(SomeTpl::somelib
@@ -676,7 +676,7 @@ add_library(SomeTpl::lib1 IMPORTED INTERFACE GLOBAL)
 set_target_properties(SomeTpl::lib1 PROPERTIES
   IMPORTED_LIBNAME "lib1")
 
-add_library(SomeTpl::somelib IMPORTED UNKNOWN GLOBAL)
+add_library(SomeTpl::somelib IMPORTED STATIC GLOBAL)
 set_target_properties(SomeTpl::somelib PROPERTIES
   IMPORTED_LOCATION "/some/other/path/to/libsomelib.a")
 target_link_libraries(SomeTpl::somelib

--- a/tribits/core/package_arch/TribitsExternalPackageWriteConfigFile.cmake
+++ b/tribits/core/package_arch/TribitsExternalPackageWriteConfigFile.cmake
@@ -583,8 +583,14 @@ function(tribits_extpkg_append_add_library_str
   )
   set(configFileStr "${${configFileStrInOut}}")
   if (libEntryType STREQUAL "FULL_LIB_PATH")
+    get_filename_component(libExt "${libpath}" LAST_EXT)
+    if (libExt  STREQUAL ".a")
+      set(libType  STATIC)
+    else()
+      set(libType  UNKNOWN)
+    endif()
     string(APPEND configFileStr
-      "add_library(${prefixed_libname} IMPORTED UNKNOWN GLOBAL)\n"
+      "add_library(${prefixed_libname} IMPORTED ${libType} GLOBAL)\n"
       "set_target_properties(${prefixed_libname} PROPERTIES\n"
       "  IMPORTED_LOCATION \"${libpath}\")\n"
       )


### PR DESCRIPTION
Resolves link problems on ATS1 described in https://github.com/trilinos/Trilinos/issues/10774#issuecomment-1194856254 and https://github.com/trilinos/Trilinos/issues/10774#issuecomment-1192075276.  See commit messages for more details.

NOTE: This is not really a TriBITS bug.  I believe this to be a CMake bug that we are working around here.  And this makes this TriBITS code just a little bit less general and perhaps more fragile.

