### PR TITLE
Fix test dependencies for subpackages and subpackage tests/examples enabless (#63, #268, #299, #510)

### DIFF
--- a/test/core/ExamplesUnitTests/TribitsExampleProject_Tests.cmake
+++ b/test/core/ExamplesUnitTests/TribitsExampleProject_Tests.cmake
@@ -2124,6 +2124,148 @@ tribits_add_advanced_test( TribitsExampleProject_SKIP_CTEST_ADD_TEST_Package_Bla
 ########################################################################
 
 
+tribits_add_advanced_test( TribitsExampleProject_EnableWithSubpackagesB_EnableWithsubpackagesTests
+  OVERALL_WORKING_DIRECTORY TEST_NAME
+  OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
+  XHOSTTYPE "Darwin"
+
+  TEST_0
+    MESSAGE "Configure enabling a subpackage and parent package tests"
+    CMND ${CMAKE_COMMAND}
+    ARGS
+      ${TribitsExampleProject_COMMON_CONFIG_ARGS}
+      -DTribitsExProj_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
+      -DTribitsExProj_ENABLE_WithSubpackagesB=ON
+      -DWithSubpackages_ENABLE_TESTS=ON
+       -DTribitsExProj_DUMP_PACKAGE_DEPENDENCIES=ON
+      ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
+    PASS_REGULAR_EXPRESSION_ALL
+      "Enabling subpackage tests/examples based on parent package tests/examples enables"
+      "-- Setting WithSubpackages_ENABLE_EXAMPLES=ON because WithSubpackages_ENABLE_TESTS=ON"
+      "-- Setting WithSubpackagesB_ENABLE_TESTS=ON because parent package WithSubpackages_ENABLE_TESTS=ON"
+      "-- Setting WithSubpackagesB_ENABLE_EXAMPLES=ON because parent package WithSubpackages_ENABLE_EXAMPLES=ON"
+      "-- WithSubpackagesB_TEST_ENABLED_DEPENDENCIES: MixedLang"
+      "-- WithSubpackagesB_TEST_ALL_DEPENDENCIES: MixedLang"
+      "Processing enabled package: WithSubpackages [(]A, B, Tests, Examples[)]"
+      "Configuring done"
+      "Generating done"
+    ALWAYS_FAIL_ON_NONZERO_RETURN
+
+  TEST_1 CMND make ARGS ${CTEST_BUILD_FLAGS}
+
+  TEST_2 CMND ${CMAKE_CTEST_COMMAND}
+    PASS_REGULAR_EXPRESSION_ALL
+      "WithSubpackagesB_test_of_b [.]* *Passed"
+      "WithSubpackagesB_test_of_b_mixed_lang_MPI_1 [.]* *Passed"
+      "100% tests passed, 0 tests failed out of 2"
+
+  )
+# NOTE: The above test covers one of the use cases for the the defect
+# described in TriBITSPub/TriBITS#510.  This shows that only the tests for
+# WithSubpackagesB are enabled and run and not for any of the other
+# subpackages of of the parent package WithSubpackages
+
+
+########################################################################
+
+
+tribits_add_advanced_test( TribitsExampleProject_EnableWithSubpackagesB_EnableWithsubpackagesExamples
+  OVERALL_WORKING_DIRECTORY TEST_NAME
+  OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
+  XHOSTTYPE "Darwin"
+
+  TEST_0
+    MESSAGE "Configure enabling a subpackage and parent package examples"
+    CMND ${CMAKE_COMMAND}
+    ARGS
+      ${TribitsExampleProject_COMMON_CONFIG_ARGS}
+      -DTribitsExProj_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
+      -DTribitsExProj_ENABLE_WithSubpackagesB=ON
+      -DWithSubpackages_ENABLE_EXAMPLES=ON
+       -DTribitsExProj_DUMP_PACKAGE_DEPENDENCIES=ON
+      ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
+    PASS_REGULAR_EXPRESSION_ALL
+      "Enabling subpackage tests/examples based on parent package tests/examples enables"
+      "-- Setting WithSubpackagesB_ENABLE_EXAMPLES=ON because parent package WithSubpackages_ENABLE_EXAMPLES=ON"
+      "-- WithSubpackagesB_TEST_ENABLED_DEPENDENCIES: MixedLang"
+      "-- WithSubpackagesB_TEST_ALL_DEPENDENCIES: MixedLang"
+      "Processing enabled package: WithSubpackages [(]A, B, Examples[)]"
+      "Configuring done"
+      "Generating done"
+    ALWAYS_FAIL_ON_NONZERO_RETURN
+
+  TEST_1 CMND make ARGS ${CTEST_BUILD_FLAGS}
+
+  TEST_2 CMND ${CMAKE_CTEST_COMMAND}
+    PASS_REGULAR_EXPRESSION_ALL
+      "No tests were found"
+
+  )
+# NOTE: The above test ensures that
+# WithSubpackagesB_TEST_ENABLED_DEPENDENCIES=MixedLang gets set but that the
+# tests are not actually run because only examples where enabled.  This was
+# not a use case for the Trilinos failures reported in TriBITSPub/TriBITS#510
+# but this is a valid use case that needs to be supported and tested.
+
+
+########################################################################
+
+
+tribits_add_advanced_test( TribitsExampleProject_ST_EnableMixedLang_EnableAllForwardDepPackages
+  OVERALL_WORKING_DIRECTORY TEST_NAME
+  OVERALL_NUM_MPI_PROCS 1
+  EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_Fortran
+  XHOSTTYPE "Darwin"
+
+  TEST_0
+    MESSAGE "Configure enabling an upstream package and enableee forward dep packages"
+    CMND ${CMAKE_COMMAND}
+    ARGS
+      ${TribitsExampleProject_COMMON_CONFIG_ARGS}
+      -DTribitsExProj_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
+      -DTribitsExProj_ENABLE_SECONDARY_TESTED_CODE=ON
+      -DTribitsExProj_ENABLE_MixedLang=ON
+      -DTribitsExProj_ENABLE_TESTS=ON
+      -DTribitsExProj_ENABLE_ALL_FORWARD_DEP_PACKAGES=ON
+      -DTribitsExProj_DUMP_PACKAGE_DEPENDENCIES=ON
+      -DTribitsExProj_DUMP_FORWARD_PACKAGE_DEPENDENCIES=ON
+      ${${PROJECT_NAME}_TRIBITS_DIR}/examples/TribitsExampleProject
+    PASS_REGULAR_EXPRESSION_ALL
+      "Sweep backward enabling all forward test dependent packages because TribitsExProj_ENABLE_ALL_FORWARD_DEP_PACKAGES=ON"
+      "-- Setting TribitsExProj_ENABLE_WithSubpackagesB=ON because TribitsExProj_ENABLE_MixedLang=ON"
+      "Enabling all tests and/or examples that have not been explicitly disabled because TribitsExProj_ENABLE_.TESTS,EXAMPLES.=ON"
+      "-- Setting MixedLang_ENABLE_TESTS=ON"
+      "-- Setting MixedLang_ENABLE_EXAMPLES=ON"
+      "-- Setting WithSubpackagesB_ENABLE_TESTS=ON"
+      "-- Setting WithSubpackagesB_ENABLE_EXAMPLES=ON"
+      "-- WithSubpackagesB_TEST_ENABLED_DEPENDENCIES: MixedLang"
+      "-- WithSubpackagesB_TEST_ALL_DEPENDENCIES: MixedLang"
+      "Final set of enabled packages:  SimpleCxx MixedLang WithSubpackages 3"
+      "Final set of enabled SE packages:  SimpleCxx MixedLang WithSubpackagesA WithSubpackagesB WithSubpackages 5"
+      "Processing enabled package: MixedLang [(]Libs, Tests, Examples[)]"
+      "Processing enabled package: WithSubpackages [(]A, B, Tests, Examples[)]"
+      "Configuring done"
+      "Generating done"
+    ALWAYS_FAIL_ON_NONZERO_RETURN
+
+  TEST_1 CMND make ARGS ${CTEST_BUILD_FLAGS}
+
+  TEST_2 CMND ${CMAKE_CTEST_COMMAND}
+    PASS_REGULAR_EXPRESSION_ALL
+      "MixedLang_RayTracerTests_MPI_1 [.]* *Passed"
+      "WithSubpackagesB_test_of_b [.]* *Passed"
+      "WithSubpackagesB_test_of_b_mixed_lang_MPI_1 [.]* *Passed"
+      "100% tests passed, 0 tests failed out of 3"
+  )
+# NOTE: The above test covers one of the failure modes reported in
+# TriBITSPub/TriBITS#510 that resulted in missing test dependencies.
+
+
+########################################################################
+
+
 tribits_add_advanced_test( TribitsExampleProject_WrapExternal
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1

--- a/test/core/ExamplesUnitTests/TribitsExampleProject_Tests.cmake
+++ b/test/core/ExamplesUnitTests/TribitsExampleProject_Tests.cmake
@@ -2123,7 +2123,6 @@ tribits_add_advanced_test( TribitsExampleProject_SKIP_CTEST_ADD_TEST_Package_Bla
 
 ########################################################################
 
-
 tribits_add_advanced_test( TribitsExampleProject_EnableWithSubpackagesB_EnableWithsubpackagesTests
   OVERALL_WORKING_DIRECTORY TEST_NAME
   OVERALL_NUM_MPI_PROCS 1
@@ -2157,7 +2156,7 @@ tribits_add_advanced_test( TribitsExampleProject_EnableWithSubpackagesB_EnableWi
   TEST_2 CMND ${CMAKE_CTEST_COMMAND}
     PASS_REGULAR_EXPRESSION_ALL
       "WithSubpackagesB_test_of_b [.]* *Passed"
-      "WithSubpackagesB_test_of_b_mixed_lang_MPI_1 [.]* *Passed"
+      "WithSubpackagesB_test_of_b_mixed_lang.* [.]* *Passed"
       "100% tests passed, 0 tests failed out of 2"
 
   )
@@ -2254,9 +2253,9 @@ tribits_add_advanced_test( TribitsExampleProject_ST_EnableMixedLang_EnableAllFor
 
   TEST_2 CMND ${CMAKE_CTEST_COMMAND}
     PASS_REGULAR_EXPRESSION_ALL
-      "MixedLang_RayTracerTests_MPI_1 [.]* *Passed"
+      "MixedLang_RayTracerTests.* [.]* *Passed"
       "WithSubpackagesB_test_of_b [.]* *Passed"
-      "WithSubpackagesB_test_of_b_mixed_lang_MPI_1 [.]* *Passed"
+      "WithSubpackagesB_test_of_b_mixed_lang.* [.]* *Passed"
       "100% tests passed, 0 tests failed out of 3"
   )
 # NOTE: The above test covers one of the failure modes reported in

--- a/tribits/CHANGELOG.md
+++ b/tribits/CHANGELOG.md
@@ -2,9 +2,25 @@
 ChangeLog for TriBITS
 ----------------------------------------
 
+
+## 2022-08-11:
+
+* **Changed:** Fix a bug where the test dependencies for an enabled
+  subpackage that resulted in a build error (see
+  [trilinos/Trilinos#10842](https://github.com/trilinos/Trilinos/issues/10842)
+  and
+  [TriBITSPub/TriBITS#510](https://github.com/TriBITSPub/TriBITS/issues/510)).
+
+* **Changed:** Made setting parent package tests/examples enables correctly
+  propagate down to subpackages in a more intuitive way (see
+  [TriBITSPub/TriBITS#268](https://github.com/TriBITSPub/TriBITS/issues/268)).
+  This also results in not enabling tests for subpackages that are not
+  explicitly enabled or enabled as part of the forward sweep of packages
+  enables due to `<Project>_ENABLE_ALL_FORWARD_DEP_PACKAGES=ON`.
+
 ## 2022-07-20:
 
-* ** Changed:** Fixed TriBITS generated and installed `<tplName>Config.cmake`
+* **Changed:** Fixed TriBITS generated and installed `<tplName>Config.cmake`
   files to not point into the build dir but instead point into relative dir
   for upstream TPL's when calling find_dependency() (see
   [TribitsPub/TriBITS#500](https://github.com/TriBITSPub/TriBITS/issues/500)).

--- a/tribits/core/package_arch/TribitsAddTestHelpers.cmake
+++ b/tribits/core/package_arch/TribitsAddTestHelpers.cmake
@@ -204,21 +204,14 @@ endfunction()
 
 
 # Determine if to add the test based on if testing is enabled for the current
-# package or subpackage.
+# package.
 #
 function(tribits_add_test_process_enable_tests  ADD_THE_TEST_OUT)
-  if(${PACKAGE_NAME}_ENABLE_TESTS OR ${PARENT_PACKAGE_NAME}_ENABLE_TESTS)
+  if(${PACKAGE_NAME}_ENABLE_TESTS)
    set(ADD_THE_TEST TRUE)
   else()
-    if (PARENT_PACKAGE_NAME STREQUAL PACKAGE_NAME)
-      set(PARENT_EANBLE_TESTS_DISABLE_MSG)
-    else()
-      set(PARENT_EANBLE_TESTS_DISABLE_MSG
-	", ${PARENT_PACKAGE_NAME}_ENABLE_TESTS='${${PARENT_PACKAGE_NAME}_ENABLE_TESTS}'"
-	)
-    endif()
     message_wrapper(
-      "-- ${TEST_NAME}: NOT added test because ${PACKAGE_NAME}_ENABLE_TESTS='${${PACKAGE_NAME}_ENABLE_TESTS}${PARENT_EANBLE_TESTS_DISABLE_MSG}'."
+      "-- ${TEST_NAME}: NOT added test because ${PACKAGE_NAME}_ENABLE_TESTS='${${PACKAGE_NAME}_ENABLE_TESTS}'."
      )
    set(ADD_THE_TEST FALSE)
   endif()

--- a/tribits/core/package_arch/TribitsPackageMacros.cmake
+++ b/tribits/core/package_arch/TribitsPackageMacros.cmake
@@ -408,40 +408,8 @@ endmacro()
 #
 macro(tribits_add_test_directories)
 
-  if (CURRENTLY_PROCESSING_SUBPACKAGE)
-
-    # This is a subpackage being processed
-
-    if(NOT ${SUBPACKAGE_FULLNAME}_TRIBITS_SUBPACKAGE_CALLED)
-      tribits_report_invalid_tribits_usage(
-        "Must call tribits_subpackage() before tribits_add_test_directories()"
-        " in ${CURRENT_SUBPACKAGE_CMAKELIST_FILE}")
-    endif()
-
-    if(${SUBPACKAGE_FULLNAME}_TRIBITS_SUBPACKAGE_POSTPROCESS_CALLED)
-      tribits_report_invalid_tribits_usage(
-        "Must call tribits_add_test_directories() before"
-        " tribits_subpackage_postprocess() in"
-        " ${CURRENT_SUBPACKAGE_CMAKELIST_FILE}")
-    endif()
-
-  else()
-
-    # This is a package being processed
-
-    if(NOT ${PACKAGE_NAME}_TRIBITS_PACKAGE_DECL_CALLED)
-      tribits_report_invalid_tribits_usage(
-        "Must call tribits_package() or tribits_package_decl() before"
-        " tribits_add_test_directories() in ${TRIBITS_PACKAGE_CMAKELIST_FILE}")
-    endif()
-
-    if(${PACKAGE_NAME}_TRIBITS_PACKAGE_POSTPROCESS_CALLED)
-      tribits_report_invalid_tribits_usage(
-        "Must call tribits_add_test_directories() before "
-        " tribits_package_postprocess() in ${TRIBITS_PACKAGE_CMAKELIST_FILE}")
-    endif()
-
-  endif()
+  tribits_add_test_example_directories_assert_call_context(
+    tribits_add_test_directories)
 
   if(${PACKAGE_NAME}_ENABLE_TESTS OR ${PARENT_PACKAGE_NAME}_ENABLE_TESTS)
     foreach(TEST_DIR ${ARGN})
@@ -563,44 +531,55 @@ endmacro()
 #
 macro(tribits_add_example_directories)
 
-  if (CURRENTLY_PROCESSING_SUBPACKAGE)
+  tribits_add_test_example_directories_assert_call_context(
+    tribits_add_example_directories)
 
-    # This is a subpackage being processed
-    if(NOT ${SUBPACKAGE_FULLNAME}_TRIBITS_SUBPACKAGE_CALLED)
-      tribits_report_invalid_tribits_usage(
-        "Must call tribits_subpackage() before tribits_add_example_directories()"
-        " in ${CURRENT_SUBPACKAGE_CMAKELIST_FILE}")
-    endif()
-
-    if(${SUBPACKAGE_FULLNAME}_TRIBITS_SUBPACKAGE_POSTPROCESS_CALLED)
-      tribits_report_invalid_tribits_usage(
-        "Must call tribits_add_example_directories() before "
-        " tribits_subpackage_postprocess() in ${CURRENT_SUBPACKAGE_CMAKELIST_FILE}")
-    endif()
-
-  else()
-
-    # This is a package being processed
-    if(NOT ${PACKAGE_NAME}_TRIBITS_PACKAGE_DECL_CALLED)
-      tribits_report_invalid_tribits_usage(
-        "Must call tribits_package() or tribits_package_decl() before"
-        " tribits_add_example_directories() in ${TRIBITS_PACKAGE_CMAKELIST_FILE}")
-    endif()
-
-    if(${PACKAGE_NAME}_TRIBITS_PACKAGE_POSTPROCESS_CALLED)
-      tribits_report_invalid_tribits_usage(
-        "Must call tribits_add_example_directories() before "
-        " tribits_package_postprocess() in ${TRIBITS_PACKAGE_CMAKELIST_FILE}")
-    endif()
-
-  endif()
-
-  if(${PACKAGE_NAME}_ENABLE_EXAMPLES OR ${PARENT_PACKAGE_NAME}_ENABLE_EXAMPLES)
+  if(${PACKAGE_NAME}_ENABLE_EXAMPLES  OR ${PARENT_PACKAGE_NAME}_ENABLE_EXAMPLES)
     foreach(EXAMPLE_DIR ${ARGN})
       tribits_trace_file_processing(PACKAGE  ADD_SUBDIR
         "${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE_DIR}/CMakeLists.txt")
       add_subdirectory(${EXAMPLE_DIR})
     endforeach()
+  endif()
+
+endmacro()
+
+
+macro(tribits_add_test_example_directories_assert_call_context  macroName)
+
+  if (CURRENTLY_PROCESSING_SUBPACKAGE)
+
+    # This is a subpackage being processed
+
+    if(NOT ${SUBPACKAGE_FULLNAME}_TRIBITS_SUBPACKAGE_CALLED)
+      tribits_report_invalid_tribits_usage(
+        "Must call tribits_subpackage() before ${macroName}()"
+        " in ${CURRENT_SUBPACKAGE_CMAKELIST_FILE}")
+    endif()
+
+    if(${SUBPACKAGE_FULLNAME}_TRIBITS_SUBPACKAGE_POSTPROCESS_CALLED)
+      tribits_report_invalid_tribits_usage(
+        "Must call ${macroName}() before"
+        " tribits_subpackage_postprocess() in"
+        " ${CURRENT_SUBPACKAGE_CMAKELIST_FILE}")
+    endif()
+
+  else()
+
+    # This is a package being processed
+
+    if(NOT ${PACKAGE_NAME}_TRIBITS_PACKAGE_DECL_CALLED)
+      tribits_report_invalid_tribits_usage(
+        "Must call tribits_package() or tribits_package_decl() before"
+        " ${macroName}() in ${TRIBITS_PACKAGE_CMAKELIST_FILE}")
+    endif()
+
+    if(${PACKAGE_NAME}_TRIBITS_PACKAGE_POSTPROCESS_CALLED)
+      tribits_report_invalid_tribits_usage(
+        "Must call ${macroName}() before "
+        " tribits_package_postprocess() in ${TRIBITS_PACKAGE_CMAKELIST_FILE}")
+    endif()
+
   endif()
 
 endmacro()

--- a/tribits/core/package_arch/TribitsPackageMacros.cmake
+++ b/tribits/core/package_arch/TribitsPackageMacros.cmake
@@ -401,17 +401,14 @@ endmacro()
 # right effect.
 #
 # Currently, all this macro does macro is to call ``add_subdirectory(<diri>)``
-# if ``${PACKAGE_NAME}_ENABLE_TESTS`` or
-# ``${PARENT_PACKAGE_NAME}_ENABLE_TESTS`` are ``TRUE``. However, this macro
-# may be extended in the future in order to modify behavior related to adding
-# tests and examples in a uniform way.
+# if ``${PACKAGE_NAME}_ENABLE_TESTS`` is ``TRUE``.
 #
 macro(tribits_add_test_directories)
 
   tribits_add_test_example_directories_assert_call_context(
     tribits_add_test_directories)
 
-  if(${PACKAGE_NAME}_ENABLE_TESTS OR ${PARENT_PACKAGE_NAME}_ENABLE_TESTS)
+  if(${PACKAGE_NAME}_ENABLE_TESTS)
     foreach(TEST_DIR ${ARGN})
       tribits_trace_file_processing(PACKAGE  ADD_SUBDIR
         "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_DIR}/CMakeLists.txt")
@@ -534,7 +531,7 @@ macro(tribits_add_example_directories)
   tribits_add_test_example_directories_assert_call_context(
     tribits_add_example_directories)
 
-  if(${PACKAGE_NAME}_ENABLE_EXAMPLES  OR ${PARENT_PACKAGE_NAME}_ENABLE_EXAMPLES)
+  if(${PACKAGE_NAME}_ENABLE_EXAMPLES)
     foreach(EXAMPLE_DIR ${ARGN})
       tribits_trace_file_processing(PACKAGE  ADD_SUBDIR
         "${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE_DIR}/CMakeLists.txt")

--- a/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
+++ b/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
@@ -411,6 +411,8 @@ Both of these variables are automatically enabled when
 Enable a set of packages
 ++++++++++++++++++++++++
 
+.. _<Project>_ENABLE_ALL_OPTIONAL_PACKAGES:
+
 .. _<Project>_ENABLE_TESTS:
 
 To enable an SE package ``<TRIBITS_PACKAGE>`` (and optionally also its tests
@@ -447,6 +449,9 @@ not enforce this if you set the value on the command line or in a set()
 statement in an input ```*.cmake`` options files.  However, setting
 ``-DXXX_ENABLE_YYY=TRUE`` and ``-DXXX_ENABLE_YYY=FALSE`` is allowed and will
 be interpreted correctly..
+
+NOTE: Setting ``<Project>_ENABLE_TESTS=ON`` also causes
+``<Project>_ENABLE_EXAMPLES=ON`` to be set by default as well.
 
 
 Enable or disable tests for specific packages
@@ -501,6 +506,11 @@ all packages that depend on ``<TRIBITS_PACKAGE>`` to be enabled and have all
 of their tests turned on.  Tests will not be enabled in packages that do not
 depend on ``<TRIBITS_PACKAGE>`` in this case.  This speeds up and robustifies
 pre-push testing.
+
+NOTE: setting ``<Project>_ENABLE_ALL_FORWARD_DEP_PACKAGES=ON`` also
+automatically sets and overrides `<Project>_ENABLE_ALL_OPTIONAL_PACKAGES`_ to
+be ``ON`` as well.  (It makes no sense to want to enable forward dependent
+packages for testing purposes unless you are enabling all optional packages.)
 
 
 Enable all packages (and optionally all tests)

--- a/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
+++ b/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
@@ -472,8 +472,8 @@ packages.
 .. _<TRIBITS_PACKAGE>_ENABLE_TESTS:
 
 If one wants to enable a package along with the enable of other packages, but
-not the test suite for that package, then when can disable the tests for that
-package by configuring with::
+not the test suite for that package, then one can use a "exclude-list"
+appraoch to disable the tests for that package by configuring with::
 
   -D <Project>_ENABLE_<TRIBITS_PACKAGE_1>=ON \
   -D <Project>_ENABLE_<TRIBITS_PACKAGE_2>=ON \
@@ -487,12 +487,32 @@ packages that might get implicitly enabled).  One might use this if one wants
 to build and install package ``<TRIBITS_PACKAGE_2>`` but does not want to
 build and run the test suite for that package.
 
+Alternatively, one can use an "include-list" appraoch to enable packages and
+only enable tests for specific packages.  For example, configuring with::
+
+  -D <Project>_ENABLE_<TRIBITS_PACKAGE_1>=ON \
+    -D <TRIBITS_PACKAGE_1>_ENABLE_TESTS=ON \
+  -D <Project>_ENABLE_<TRIBITS_PACKAGE_2>=ON \
+  -D <Project>_ENABLE_<TRIBITS_PACKAGE_3>=ON \
+    -D <TRIBITS_PACKAGE_3>_ENABLE_TESTS=ON \
+
+That will have the same result as using the "exclude-list" approach above.
+
+**NOTE:** Setting ``<TRIBITS_PACKAGE>_ENABLE_TESTS=ON`` will set
+``<TRIBITS_PACKAGE>_ENABLE_EXAMPLES=ON`` by default.  Also, setting
+``<TRIBITS_PACKAGE>_ENABLE_TESTS=ON`` will result in setting
+``<TRIBITS_PACKAGE><SP>_ENABLE_TESTS=ON`` for all subpackages in a parent
+package that are explicitly enabled or are enabled in the forward sweep as a
+result of `<Project>_ENABLE_ALL_FORWARD_DEP_PACKAGES`_ being set to ``ON``.
+
 These and other options give the user complete control of what packages get
 enabled or disabled and what package test suites are enabled or disabled.
 
 
 Enable to test all effects of changing a given package(s)
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. _<Project>_ENABLE_ALL_FORWARD_DEP_PACKAGES:
 
 To enable an SE package ``<TRIBITS_PACKAGE>`` to test it and all of its
 down-stream packages, configure with::

--- a/tribits/doc/guides/TribitsGuidesBody.rst
+++ b/tribits/doc/guides/TribitsGuidesBody.rst
@@ -3378,17 +3378,18 @@ management system are:
 9)  `TPL disable triggers auto-disables of downstream dependencies`_
 10) `Disables trump enables where there is a conflict`_
 11) `Enable/disable of parent package is enable/disable for subpackages`_
-12) `Subpackage enable does not auto-enable the parent package`_
-13) `Support for optional SE package/TPL is enabled by default`_
-14) `Support for optional SE package/TPL can be explicitly disabled`_
-15) `Explicit enable of optional SE package/TPL support auto-enables SE package/TPL`_
-16) `ST SE packages only auto-enabled if ST code is enabled`_
-17) `<Project>_ENABLE_ALL_FORWARD_DEP_PACKAGES enables downstream packages/tests`_
-18) `<Project>_ENABLE_ALL_PACKAGES enables all PT (cond. ST) SE packages`_
-19) `<Project>_ENABLE_TESTS only enables explicitly enabled SE package tests`_
-20) `If no SE packages are enabled, nothing will get built`_
-21) `TriBITS prints all enables and disables to stdout`_
-22) `TriBITS auto-enables/disables done using non-cache local variables`_
+12) `Enable of parent package tests/examples is enable for subpackages tests/examples`_
+13) `Subpackage enable does not auto-enable the parent package`_
+14) `Support for optional SE package/TPL is enabled by default`_
+15) `Support for optional SE package/TPL can be explicitly disabled`_
+16) `Explicit enable of optional SE package/TPL support auto-enables SE package/TPL`_
+17) `ST SE packages only auto-enabled if ST code is enabled`_
+18) `<Project>_ENABLE_ALL_FORWARD_DEP_PACKAGES enables downstream packages/tests`_
+19) `<Project>_ENABLE_ALL_PACKAGES enables all PT (cond. ST) SE packages`_
+20) `<Project>_ENABLE_TESTS only enables explicitly enabled SE package tests`_
+21) `If no SE packages are enabled, nothing will get built`_
+22) `TriBITS prints all enables and disables to stdout`_
+23) `TriBITS auto-enables/disables done using non-cache local variables`_
 
 In more detail, these rules/behaviors are:
 
@@ -3587,9 +3588,21 @@ In more detail, these rules/behaviors are:
     see `Explicit enable of a package, its tests, an optional TPL, with ST
     enabled`_.
 
+.. _Enable of parent package tests/examples is enable for subpackages tests/examples:
+
+12) **Enable of parent package tests/examples is enable for subpackages
+    tests/examples**: Setting ``<TRIBITS_PACKAGE>_ENABLE_TESTS=ON`` is
+    equivalent to setting the default for
+    ``<TRIBITS_PACKAGE><SP>_ENABLE_TESTS=ON`` for each subpackage ``<SP>`` of
+    the parent package ``<TRIBITS_PACKAGE>`` (if ``<TRIBITS_PACKAGE>`` has
+    subpackages).  Same is true for ``<TRIBITS_PACKAGE>_ENABLE_EXAMPLES=ON``
+    setting the default for ``<TRIBITS_PACKAGE><SP>_ENABLE_EXAMPLES=ON``.  In
+    addition, setting ``<TRIBITS_PACKAGE>_ENABLE_TESTS=ON`` will set
+    ``<TRIBITS_PACKAGE>_ENABLE_EXAMPLES=ON`` by default as well.
+
 .. _Subpackage enable does not auto-enable the parent package:
 
-12) **Subpackage enable does not auto-enable the parent package**: Enabling an
+13) **Subpackage enable does not auto-enable the parent package**: Enabling an
     SE package that is a subpackage does **not** automatically enable the
     parent package (except for at the very end, mostly just for show).  For
     example, enabling the SE package ``ThyraEpetra`` does not result in enable
@@ -3612,7 +3625,7 @@ In more detail, these rules/behaviors are:
 
 .. _Support for optional SE package/TPL is enabled by default:
 
-13) **Support for optional SE package/TPL is enabled by default**: For an SE
+14) **Support for optional SE package/TPL is enabled by default**: For an SE
     package ``<TRIBITS_PACKAGE>`` with an optional dependency on an
     `upstream`_ SE package or TPL ``<TRIBITS_DEP_PACKAGE_OR_TPL>``, TriBITS
     will automatically set the intra-enable variable
@@ -3629,7 +3642,7 @@ In more detail, these rules/behaviors are:
 
 .. _Support for optional SE package/TPL can be explicitly disabled:
 
-14) **Support for optional SE package/TPL can be explicitly disabled:** Even
+15) **Support for optional SE package/TPL can be explicitly disabled:** Even
     though TriBITS will automatically set
     ``<TRIBITS_PACKAGE>_ENABLE_<TRIBITS_DEP_PACKAGE_OR_TPL>=ON`` by default if
     ``<TRIBITS_PACKAGE>`` and ``<TRIBITS_DEP_PACKAGE_OR_TPL>`` are both
@@ -3649,7 +3662,7 @@ In more detail, these rules/behaviors are:
 
 .. _Explicit enable of optional SE package/TPL support auto-enables SE package/TPL:
 
-15) **Explicit enable of optional SE package/TPL support auto-enables SE
+16) **Explicit enable of optional SE package/TPL support auto-enables SE
     package/TPL**: If the user explicitly enables the TriBITS SE package
     ``<TRIBITS_PACKAGE>`` and explicitly sets
     ``<TRIBITS_PACKAGE>_ENABLE_<TRIBITS_DEP_PACKAGE_OR_TPL>=ON`` on input,
@@ -3669,7 +3682,7 @@ In more detail, these rules/behaviors are:
 
 .. _ST SE packages only auto-enabled if ST code is enabled:
 
-16) **ST SE packages only auto-enabled if ST code is enabled**: TriBITS will
+17) **ST SE packages only auto-enabled if ST code is enabled**: TriBITS will
     only enable an optional ``ST`` SE package when
     ``${PROJECT_NAME}_ENABLE_ALL_OPTIONAL_PACKAGES=ON`` if
     ``${PROJECT_NAME}_SECONDARY_TESTED_CODE=ON`` is also set.  Otherwise, when
@@ -3688,7 +3701,7 @@ In more detail, these rules/behaviors are:
 
 .. _<Project>_ENABLE_ALL_FORWARD_DEP_PACKAGES enables downstream packages/tests:
 
-17) **<Project>_ENABLE_ALL_FORWARD_DEP_PACKAGES enables downstream packages/tests**:
+18) **<Project>_ENABLE_ALL_FORWARD_DEP_PACKAGES enables downstream packages/tests**:
     Setting the user cache-variable
     ``${PROJECT_NAME}_ENABLE_ALL_FORWARD_PACKAGES=ON`` will result in the
     `downstream`_ ``PT`` SE packages and tests to be enabled (and all ``PT``
@@ -3706,7 +3719,7 @@ In more detail, these rules/behaviors are:
 
 .. _<Project>_ENABLE_ALL_PACKAGES enables all PT (cond. ST) SE packages:
 
-18) **<Project>_ENABLE_ALL_PACKAGES enables all PT (cond. ST) SE packages**:
+19) **<Project>_ENABLE_ALL_PACKAGES enables all PT (cond. ST) SE packages**:
     Setting the user cache-variable ``${PROJECT_NAME}_ENABLE_ALL_PACKAGES=ON``
     will result in the enable of all ``PT`` SE packages when
     ``${PROJECT_NAME}_SECONDARY_TESTED_CODE=OFF`` and all ``PT`` and ``ST`` SE
@@ -3725,7 +3738,7 @@ In more detail, these rules/behaviors are:
 
 .. _<Project>_ENABLE_TESTS only enables explicitly enabled SE package tests:
 
-19) **<Project>_ENABLE_TESTS only enables explicitly enabled SE package
+20) **<Project>_ENABLE_TESTS only enables explicitly enabled SE package
     tests**: Setting ``${PROJECT_NAME}_ENABLE_TESTS=ON`` will **only enable
     tests for explicitly enabled SE packages** on input.  For example,
     configuring with ``Trilinos_ENABLE_RTOp=ON`` and
@@ -3740,7 +3753,7 @@ In more detail, these rules/behaviors are:
 
 .. _If no SE packages are enabled, nothing will get built:
 
-20) **If no SE packages are enabled, nothing will get built**: Most TriBITS
+21) **If no SE packages are enabled, nothing will get built**: Most TriBITS
     projects are set up such that if the user does not explicitly enable at
     least one SE package in some way, then nothing will be enabled or built.
     In this case, when ``${PROJECT_NAME}_ALLOW_NO_PACKAGES=TRUE`` a warning
@@ -3754,7 +3767,7 @@ In more detail, these rules/behaviors are:
 
 .. _TriBITS prints all enables and disables to stdout:
 
-21) **TriBITS prints all enables and disables to stdout**: TriBITS prints out
+22) **TriBITS prints all enables and disables to stdout**: TriBITS prints out
     (to ``cmake`` stdout) the initial set of enables/disables on input, prints
     a line whenever it sets (or overrides) an enable or disable, and prints
     out the final set of enables/disables.  Therefore, the user just needs to
@@ -3767,7 +3780,7 @@ In more detail, these rules/behaviors are:
 
 .. _TriBITS auto-enables/disables done using non-cache local variables:
 
-22) **TriBITS auto-enables/disables done using non-cache local variables**:
+23) **TriBITS auto-enables/disables done using non-cache local variables**:
     TriBITS setting (or overrides) of enable/disable cache variables are done
     by setting local non-cache variables at the top project-level scope
     (i.e. the ``<projectDir>/CMakeLists.txt`` file scope).  This is done so


### PR DESCRIPTION
Addresses specifically the defect in #510 which resulted from work done as part of #63 and #299.  This also mostly addresses the scope of #268.

Once this is updated to Trilinos, it will fix https://github.com/trilinos/Trilinos/issues/10842.

See the specific git commit log messages for more detail.

