### PR TITLE
tribits_add_option_and_define(): restore optional macro define var arg, refactor (#516)

### DIFF
--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -49,7 +49,7 @@ tribits_add_advanced_test( TestingFunctionMacro_UnitTests
       -D${PROJECT_NAME}_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
       -P "${CMAKE_CURRENT_SOURCE_DIR}/TestingFunctionMacro_UnitTests.cmake"
     PASS_REGULAR_EXPRESSION_ALL
-      "Final UnitTests Result: num_run = 703"
+      "Final UnitTests Result: num_run = 708"
       "Final UnitTests Result: PASSED"
   )
 

--- a/test/core/TestingFunctionMacro_UnitTests.cmake
+++ b/test/core/TestingFunctionMacro_UnitTests.cmake
@@ -58,6 +58,7 @@ include(TribitsETISupport)
 include(TribitsFindPythonInterp)
 include(TribitsStripQuotesFromStr)
 include(TribitsStandardizePaths)
+include(TribitsAddOptionAndDefine)
 include(TribitsFilepathHelpers)
 include(TribitsGetVersionDate)
 include(TribitsTplFindIncludeDirsAndLibraries)
@@ -405,6 +406,34 @@ function(unittest_tribits_strip_quotes_from_str)
   message("Testing tribits_strip_quotes_from_str() with str with quote only on back")
   tribits_strip_quotes_from_str("some string in quotes\"" STR_OUT)
   unittest_compare_const(STR_OUT "some string in quotes\"")
+
+endfunction()
+
+
+function(unittest_tribits_add_option_and_define)
+
+  message("\n***")
+  message("*** Testing tribits_add_option_and_define()")
+  message("***\n")
+
+  message("\nPass both option and define var, default YES")
+  tribits_add_option_and_define(optName1  macroOptName1 "doc" YES)
+  unittest_compare_const(optName1 "YES")
+  unittest_compare_const(macroOptName1 "ON")
+  unset(optName1 CACHE)
+  unset(macroOptName1 CACHE)
+
+  message("\nPass both option and define var, default FALSE")
+  tribits_add_option_and_define(optName2  macroOptName2 "doc" FALSE)
+  unittest_compare_const(optName2 "FALSE")
+  unittest_compare_const(macroOptName2 "OFF")
+  unset(optName2 CACHE)
+  unset(macroOptName2 CACHE)
+
+  message("\nPass only option var, not define var, default YES")
+  tribits_add_option_and_define(optName3 "" "doc" YES)
+  unittest_compare_const(optName3 "YES")
+  unset(optName3 CACHE)
 
 endfunction()
 
@@ -4587,6 +4616,7 @@ unittest_tribits_dir_is_basedir()
 unittest_tribits_get_dir_array_below_base_dir()
 unittest_tribits_misc()
 unittest_tribits_strip_quotes_from_str()
+unittest_tribits_add_option_and_define()
 unittest_tribits_get_version_date_from_raw_git_commit_utc_time()
 unittest_tribits_get_raw_git_commit_utc_time()
 unittest_tribits_git_repo_sha1()
@@ -4646,4 +4676,4 @@ message("*** Determine final result of all unit tests")
 message("***\n")
 
 # Pass in the number of expected tests that must pass!
-unittest_final_result(703)
+unittest_final_result(708)

--- a/tribits/core/package_arch/TribitsAddOptionAndDefine.cmake
+++ b/tribits/core/package_arch/TribitsAddOptionAndDefine.cmake
@@ -37,12 +37,13 @@
 # ************************************************************************
 # @HEADER
 
+include(TribitsPkgExportCacheVars)
 include(GlobalSet)
 
 
 # @MACRO: tribits_add_option_and_define()
 #
-# Add an option and a define variable in one shot.
+# Add an option and an optional macro define variable in one shot.
 #
 # Usage::
 #
@@ -59,7 +60,16 @@ include(GlobalSet)
 #   #cmakedefine <macroDefineName>
 #
 # NOTE: This also calls `tribits_pkg_export_cache_var()`_ to export the
-# variables ``<userOptionName>`` and ``<macroDefineName>``.
+# variables ``<userOptionName>`` and ``<macroDefineName>``.  This also
+# requires that local variables with the same names of these cache variables
+# not be assigned with a different value from these cache variables.  If they
+# are, then an error will occur later when these variables are read.
+#
+# NOTE: The define var name ``<macroDefineName>`` can be empty "" in which
+# case all logic related to ``<macroDefineName>`` is skipped.  (But in this
+# case, it would be better to just call::
+#
+#   set(<userOptionName> <defaultValue> CACHE BOOL "<docStr>")
 #
 macro(tribits_add_option_and_define  USER_OPTION_NAME  MACRO_DEFINE_NAME
   DOCSTRING  DEFAULT_VALUE
@@ -73,8 +83,8 @@ macro(tribits_add_option_and_define  USER_OPTION_NAME  MACRO_DEFINE_NAME
       global_set(${MACRO_DEFINE_NAME} OFF)
     endif()
   endif()
-  if (COMMAND tribits_pkg_export_cache_var)
-    tribits_pkg_export_cache_var(${USER_OPTION_NAME})
+  tribits_pkg_export_cache_var(${USER_OPTION_NAME})
+  if(NOT ${MACRO_DEFINE_NAME} STREQUAL "")
     tribits_pkg_export_cache_var(${MACRO_DEFINE_NAME})
   endif()
 endmacro()

--- a/tribits/core/package_arch/TribitsGeneralMacros.cmake
+++ b/tribits/core/package_arch/TribitsGeneralMacros.cmake
@@ -426,27 +426,3 @@ function(tribits_trace_file_processing  TYPE_IN  PROCESSING_TYPE_IN  FILE_PATH)
   endif()
 
 endfunction()
-
-
-# @MACRO: tribits_assert_cache_and_local_vars_same_value()
-#
-# Asset that a cache variable and a possible local variable (if it exists)
-# have the same value.
-#
-# Usage::
-#
-#   tribits_assert_cache_and_local_vars_same_value(<cacheVarName>)
-#
-# If the local var ``<cacheVarName>`` and the cache var ``<cacheVarName>``
-# both exist but have different values, then ``message(SEND_ERROR ...)`` is
-# called with an informative error message.
-#
-macro(tribits_assert_cache_and_local_vars_same_value  cacheVarName)
-  set(cacheVarValue "$CACHE{${cacheVarName}}")
-  set(localValue "${${cacheVarName}}")
-  if (NOT localValue STREQUAL cacheVarValue)
-    message_wrapper(SEND_ERROR "ERROR: The cache variable ${cacheVarName} with the"
-      " cache var value '${cacheVarValue}' is not the same value as the local"
-      " variable ${cacheVarName} with value '${localValue}'!")
-  endif()
-endmacro()

--- a/tribits/core/package_arch/TribitsPackageMacros.cmake
+++ b/tribits/core/package_arch/TribitsPackageMacros.cmake
@@ -52,6 +52,7 @@ include(RemoveGlobalDuplicates)
 include(TribitsGatherBuildTargets)
 
 include(TribitsAddOptionAndDefine)
+include(TribitsPkgExportCacheVars)
 include(TribitsLibraryMacros)
 include(TribitsAddExecutable)
 include(TribitsAddExecutableAndTest)
@@ -75,47 +76,6 @@ include(TribitsReportInvalidTribitsUsage)
 macro(tribits_define_linkage_vars PACKAGE_NAME_IN)
   global_null_set(${PACKAGE_NAME_IN}_LIBRARIES "")
   global_set(${PACKAGE_NAME_IN}_HAS_NATIVE_LIBRARIES_TO_INSTALL FALSE)
-endmacro()
-
-
-# Macro that sets up data-structures for variables to be exported
-#
-macro(tribits_pkg_init_exported_vars  PACKAGE_NAME_IN)
-  global_set(${PACKAGE_NAME_IN}_PKG_VARS_TO_EXPORT "")
-endmacro()
-
-
-# @MACRO: tribits_pkg_export_cache_var()
-#
-# Macro that registers a package-level cache var to be exported in the
-# ``<Package>Config.cmake`` file
-#
-# Usage::
-#
-#   tribits_pkg_export_cache_var(<cacheVarName>)
-#
-# where ``<cacheVarName>`` must be the name of a cache variable (or an error
-# will occur).
-#
-# NOTE: This will also export this variable to the
-# ``<Package><Spkg>Config.cmake`` file for every enabled subpackage (if this
-# is called from a ``CMakeLists.txt`` file of a top-level package that has
-# subpackages).  That way, any top-level package cache vars are provided by
-# any of the subpackages' ``<Package><Spkg>Config.cmake`` files.
-#
-macro(tribits_pkg_export_cache_var  cacheVarName)
-  if (DEFINED ${PACKAGE_NAME}_PKG_VARS_TO_EXPORT)
-    # Assert this is a cache var
-    get_property(cacheVarIsCacheVar  CACHE ${cacheVarName} PROPERTY  VALUE  SET)
-    if (NOT cacheVarIsCacheVar)
-      message(SEND_ERROR
-        "ERROR: The variable ${cacheVarName} is NOT a cache var and cannot"
-        " be exported!")
-    endif()
-    # Add to the list of package cache vars to export
-    append_global_set(${PACKAGE_NAME}_PKG_VARS_TO_EXPORT
-      ${cacheVarName})
-  endif()
 endmacro()
 
 

--- a/tribits/core/package_arch/TribitsPkgExportCacheVars.cmake
+++ b/tribits/core/package_arch/TribitsPkgExportCacheVars.cmake
@@ -1,0 +1,130 @@
+# @HEADER
+# ************************************************************************
+#
+#            TriBITS: Tribal Build, Integrate, and Test System
+#                    Copyright 2013 Sandia Corporation
+#
+# Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+# the U.S. Government retains certain rights in this software.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the Corporation nor the names of the
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# ************************************************************************
+# @HEADER
+
+
+# @MACRO: tribits_pkg_export_cache_var()
+#
+# Macro that registers a package-level cache var to be exported in the
+# ``<Package>Config.cmake`` file
+#
+# Usage::
+#
+#   tribits_pkg_export_cache_var(<cacheVarName>)
+#
+# where ``<cacheVarName>`` must be the name of a cache variable (or an error
+# will occur).
+#
+# NOTE: This will also export this variable to the
+# ``<Package><Spkg>Config.cmake`` file for every enabled subpackage (if this
+# is called from a ``CMakeLists.txt`` file of a top-level package that has
+# subpackages).  That way, any top-level package cache vars are provided by
+# any of the subpackages' ``<Package><Spkg>Config.cmake`` files.
+#
+macro(tribits_pkg_export_cache_var  cacheVarName)
+  if (DEFINED ${PACKAGE_NAME}_PKG_VARS_TO_EXPORT)
+    # Assert this is a cache var
+    get_property(cacheVarIsCacheVar  CACHE ${cacheVarName} PROPERTY  VALUE  SET)
+    if (NOT cacheVarIsCacheVar)
+      message(SEND_ERROR
+        "ERROR: The variable ${cacheVarName} is NOT a cache var and cannot"
+        " be exported!")
+    endif()
+    # Add to the list of package cache vars to export
+    append_global_set(${PACKAGE_NAME}_PKG_VARS_TO_EXPORT
+      ${cacheVarName})
+  endif()
+endmacro()
+
+
+# @MACRO: tribits_assert_cache_and_local_vars_same_value()
+#
+# Asset that a cache variable and a possible local variable (if it exists)
+# have the same value.
+#
+# Usage::
+#
+#   tribits_assert_cache_and_local_vars_same_value(<cacheVarName>)
+#
+# If the local var ``<cacheVarName>`` and the cache var ``<cacheVarName>``
+# both exist but have different values, then ``message(SEND_ERROR ...)`` is
+# called with an informative error message.
+#
+macro(tribits_assert_cache_and_local_vars_same_value  cacheVarName)
+  set(cacheVarValue "$CACHE{${cacheVarName}}")
+  set(localValue "${${cacheVarName}}")
+  if (NOT localValue STREQUAL cacheVarValue)
+    message_wrapper(SEND_ERROR "ERROR: The cache variable ${cacheVarName} with the"
+      " cache var value '${cacheVarValue}' is not the same value as the local"
+      " variable ${cacheVarName} with value '${localValue}'!")
+  endif()
+endmacro()
+
+
+# Function that sets up data-structures for package-level cache var to be
+# exported
+#
+function(tribits_pkg_init_exported_vars  PACKAGE_NAME_IN)
+  global_set(${PACKAGE_NAME_IN}_PKG_VARS_TO_EXPORT "")
+endfunction()
+
+
+# Function that injects set() statements for a package's exported cache vars into
+# a string.
+#
+# This is used to create set() statements to be injected into a package's
+# ``<Package>Config.cmake`` file.
+#
+function(tribits_pkg_append_set_commands_for_exported_vars  packageName
+    configFileStrInOut
+  )
+  set(configFileStr "${${configFileStrInOut}}")
+  if (NOT "${${packageName}_PARENT_PACKAGE}" STREQUAL "")
+    foreach(exportedCacheVar IN LISTS ${${packageName}_PARENT_PACKAGE}_PKG_VARS_TO_EXPORT)
+      tribits_assert_cache_and_local_vars_same_value(${exportedCacheVar})
+      string(APPEND configFileStr
+        "set(${exportedCacheVar} \"${${exportedCacheVar}}\")\n")
+    endforeach()
+  endif()
+  foreach(exportedCacheVar IN LISTS ${packageName}_PKG_VARS_TO_EXPORT)
+    tribits_assert_cache_and_local_vars_same_value(${exportedCacheVar})
+    string(APPEND configFileStr
+      "set(${exportedCacheVar} \"${${exportedCacheVar}}\")\n")
+  endforeach()
+  set(${configFileStrInOut} "${configFileStr}" PARENT_SCOPE)
+endfunction()

--- a/tribits/core/package_arch/TribitsWriteClientExportFiles.cmake
+++ b/tribits/core/package_arch/TribitsWriteClientExportFiles.cmake
@@ -38,6 +38,7 @@
 # @HEADER
 
 include(TribitsGeneralMacros)
+include(TribitsPkgExportCacheVars)
 
 ###
 ### WARNING: See "NOTES TO DEVELOPERS" at the bottom of the file
@@ -579,18 +580,7 @@ function(tribits_append_dependent_package_config_file_includes_and_enables packa
   # Put in set() statements for exported cache vars
   string(APPEND configFileStr
     "\n# Exported cache variables\n")
-  if (NOT "${${packageName}_PARENT_PACKAGE}" STREQUAL "")
-    foreach(exportedCacheVar IN LISTS ${${packageName}_PARENT_PACKAGE}_PKG_VARS_TO_EXPORT)
-      tribits_assert_cache_and_local_vars_same_value(${exportedCacheVar})
-      string(APPEND configFileStr
-        "set(${exportedCacheVar} \"${${exportedCacheVar}}\")\n")
-    endforeach()
-  endif()
-  foreach(exportedCacheVar IN LISTS ${packageName}_PKG_VARS_TO_EXPORT)
-    tribits_assert_cache_and_local_vars_same_value(${exportedCacheVar})
-    string(APPEND configFileStr
-      "set(${exportedCacheVar} \"${${exportedCacheVar}}\")\n")
-  endforeach()
+  tribits_pkg_append_set_commands_for_exported_vars(${packageName} configFileStr)
 
   # Include configurations of dependent packages
   string(APPEND configFileStr


### PR DESCRIPTION
Follow-up from PR #520, addresses #516 

See commit log msg for details.

NOTE: This should fix the error reported in https://github.com/trilinos/Trilinos/issues/10925 (@glhenni).

