### PR TITLE
Fix package test/example enable logic for global test/example case (#trilinos/Trilinos#11002)

### DIFF
--- a/test/core/DependencyUnitTests/CMakeLists.txt
+++ b/test/core/DependencyUnitTests/CMakeLists.txt
@@ -679,6 +679,24 @@ create_dependency_handling_test_case(
 
 
 create_dependency_handling_test_case(
+  EnableThyra_EnableExamples_EnableTestsEmpty_DisableThyraExamples_EnableThyraTests
+  ARGS -DTrilinos_ENABLE_Thyra=ON
+    -DTrilinos_ENABLE_EXAMPLES=ON -DTrilinos_ENABLE_TESTS= -DThyra_ENABLE_EXAMPLES=OFF -DThyra_ENABLE_TESTS=ON
+  PASS_REGULAR_EXPRESSION_ALL
+    "Disabling subpackage tests/examples based on parent package tests/examples disables ..."
+    "-- Setting ThyraCoreLibs_ENABLE_EXAMPLES=OFF because parent package Thyra_ENABLE_EXAMPLES=OFF"
+    "-- Setting ThyraEpetra_ENABLE_EXAMPLES=OFF because parent package Thyra_ENABLE_EXAMPLES=OFF"
+    "-- Setting ThyraEpetraExt_ENABLE_EXAMPLES=OFF because parent package Thyra_ENABLE_EXAMPLES=OFF"
+    "-- Setting ThyraTpetra_ENABLE_EXAMPLES=OFF because parent package Thyra_ENABLE_EXAMPLES=OFF"
+    "Enabling all tests and/or examples that have not been explicitly disabled because Trilinos_ENABLE_.TESTS,EXAMPLES.=ON ..."
+    "-- Setting ThyraCoreLibs_ENABLE_TESTS=ON"
+    "-- Setting ThyraEpetra_ENABLE_TESTS=ON"
+    "-- Setting ThyraEpetraExt_ENABLE_TESTS=ON"
+    "-- Setting ThyraTpetra_ENABLE_TESTS=ON"
+  )
+
+
+create_dependency_handling_test_case(
   TestTrueFalse
   ARGS -DTrilinos_ENABLE_ALL_PACKAGES=TRUE -DTrilinos_ENABLE_Zoltan=TRUE
     -DTrilinos_ENABLE_TEST=TRUE -DTPL_ENABLE_BLAS=FALSE

--- a/test/core/DependencyUnitTests/CMakeLists.txt
+++ b/test/core/DependencyUnitTests/CMakeLists.txt
@@ -688,11 +688,11 @@ create_dependency_handling_test_case(
     "-- Setting ThyraEpetra_ENABLE_EXAMPLES=OFF because parent package Thyra_ENABLE_EXAMPLES=OFF"
     "-- Setting ThyraEpetraExt_ENABLE_EXAMPLES=OFF because parent package Thyra_ENABLE_EXAMPLES=OFF"
     "-- Setting ThyraTpetra_ENABLE_EXAMPLES=OFF because parent package Thyra_ENABLE_EXAMPLES=OFF"
-    "Enabling all tests and/or examples that have not been explicitly disabled because Trilinos_ENABLE_.TESTS,EXAMPLES.=ON ..."
-    "-- Setting ThyraCoreLibs_ENABLE_TESTS=ON"
-    "-- Setting ThyraEpetra_ENABLE_TESTS=ON"
-    "-- Setting ThyraEpetraExt_ENABLE_TESTS=ON"
-    "-- Setting ThyraTpetra_ENABLE_TESTS=ON"
+    "Enabling subpackage tests/examples based on parent package tests/examples enables ..."
+    "-- Setting ThyraCoreLibs_ENABLE_TESTS=ON because parent package Thyra_ENABLE_TESTS=ON"
+    "-- Setting ThyraEpetra_ENABLE_TESTS=ON because parent package Thyra_ENABLE_TESTS=ON"
+    "-- Setting ThyraEpetraExt_ENABLE_TESTS=ON because parent package Thyra_ENABLE_TESTS=ON"
+    "-- Setting ThyraTpetra_ENABLE_TESTS=ON because parent package Thyra_ENABLE_TESTS=ON"
   )
 
 

--- a/tribits/core/package_arch/TribitsAdjustPackageEnables.cmake
+++ b/tribits/core/package_arch/TribitsAdjustPackageEnables.cmake
@@ -927,28 +927,31 @@ macro(tribits_postprocess_optional_tpl_enables PACKAGE_NAME)
 endmacro()
 
 
-# Set an individual package variable enable based on the global value
+# Set an individual package variable enable variable (to on or off) based on a
+# global enable value
 #
-macro(tribits_set_all_packages_package_enable_variable   PACKAGE_ARCH_VAR   PACKAGE_VAR)
+macro(tribits_set_package_enable_based_on_global_enable  projectEnableVar
+    packageEnableVar
+  )
 
   if (${PROJECT_NAME}_VERBOSE_CONFIGURE)
     message("")
-    message("TRIBITS_SET_ALL_PACKAGES_PACKAGE_ENABLE_VARIABLE:")
-    message("-- " "${PACKAGE_ARCH_VAR} = ${${PACKAGE_ARCH_VAR}}")
-    message("-- " "${PACKAGE_VAR} = ${${PACKAGE_VAR}}")
+    message("TRIBITS_SET_PACKAGE_ENABLE_BASED_ON_GLOBAL_ENABLE:")
+    message("-- " "${projectEnableVar} = ${${projectEnableVar}}")
+    message("-- " "${packageEnableVar} = ${${packageEnableVar}}")
   endif()
 
-  if ("${${PACKAGE_VAR}}" STREQUAL "")
-    if (${PACKAGE_ARCH_VAR})
-      message("-- " "Setting ${PACKAGE_VAR}=ON")
-      set(${PACKAGE_VAR} ON)
+  if ("${${packageEnableVar}}" STREQUAL "")
+    if (${projectEnableVar})
+      message("-- " "Setting ${packageEnableVar}=ON")
+      set(${packageEnableVar} ON)
     elseif (
-      (NOT ${PACKAGE_ARCH_VAR})
+      (NOT ${projectEnableVar})
       AND
-      (NOT "${PACKAGE_ARCH_VAR}" STREQUAL "")
+      (NOT "${projectEnableVar}" STREQUAL "")
       )
-      message("-- " "Setting ${PACKAGE_VAR}=OFF")
-      set(${PACKAGE_VAR} OFF)
+      message("-- " "Setting ${packageEnableVar}=OFF")
+      set(${packageEnableVar} OFF)
     else()
       if (${PROJECT_NAME}_VERBOSE_CONFIGURE)
         message("-- " "ELSE")
@@ -958,12 +961,12 @@ macro(tribits_set_all_packages_package_enable_variable   PACKAGE_ARCH_VAR   PACK
     endif()
   else()
     if (${PROJECT_NAME}_VERBOSE_CONFIGURE)
-      message("-- " "${PACKAGE_VAR} NOT DEFAULT")
+      message("-- " "${packageEnableVar} NOT DEFAULT")
     endif()
   endif()
 
   if (${PROJECT_NAME}_VERBOSE_CONFIGURE)
-    message("-- " "${PACKAGE_VAR} = ${${PACKAGE_VAR}}")
+    message("-- " "${packageEnableVar} = ${${packageEnableVar}}")
   endif()
 
 endmacro()
@@ -977,22 +980,22 @@ macro(tribits_apply_all_package_enables  PACKAGE_NAME)
   tribits_implicit_package_enable_is_allowed( "" ${PACKAGE_NAME}
     PROCESS_PACKAGE_ENABLE )
   if (PACKAGE_IS_PMPP  AND  PROCESS_PACKAGE_ENABLE)
-    tribits_set_all_packages_package_enable_variable(
+    tribits_set_package_enable_based_on_global_enable(
       ${PROJECT_NAME}_ENABLE_ALL_PACKAGES ${PROJECT_NAME}_ENABLE_${PACKAGE_NAME} )
   endif()
 endmacro()
 
 
 # Macro used to set ${TRIBITS_PACKAGE)_ENABLE_TESTS and ${TRIBITS_PACKAGE)_ENABLE_EXAMPLES
-# based on ${PROJECT_NAME}_ENABLE_ALL_PACKAGES
+# based on ${PROJECT_NAME}_ENABLE_TESTS and ${PROJECT_NAME}_ENABLE_EXAMPLES 
 #
 macro(tribits_apply_test_example_enables PACKAGE_NAME)
   if (${PROJECT_NAME}_ENABLE_${PACKAGE_NAME})
     tribits_is_primary_meta_project_package(${PACKAGE_NAME}  PACKAGE_IS_PMPP)
     if (PACKAGE_IS_PMPP)
-      tribits_set_all_packages_package_enable_variable(
+      tribits_set_package_enable_based_on_global_enable(
         ${PROJECT_NAME}_ENABLE_TESTS ${PACKAGE_NAME}_ENABLE_TESTS )
-      tribits_set_all_packages_package_enable_variable(
+      tribits_set_package_enable_based_on_global_enable(
         ${PROJECT_NAME}_ENABLE_EXAMPLES ${PACKAGE_NAME}_ENABLE_EXAMPLES )
     endif()
   endif()

--- a/tribits/core/package_arch/TribitsAdjustPackageEnables.cmake
+++ b/tribits/core/package_arch/TribitsAdjustPackageEnables.cmake
@@ -972,6 +972,20 @@ macro(tribits_set_package_enable_based_on_global_enable  projectEnableVar
 endmacro()
 
 
+# Set an individual package test or examples enable to on only if global enable var is on
+#
+macro(tribits_set_package_enable_based_on_global_enable_on  projectEnableVar
+    packageEnableVar
+  )
+  if ("${${packageEnableVar}}" STREQUAL "")
+    if (${projectEnableVar})
+      message("-- " "Setting ${packageEnableVar}=ON")
+      set(${packageEnableVar} ON)
+    endif()
+  endif()
+endmacro()
+
+
 # Macro used to set ${PROJECT_NAME}_ENABLE_${PACKAGE_NAME} based on
 # ${PROJECT_NAME}_ENABLE_ALL_PACKAGES
 #
@@ -993,9 +1007,9 @@ macro(tribits_apply_test_example_enables PACKAGE_NAME)
   if (${PROJECT_NAME}_ENABLE_${PACKAGE_NAME})
     tribits_is_primary_meta_project_package(${PACKAGE_NAME}  PACKAGE_IS_PMPP)
     if (PACKAGE_IS_PMPP)
-      tribits_set_package_enable_based_on_global_enable(
+      tribits_set_package_enable_based_on_global_enable_on(
         ${PROJECT_NAME}_ENABLE_TESTS ${PACKAGE_NAME}_ENABLE_TESTS )
-      tribits_set_package_enable_based_on_global_enable(
+      tribits_set_package_enable_based_on_global_enable_on(
         ${PROJECT_NAME}_ENABLE_EXAMPLES ${PACKAGE_NAME}_ENABLE_EXAMPLES )
     endif()
   endif()


### PR DESCRIPTION
This PR adds a failing test to show the defect reported in #trilinos/Trilinos#11002 and then updates the code to make the test pass.

I think this TriBITS enable/disable logic could use a little more messaging but I think  this is okay for now.
