### PR TITLE
Update MPI, HDF5, and Netcdf TriBITS find modules (#533, #534)

### DIFF
--- a/tribits/common_tpls/FindTPLHDF5.cmake
+++ b/tribits/common_tpls/FindTPLHDF5.cmake
@@ -4,17 +4,18 @@
 
 if (Netcdf_ALLOW_MODERN)
 
-  #set(minimum_modern_HDF5_version 4.7.4)
+  set(minimum_modern_HDF5_version 1.13.2)
   print_var(Netcdf_ALLOW_MODERN)
   message("-- Using find_package(HDF5 ${minimum_modern_HDF5_version} CONFIG) ...")
   find_package(HDF5  ${minimum_modern_HDF5_version}  CONFIG)
   if (HDF5_FOUND)
     message("-- Found HDF5_CONFIG=${HDF5_CONFIG}")
     message("-- Generating Netcdf::all_libs and NetcdfConfig.cmake")
+    message("-- HDF5_EXPORT_LIBRARIES=${HDF5_EXPORT_LIBRARIES}")
     tribits_extpkg_create_imported_all_libs_target_and_config_file(
       HDF5
       INNER_FIND_PACKAGE_NAME  HDF5
-      IMPORTED_TARGETS_FOR_ALL_LIBS   HDF5::HDF5)
+      IMPORTED_TARGETS_FOR_ALL_LIBS   ${HDF5_EXPORT_LIBRARIES})
   endif()
 
 endif()

--- a/tribits/common_tpls/FindTPLHDF5.cmake
+++ b/tribits/common_tpls/FindTPLHDF5.cmake
@@ -2,78 +2,97 @@
 # See associated tribits/Copyright.txt file for copyright and license! #
 ########################################################################
 
-#
-# First, set up the variables for the (backward-compatible) TriBITS way of
-# finding HDF5.  These are used in case find_package(HDF5 ...) is not called
-# or does not find HDF5.  Also, these variables need to be non-null in order
-# to trigger the right behavior in the function
-# tribits_tpl_find_include_dirs_and_libraries().
-#
+if (Netcdf_ALLOW_MODERN)
 
-set(REQUIRED_HEADERS hdf5.h)
-set(REQUIRED_LIBS_NAMES hdf5)
+  #set(minimum_modern_HDF5_version 4.7.4)
+  print_var(Netcdf_ALLOW_MODERN)
+  message("-- Using find_package(HDF5 ${minimum_modern_HDF5_version} CONFIG) ...")
+  find_package(HDF5  ${minimum_modern_HDF5_version}  CONFIG)
+  if (HDF5_FOUND)
+    message("-- Found HDF5_CONFIG=${HDF5_CONFIG}")
+    message("-- Generating Netcdf::all_libs and NetcdfConfig.cmake")
+    tribits_extpkg_create_imported_all_libs_target_and_config_file(
+      HDF5
+      INNER_FIND_PACKAGE_NAME  HDF5
+      IMPORTED_TARGETS_FOR_ALL_LIBS   HDF5::HDF5)
+  endif()
 
-if (HDF5_REQUIRE_FORTRAN)
-  set(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} hdf5_fortran)
 endif()
 
-if (TPL_ENABLE_MPI)
-  set(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} z)
-endif()
+if (NOT TARGET HDF5::all_libs)
 
-if (TPL_ENABLE_Netcdf)
-  set(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} hdf5_hl)
-endif()
+  # First, set up the variables for the (backward-compatible) TriBITS way of
+  # finding HDF5.  These are used in case find_package(HDF5 ...) is not called
+  # or does not find HDF5.  Also, these variables need to be non-null in order
+  # to trigger the right behavior in the function
+  # tribits_tpl_find_include_dirs_and_libraries().
 
-#
-# Second, search for HDF5 components (if allowed) using the standard
-# find_package(HDF5 ...).
-#
-tribits_tpl_allow_pre_find_package(HDF5  HDF5_ALLOW_PREFIND)
-if (HDF5_ALLOW_PREFIND)
+  set(REQUIRED_HEADERS hdf5.h)
+  set(REQUIRED_LIBS_NAMES hdf5)
 
-  message("-- Using find_package(HDF5 ...) ...")
-
-  set(HDF5_COMPONENTS C)
   if (HDF5_REQUIRE_FORTRAN)
-    list(APPEND HDF5_COMPONENTS Fortran)
+    set(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} hdf5_fortran)
   endif()
 
   if (TPL_ENABLE_MPI)
-    set(HDF5_PREFER_PARALLEL TRUE)
+    set(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} z)
   endif()
 
-  find_package(HDF5 COMPONENTS ${HDF5_COMPONENTS})
-
-  # Make sure that HDF5 is parallel.
-  if (TPL_ENABLE_MPI AND NOT HDF5_IS_PARALLEL)
-    message(FATAL_ERROR "Trilinos is configured for MPI, HDF5 is not.
-    Did CMake find the correct libraries?
-    Try setting HDF5_INCLUDE_DIRS and/or HDF5_LIBRARY_DIRS explicitly.
-    ")
+  if (TPL_ENABLE_Netcdf)
+    set(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} hdf5_hl)
   endif()
 
-  if (HDF5_FOUND)
-    # Tell TriBITS that we found HDF5 and there no need to look any further!
-    set(TPL_HDF5_INCLUDE_DIRS ${HDF5_INCLUDE_DIRS} CACHE PATH
-      "HDF5 include dirs")
-    set(TPL_HDF5_LIBRARIES ${HDF5_LIBRARIES} CACHE FILEPATH
-      "HDF5 libraries")
-    set(TPL_HDF5_LIBRARY_DIRS ${HDF5_LIBRARY_DIRS} CACHE PATH
-      "HDF5 library dirs")
+  #
+  # Second, search for HDF5 components (if allowed) using the standard
+  # find_package(HDF5 ...).
+  #
+  tribits_tpl_allow_pre_find_package(HDF5  HDF5_ALLOW_PREFIND)
+  if (HDF5_ALLOW_PREFIND)
+
+    message("-- Using find_package(HDF5 ...) ...")
+
+    set(HDF5_COMPONENTS C)
+    if (HDF5_REQUIRE_FORTRAN)
+      list(APPEND HDF5_COMPONENTS Fortran)
+    endif()
+
+    if (TPL_ENABLE_MPI)
+      set(HDF5_PREFER_PARALLEL TRUE)
+    endif()
+
+    find_package(HDF5 COMPONENTS ${HDF5_COMPONENTS})
+
+    # Make sure that HDF5 is parallel.
+    if (TPL_ENABLE_MPI AND NOT HDF5_IS_PARALLEL)
+      message(FATAL_ERROR "Trilinos is configured for MPI, HDF5 is not.
+      Did CMake find the correct libraries?
+      Try setting HDF5_INCLUDE_DIRS and/or HDF5_LIBRARY_DIRS explicitly.
+      ")
+    endif()
+
+    if (HDF5_FOUND)
+      # Tell TriBITS that we found HDF5 and there no need to look any further!
+      set(TPL_HDF5_INCLUDE_DIRS ${HDF5_INCLUDE_DIRS} CACHE PATH
+        "HDF5 include dirs")
+      set(TPL_HDF5_LIBRARIES ${HDF5_LIBRARIES} CACHE FILEPATH
+        "HDF5 libraries")
+      set(TPL_HDF5_LIBRARY_DIRS ${HDF5_LIBRARY_DIRS} CACHE PATH
+        "HDF5 library dirs")
+    endif()
+
   endif()
+
+  #
+  # Third, call tribits_tpl_find_include_dirs_and_libraries()
+  #
+  tribits_tpl_find_include_dirs_and_libraries( HDF5
+    REQUIRED_HEADERS ${REQUIRED_HEADERS}
+    REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES}
+    )
+  # NOTE: If find_package(HDF5 ...) was called and successfully found HDF5, then
+  # tribits_tpl_find_include_dirs_and_libraries() will use the already-set
+  # variables TPL_HDF5_INCLUDE_DIRS and TPL_HDF5_LIBRARIES and then print them
+  # out (and set some other standard variables as well).  This is the final
+  # "hook" into the TriBITS TPL system.
 
 endif()
-
-#
-# Third, call tribits_tpl_find_include_dirs_and_libraries()
-#
-tribits_tpl_find_include_dirs_and_libraries( HDF5
-  REQUIRED_HEADERS ${REQUIRED_HEADERS}
-  REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES}
-  )
-# NOTE: If find_package(HDF5 ...) was called and successfully found HDF5, then
-# tribits_tpl_find_include_dirs_and_libraries() will use the already-set
-# variables TPL_HDF5_INCLUDE_DIRS and TPL_HDF5_LIBRARIES and then print them
-# out (and set some other standard variables as well).  This is the final
-# "hook" into the TriBITS TPL system.

--- a/tribits/common_tpls/FindTPLHDF5.cmake
+++ b/tribits/common_tpls/FindTPLHDF5.cmake
@@ -2,7 +2,7 @@
 # See associated tribits/Copyright.txt file for copyright and license! #
 ########################################################################
 
-set(INTERNAL_IS_MODERN FALSE)
+set(HDF5_INTERNAL_IS_MODERN FALSE)
 
 if (Netcdf_ALLOW_MODERN)
 
@@ -18,12 +18,12 @@ if (Netcdf_ALLOW_MODERN)
       HDF5
       INNER_FIND_PACKAGE_NAME  HDF5
       IMPORTED_TARGETS_FOR_ALL_LIBS   ${HDF5_EXPORT_LIBRARIES})
-    set(INTERNAL_IS_MODERN TRUE)
+    set(HDF5_INTERNAL_IS_MODERN TRUE)
   endif()
 
 endif()
 
-set(HDF5_FOUND_MODERN_CONFIG_FILE ${INTERNAL_IS_MODERN} CACHE BOOL "True if HDF5 was found by the modern method" FORCE)
+set(HDF5_FOUND_MODERN_CONFIG_FILE ${HDF5_INTERNAL_IS_MODERN} CACHE INTERNAL "True if HDF5 was found by the modern method")
 
 if (NOT TARGET HDF5::all_libs)
 

--- a/tribits/common_tpls/FindTPLHDF5.cmake
+++ b/tribits/common_tpls/FindTPLHDF5.cmake
@@ -2,6 +2,8 @@
 # See associated tribits/Copyright.txt file for copyright and license! #
 ########################################################################
 
+set(INTERNAL_IS_MODERN FALSE)
+
 if (Netcdf_ALLOW_MODERN)
 
   set(minimum_modern_HDF5_version 1.13.2)
@@ -16,9 +18,12 @@ if (Netcdf_ALLOW_MODERN)
       HDF5
       INNER_FIND_PACKAGE_NAME  HDF5
       IMPORTED_TARGETS_FOR_ALL_LIBS   ${HDF5_EXPORT_LIBRARIES})
+    set(INTERNAL_IS_MODERN TRUE)
   endif()
 
 endif()
+
+set(HDF5_FOUND_MODERN_CONFIG_FILE ${INTERNAL_IS_MODERN} CACHE BOOL "True if HDF5 was found by the modern method" FORCE)
 
 if (NOT TARGET HDF5::all_libs)
 

--- a/tribits/common_tpls/FindTPLNetcdf.cmake
+++ b/tribits/common_tpls/FindTPLNetcdf.cmake
@@ -43,7 +43,7 @@ endif()
 
 set(Netcdf_ALLOW_MODERN FALSE CACHE BOOL "Allow finding Netcdf as a modern CMake config file with exported targets (and only this way)")
 
-if (Netcdf_ALLOW_MODERN  AND  TARGET HDF5::HDF5)
+if (Netcdf_ALLOW_MODERN)
 
   set(minimum_modern_netCDF_version 4.7.4)
   print_var(Netcdf_ALLOW_MODERN)
@@ -56,6 +56,7 @@ if (Netcdf_ALLOW_MODERN  AND  TARGET HDF5::HDF5)
       Netcdf
       INNER_FIND_PACKAGE_NAME  netCDF
       IMPORTED_TARGETS_FOR_ALL_LIBS   netCDF::netcdf)
+    set(TPL_Netcdf_NOT_FOUND FALSE)
   endif()
 
 endif()

--- a/tribits/common_tpls/FindTPLNetcdf.cmake
+++ b/tribits/common_tpls/FindTPLNetcdf.cmake
@@ -43,7 +43,7 @@ endif()
 
 set(Netcdf_ALLOW_MODERN FALSE CACHE BOOL "Allow finding Netcdf as a modern CMake config file with exported targets (and only this way)")
 
-if (Netcdf_ALLOW_MODERN)
+if (Netcdf_ALLOW_MODERN AND HDF5_FOUND_MODERN_CONFIG_FILE)
 
   set(minimum_modern_netCDF_version 4.7.4)
   print_var(Netcdf_ALLOW_MODERN)

--- a/tribits/common_tpls/FindTPLNetcdf.cmake
+++ b/tribits/common_tpls/FindTPLNetcdf.cmake
@@ -37,9 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-if (${CMAKE_VERSION} GREATER "3.13")
-     cmake_policy(SET CMP0074 NEW)
-endif()
+cmake_policy(SET CMP0074 NEW)
 
 set(Netcdf_ALLOW_MODERN FALSE CACHE BOOL "Allow finding Netcdf as a modern CMake config file with exported targets (and only this way)")
 

--- a/tribits/common_tpls/FindTPLNetcdf.cmake
+++ b/tribits/common_tpls/FindTPLNetcdf.cmake
@@ -44,98 +44,158 @@
 # in order to trigger the right behavior in the function
 # tribits_tpl_find_include_dirs_and_libraries().
 #
-
-set(REQUIRED_HEADERS netcdf.h)
-set(REQUIRED_LIBS_NAMES netcdf)
-
-if (TPL_ENABLE_MPI)
-  set(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} pnetcdf)
+if (${CMAKE_VERSION} GREATER "3.13")
+     cmake_policy(SET CMP0074 NEW)
 endif()
 
-#
-# Second, search for Netcdf components (if allowed) using the standard
-# find_package(NetCDF ...).
-#
-tribits_tpl_allow_pre_find_package(Netcdf  Netcdf_ALLOW_PREFIND)
-if (Netcdf_ALLOW_PREFIND)
+set(Netcdf_ALLOW_MODERN FALSE CACHE BOOL "Allow finding Netcdf as a modern CMake config file with exported targets (and only this way)")
 
-  message("-- Using find_package(Netcdf ...) ...")
+if (Netcdf_ALLOW_MODERN)
 
-  set(CMAKE_MODULE_PATH
-    "${CMAKE_MODULE_PATH}"
-    "${CMAKE_CURRENT_LIST_DIR}/find_modules"
-    "${CMAKE_CURRENT_LIST_DIR}/utils"
-     )
-
-  find_package(NetCDF)
-
-  if (NetCDF_FOUND)
-    set(DOCSTR "List of semi-colon separated paths to look for the TPL Netcdf")
-    set(TPL_Netcdf_Enables_Netcdf4 ${NetCDF_NEEDS_HDF5} CACHE BOOL
+  set(minimum_modern_netCDF_version 4.7.4)
+  message("-- Netcdf_ALLOW_MODERN=${Netcdf_ALLOW_MODERN}")
+  message("-- Using find_package(netCDF ${minimum_modern_netCDF_version} CONFIG) ...")
+  find_package(netCDF ${minimum_modern_netCDF_version} CONFIG)
+  if (netCDF_FOUND)
+    message("-- Found netCDF_CONFIG=${netCDF_CONFIG}")
+    message("-- Generating Netcdf::all_libs and NetcdfConfig.cmake")
+    # instead of using tribits_extpkg_create_imported_all_libs_target_and_config_file,
+    # we will do what it does ourselves because we need to bring in two
+    # inner find packages (netCDF and hdf5) because netCDF does not properly
+    # do find_dependency(hdf5)
+    add_library(Netcdf::all_libs  INTERFACE  IMPORTED  GLOBAL)
+    target_link_libraries(Netcdf::all_libs  INTERFACE  netCDF::netcdf)
+    set(configFileStr "")
+    string(APPEND configFileStr
+      "include(CMakeFindDependencyMacro)\n" )
+    string(APPEND configFileStr
+      "set(netCDF_DIR \"${netCDF_DIR}\")\n" )
+    string(APPEND configFileStr
+      "find_dependency(netCDF ${minimum_modern_netCDF_version} CONFIG)\n"
+      )
+    if (netCDF_HAS_HDF5)
+      find_package(hdf5 CONFIG REQUIRED)
+      string(APPEND configFileStr
+        "set(hdf5_DIR \"${hdf5_DIR}\")\n" )
+      string(APPEND configFileStr
+        "find_dependency(hdf5 CONFIG)\n"
+        )
+    endif()
+    string(APPEND configFileStr
+      "add_library(Netcdf::all_libs  INTERFACE  IMPORTED  GLOBAL)\n"
+      )
+    string(APPEND configFileStr
+      "target_link_libraries(Netcdf::all_libs  INTERFACE  netCDF::netcdf)\n")
+    set(buildDirExternalPkgsDir
+      "${${PROJECT_NAME}_BINARY_DIR}/${${PROJECT_NAME}_BUILD_DIR_EXTERNAL_PKGS_DIR}")
+    set(tplConfigFile
+      "${buildDirExternalPkgsDir}/Netcdf/NetcdfConfig.cmake")
+    file(WRITE "${tplConfigFile}" "${configFileStr}")
+    # the following gets set by tribits_tpl_find_include_dirs_and_libraries
+    # and it is not well-documented that you need to set it yourself if not using
+    # tribits_tpl_find_include_dirs_and_libraries
+    set(TPL_Netcdf_NOT_FOUND FALSE)
+    message("-- TPL_Netcdf_PARALLEL = netCDF_HAS_PARALLEL = ${netCDF_HAS_PARALLEL}")
+    set(TPL_Netcdf_PARALLEL ${netCDF_HAS_PARALLEL})
+    message("-- TPL_Netcdf_Enables_Netcdf4 = netCDF_HAS_NC4 = ${netCDF_HAS_NC4}")
+    set(TPL_Netcdf_Enables_Netcdf4 ${netCDF_HAS_NC4} CACHE BOOL
       "True if netcdf enables netcdf-4")
-    set(TPL_Netcdf_Enables_PNetcdf ${NetCDF_NEEDS_PNetCDF} CACHE BOOL
-      "True if netcdf enables pnetcdf")
-    set(TPL_Netcdf_PARALLEL ${NetCDF_PARALLEL} CACHE INTERNAL
-      "True if netcdf compiled with parallel enabled")
-    set(TPL_Netcdf_LIBRARY_DIRS ${_hdf5_LIBRARY_SEARCH_DIRS} CACHE PATH
-      "${DOCSTR} library files")
-    set(TPL_Netcdf_LIBRARIES ${NetCDF_LIBRARIES} CACHE PATH
-      "List of semi-colon separated library names (not 'lib' or extension).")
-    set(TPL_Netcdf_INCLUDE_DIRS ${NetCDF_INCLUDE_DIRS} CACHE PATH
-      "${DOCSTR} header files.")
   endif()
+
 else()
-  # Curl library is only required if DAP is enabled; should detect inside
-  # FindNetCDF.cmake, but that is not being called... SEMS has DAP enabled;
-  # many HPC systems don't, but they override these settings...
-  find_program(NC_CONFIG "nc-config")
-  if (NC_CONFIG)
-    execute_process(COMMAND "nc-config --has-dap2"
-                    OUTPUT_VARIABLE NETCDF_HAS_DAP2)
-    execute_process(COMMAND "nc-config --has-dap4"
-                    OUTPUT_VARIABLE NETCDF_HAS_DAP4)
+
+  set(REQUIRED_HEADERS netcdf.h)
+  set(REQUIRED_LIBS_NAMES netcdf)
+
+  if (TPL_ENABLE_MPI)
+    set(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} pnetcdf)
   endif()
-  if ((NOT NC_CONFIG) OR NETCDF_HAS_DAP2 OR NETCDF_HAS_DAP4)
-    set(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} curl)
+
+  #
+  # Second, search for Netcdf components (if allowed) using the standard
+  # find_package(NetCDF ...).
+  #
+  tribits_tpl_allow_pre_find_package(Netcdf  Netcdf_ALLOW_PREFIND)
+  if (Netcdf_ALLOW_PREFIND)
+
+    message("-- Using find_package(Netcdf ...) ...")
+
+    set(CMAKE_MODULE_PATH
+      "${CMAKE_MODULE_PATH}"
+      "${CMAKE_CURRENT_LIST_DIR}/find_modules"
+      "${CMAKE_CURRENT_LIST_DIR}/utils"
+       )
+
+    find_package(NetCDF)
+
+    if (NetCDF_FOUND)
+      set(DOCSTR "List of semi-colon separated paths to look for the TPL Netcdf")
+      set(TPL_Netcdf_Enables_Netcdf4 ${NetCDF_NEEDS_HDF5} CACHE BOOL
+        "True if netcdf enables netcdf-4")
+      set(TPL_Netcdf_Enables_PNetcdf ${NetCDF_NEEDS_PNetCDF} CACHE BOOL
+        "True if netcdf enables pnetcdf")
+      set(TPL_Netcdf_PARALLEL ${NetCDF_PARALLEL} CACHE INTERNAL
+        "True if netcdf compiled with parallel enabled")
+      set(TPL_Netcdf_LIBRARY_DIRS ${_hdf5_LIBRARY_SEARCH_DIRS} CACHE PATH
+        "${DOCSTR} library files")
+      set(TPL_Netcdf_LIBRARIES ${NetCDF_LIBRARIES} CACHE PATH
+        "List of semi-colon separated library names (not 'lib' or extension).")
+      set(TPL_Netcdf_INCLUDE_DIRS ${NetCDF_INCLUDE_DIRS} CACHE PATH
+        "${DOCSTR} header files.")
+    endif()
+  else()
+    # Curl library is only required if DAP is enabled; should detect inside
+    # FindNetCDF.cmake, but that is not being called... SEMS has DAP enabled;
+    # many HPC systems don't, but they override these settings...
+    find_program(NC_CONFIG "nc-config")
+    if (NC_CONFIG)
+      execute_process(COMMAND "nc-config --has-dap2"
+                      OUTPUT_VARIABLE NETCDF_HAS_DAP2)
+      execute_process(COMMAND "nc-config --has-dap4"
+                      OUTPUT_VARIABLE NETCDF_HAS_DAP4)
+    endif()
+    if ((NOT NC_CONFIG) OR NETCDF_HAS_DAP2 OR NETCDF_HAS_DAP4)
+      set(REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} curl)
+    endif()
   endif()
+
+  #
+  # Third, call tribits_tpl_find_include_dirs_and_libraries()
+  #
+  tribits_tpl_find_include_dirs_and_libraries( Netcdf
+    REQUIRED_HEADERS ${REQUIRED_HEADERS}
+    REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES}
+    )
+  # NOTE: If find_package(Netcdf ...) was called and successfully found Netcdf,
+  # then tribits_tpl_find_include_dirs_and_libraries() will use the already-set
+  # variables TPL_Netcdf_INCLUDE_DIRS and TPL_Netcdf_LIBRARIES and then print
+  # them out (and set some other standard variables as well).  This is the final
+  # "hook" into the TriBITS TPL system.
+
+  # If the `find_package(NetCDF)` is not run, then this may not be set
+  # Need to determine how this is set in the library that is being used...
+
+  if ("${TPL_Netcdf_PARALLEL}" STREQUAL "")
+     assert_defined(TPL_Netcdf_INCLUDE_DIRS)
+     find_path(meta_path
+        NAMES "netcdf_meta.h"
+        HINTS ${TPL_Netcdf_INCLUDE_DIRS}
+        NO_DEFAULT_PATH)
+
+     if (meta_path)
+        # Search meta for NC_HAS_PARALLEL setting...
+        # Note that there is both NC_HAS_PARALLEL and NC_HAS_PARALLEL4, only want first...
+        file(STRINGS "${meta_path}/netcdf_meta.h" netcdf_par_string REGEX "NC_HAS_PARALLEL ")
+        string(REGEX MATCH "[01]" netcdf_par_val "${netcdf_par_string}")
+        if (netcdf_par_val EQUAL 1)
+           set(TPL_Netcdf_PARALLEL True CACHE INTERNAL
+               "True if netcdf compiled with parallel enabled")
+        endif()
+     endif()
+     if ("${TPL_Netcdf_PARALLEL}" STREQUAL "")
+        set(TPL_Netcdf_PARALLEL False CACHE INTERNAL
+            "True if netcdf compiled with parallel enabled")
+     endif()
+  endif()
+  message(STATUS "TPL_Netcdf_PARALLEL is ${TPL_Netcdf_PARALLEL}")
 endif()
-
-#
-# Third, call tribits_tpl_find_include_dirs_and_libraries()
-#
-tribits_tpl_find_include_dirs_and_libraries( Netcdf
-  REQUIRED_HEADERS ${REQUIRED_HEADERS}
-  REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES}
-  )
-# NOTE: If find_package(Netcdf ...) was called and successfully found Netcdf,
-# then tribits_tpl_find_include_dirs_and_libraries() will use the already-set
-# variables TPL_Netcdf_INCLUDE_DIRS and TPL_Netcdf_LIBRARIES and then print
-# them out (and set some other standard variables as well).  This is the final
-# "hook" into the TriBITS TPL system.
-
-# If the `find_package(NetCDF)` is not run, then this may not be set
-# Need to determine how this is set in the library that is being used...
-
-if ("${TPL_Netcdf_PARALLEL}" STREQUAL "")
-   assert_defined(TPL_Netcdf_INCLUDE_DIRS)
-   find_path(meta_path
-      NAMES "netcdf_meta.h"
-      HINTS ${TPL_Netcdf_INCLUDE_DIRS}
-      NO_DEFAULT_PATH)
-
-   if (meta_path)
-      # Search meta for NC_HAS_PARALLEL setting...
-      # Note that there is both NC_HAS_PARALLEL and NC_HAS_PARALLEL4, only want first...
-      file(STRINGS "${meta_path}/netcdf_meta.h" netcdf_par_string REGEX "NC_HAS_PARALLEL ")
-      string(REGEX MATCH "[01]" netcdf_par_val "${netcdf_par_string}")
-      if (netcdf_par_val EQUAL 1)
-         set(TPL_Netcdf_PARALLEL True CACHE INTERNAL
-             "True if netcdf compiled with parallel enabled")
-      endif()
-   endif()
-   if ("${TPL_Netcdf_PARALLEL}" STREQUAL "")
-      set(TPL_Netcdf_PARALLEL False CACHE INTERNAL
-          "True if netcdf compiled with parallel enabled")
-   endif()
-endif()
-message(STATUS "TPL_Netcdf_PARALLEL is ${TPL_Netcdf_PARALLEL}")

--- a/tribits/common_tpls/FindTPLNetcdfDependencies.cmake
+++ b/tribits/common_tpls/FindTPLNetcdfDependencies.cmake
@@ -1,0 +1,2 @@
+tribits_extpkg_define_dependencies( Netcdf
+  DEPENDENCIES  HDF5)

--- a/tribits/core/package_arch/TribitsTplFindIncludeDirsAndLibraries.cmake
+++ b/tribits/core/package_arch/TribitsTplFindIncludeDirsAndLibraries.cmake
@@ -676,8 +676,11 @@ function(tribits_tpl_find_include_dirs_and_libraries TPL_NAME)
       advanced_set(TPL_${TPL_NAME}_INCLUDE_DIRS ${${TPL_NAME}_INCLUDE_DIRS}
         CACHE PATH "User provided include dirs in the absence of include files.")
     else()
-      # Library has no header files, no user override, so just set them to null
-      global_null_set(TPL_${TPL_NAME}_INCLUDE_DIRS)
+      if ("${TPL_${TPL_NAME}_INCLUDE_DIRS}" STREQUAL "")
+        # Library has no header files, no user override, so just set them to
+        # null (unless the user has already set this).
+        global_null_set(TPL_${TPL_NAME}_INCLUDE_DIRS)
+      endif()
     endif()
 
   endif()

--- a/tribits/core/std_tpls/FindTPLMPI.cmake
+++ b/tribits/core/std_tpls/FindTPLMPI.cmake
@@ -50,9 +50,7 @@ if(WIN32 AND TPL_ENABLE_MPI)
   global_set(TPL_MPI_LIBRARIES ${MPI_LIBRARIES})
 endif()
 
-tribits_tpl_find_include_dirs_and_libraries(
-    MPI
-    REQUIRED_HEADERS mpi.h)
+tribits_tpl_find_include_dirs_and_libraries(MPI)
 
 # NOTE: Above, we need to generate the MPI::all_libs target and the
 # MPIConfig.cmake file that will also provide the MPI::all_libs target.

--- a/tribits/core/std_tpls/FindTPLMPI.cmake
+++ b/tribits/core/std_tpls/FindTPLMPI.cmake
@@ -50,7 +50,9 @@ if(WIN32 AND TPL_ENABLE_MPI)
   global_set(TPL_MPI_LIBRARIES ${MPI_LIBRARIES})
 endif()
 
-tribits_tpl_find_include_dirs_and_libraries(MPI)
+tribits_tpl_find_include_dirs_and_libraries(
+    MPI
+    REQUIRED_HEADERS mpi.h)
 
 # NOTE: Above, we need to generate the MPI::all_libs target and the
 # MPIConfig.cmake file that will also provide the MPI::all_libs target.


### PR DESCRIPTION
## Description

These commits address #533 and #534

These commits were pulled off of the branch from:

* https://github.com/trilinos/Trilinos/pull/11175

(which also matches the patches in https://github.com/sandialabs/seacas/pull/336).

This seems to maintain near perfect backwards compatibility.
 
## Tasks

* [x] Test and merge https://github.com/trilinos/Trilinos/pull/11175
* [x] Test and merge https://github.com/sandialabs/seacas/pull/336
* [x] Get @KyleFromKitware to review
* [x] Address review comments with new commits
* [x] ~~Add test for change to `tribits/core/package_arch/TribitsTplFindIncludeDirsAndLibraries.cmake`~~ ... Cost of adding a test for this is not worth the value (see [below](https://github.com/TriBITSPub/TriBITS/pull/535#issuecomment-1295070533)).
