### PR TITLE
Fix documentation for updated subpacakge test/example enable logic (#268)

### DIFF
--- a/test/core/TestingFunctionMacro_UnitTests.cmake
+++ b/test/core/TestingFunctionMacro_UnitTests.cmake
@@ -812,7 +812,7 @@ function(unittest_tribits_add_test_basic)
   tribits_add_test( ${EXEN} ADDED_TESTS_NAMES_OUT ${EXEN}_TEST_NAMES )
   unittest_compare_const(
     MESSAGE_WRAPPER_INPUT
-    "-- PackageA_SomeExec: NOT added test because PackageA_ENABLE_TESTS='OFF'."
+    "-- PackageA_SomeExec: NOT added test because; PackageA_ENABLE_TESTS='OFF'."
     )
   unittest_compare_const(
     TRIBITS_ADD_TEST_ADD_TEST_INPUT
@@ -2672,7 +2672,7 @@ function(unittest_tribits_add_advanced_test_basic)
     )
   unittest_compare_const(
     MESSAGE_WRAPPER_INPUT
-    "-- PackageA_TAAT_tests_disabled: NOT added test because PackageA_ENABLE_TESTS='OFF'."
+    "-- PackageA_TAAT_tests_disabled: NOT added test because; PackageA_ENABLE_TESTS='OFF'."
     )
   unittest_compare_const(TAAT_tests_disabled_TEST_NAME "")
   unittest_compare_const(

--- a/tribits/core/package_arch/TribitsAddAdvancedTest.cmake
+++ b/tribits/core/package_arch/TribitsAddAdvancedTest.cmake
@@ -157,13 +157,10 @@ include(PrintVar)
 # for the overall test to pass.
 #
 # Finally, the test is only added if tests are enabled for the package
-# (i.e. `${PACKAGE_NAME}_ENABLE_TESTS`_ ``= ON``) or the parent package (if
-# this is a subpackage) (i.e. ``${PARENT_PACKAGE_NAME}_ENABLE_TESTS=ON``) or
-# if other criteria are met (see some of the arguments in `Overall Arguments
-# (tribits_add_advanced_test())`_ that can trigger a test to not be added).
-# (NOTE: A more efficient way to optionally enable tests is to put them in a
-# ``test/`` subdir and then include that subdir with
-# `tribits_add_test_directories()`_.)
+# (i.e. `${PACKAGE_NAME}_ENABLE_TESTS`_ ``= ON``) and if other criteria are
+# met (see `Overall Arguments (tribits_add_advanced_test())`_).  (NOTE: A more
+# efficient way to optionally enable tests is to put them in a ``test/``
+# subdir and then include that subdir with `tribits_add_test_directories()`_.)
 #
 # *Sections:*
 #

--- a/tribits/core/package_arch/TribitsAddExecutableAndTest.cmake
+++ b/tribits/core/package_arch/TribitsAddExecutableAndTest.cmake
@@ -146,6 +146,16 @@ endmacro()
 # through ``ARGS``.  For more flexibility, just use
 # ``tribits_add_executable()`` followed by ``tribits_add_test()``.
 #
+# Finally, the tests are only added if tests are enabled for the package
+# (i.e. `${PACKAGE_NAME}_ENABLE_TESTS`_ ``= ON``) and other criteria are met.
+# But the test executable will always be added if this function is called,
+# regardless of the value of ``${PACKAGE_NAME}_ENABLE_TESTS``.  To avoid
+# adding the test (or example) executable when
+# ``${PACKAGE_NAME}_ENABLE_TESTS=OFF``, put this command in a subdir under
+# ``test/`` or ``example/`` and that subdir with
+# `tribits_add_test_directories()`_ or `tribits_add_example_directories()`_,
+# respectively.
+#
 function(tribits_add_executable_and_test EXE_NAME)
 
   #
@@ -257,3 +267,5 @@ function(tribits_add_executable_and_test EXE_NAME)
   endif()
 
 endfunction()
+
+#  LocalWords:  executables

--- a/tribits/core/package_arch/TribitsAddTest.cmake
+++ b/tribits/core/package_arch/TribitsAddTest.cmake
@@ -78,10 +78,11 @@ include(TribitsAddTestHelpers)
 #     )
 #
 # The tests are only added if tests are enabled for the package
-# (i.e. `${PACKAGE_NAME}_ENABLE_TESTS`_) or the parent package (if this is a
-# subpackage) (i.e. ``${PARENT_PACKAGE_NAME}_ENABLE_TESTS``).  (NOTE: A more
-# efficient way to optionally enable tests is to put them in a ``test/``
-# subdir and then include that subdir with `tribits_add_test_directories()`_.)
+# (i.e. `${PACKAGE_NAME}_ENABLE_TESTS`_ ``= ON``).  (NOTE: A more efficient
+# way to optionally enable tests or examples is to put them in a ``test/`` or
+# ``example/`` subdir and then include that subdir with
+# `tribits_add_test_directories()`_ or `tribits_add_example_directories()`_,
+# respectively.)
 #
 # *Sections:*
 #

--- a/tribits/core/package_arch/TribitsAddTestHelpers.cmake
+++ b/tribits/core/package_arch/TribitsAddTestHelpers.cmake
@@ -211,8 +211,8 @@ function(tribits_add_test_process_enable_tests  ADD_THE_TEST_OUT)
    set(ADD_THE_TEST TRUE)
   else()
     message_wrapper(
-      "-- ${TEST_NAME}: NOT added test because ${PACKAGE_NAME}_ENABLE_TESTS='${${PACKAGE_NAME}_ENABLE_TESTS}'."
-     )
+      "-- ${TEST_NAME}: NOT added test because"
+      " ${PACKAGE_NAME}_ENABLE_TESTS='${${PACKAGE_NAME}_ENABLE_TESTS}'.")
    set(ADD_THE_TEST FALSE)
   endif()
   set(${ADD_THE_TEST_OUT} ${ADD_THE_TEST} PARENT_SCOPE)

--- a/tribits/core/package_arch/TribitsPackageMacros.cmake
+++ b/tribits/core/package_arch/TribitsPackageMacros.cmake
@@ -545,10 +545,7 @@ endmacro()
 # up example directories any way one would like.
 #
 # Currently, all it does macro does is to call ``add_subdirectory(<diri>)`` if
-# ``${PACKAGE_NAME}_ENABLE_EXAMPLES`` or
-# ``${PARENT_PACKAGE_NAME}_ENABLE_EXAMPLES`` are true. However, this macro may
-# be extended in the future in order to modify behavior related to adding
-# tests and examples in a uniform way.
+# `${PACKAGE_NAME}_ENABLE_EXAMPLES`_ ``= TRUE``.
 #
 macro(tribits_add_example_directories)
 

--- a/tribits/doc/guides/users_guide/TribitsUsersGuide.rst
+++ b/tribits/doc/guides/users_guide/TribitsUsersGuide.rst
@@ -106,3 +106,5 @@ Appendix
 .. _tribits_read_all_project_deps_files_create_deps_graph(): TribitsMaintainersGuide.html#tribits-read-all-project-deps-files-create-deps-graph
 
 .. _${PACKAGE_NAME}_LIB_DEFINED_DEPENDENCIES: TribitsMaintainersGuide.html#package-name-lib-enabled-dependencies
+
+.. _${PACKAGE_NAME}_TEST_DEFINED_DEPENDENCIES: TribitsMaintainersGuide.html#package-name-test-enabled-dependencies


### PR DESCRIPTION
I had forgotten to update some documentation for how this impacted the `tribits_add_[executable_and_][test|advanced_test]()` functions.

This makes this documentation consistent with:

* [12. Enable/disable of parent package tests/examples is enable/disable for subpackages tests/examples](https://tribitspub.github.io/TriBITS/users_guide/index.html#enable-disable-of-parent-package-tests-examples-is-enable-disable-for-subpackages-tests-examples)
* [20. `<Project>_ENABLE_TESTS` only enables explicitly enabled package tests](https://tribitspub.github.io/TriBITS/users_guide/index.html#project-enable-tests-only-enables-explicitly-enabled-package-tests)