### PR TITLE
Add RUN_SERIAL to tribits_add_executable_and_test() (#554)

### DIFF
--- a/test/core/TestingFunctionMacro_UnitTests.cmake
+++ b/test/core/TestingFunctionMacro_UnitTests.cmake
@@ -4189,6 +4189,7 @@ function(unittest_tribits_add_executable_and_test)
     KEYWORDS keyword1 keyword2
     DEFINES -DSOMEDEFINE2
     TARGET_DEFINES -DSOMEDEFINE1
+    RUN_SERIAL
     ADD_DIR_TO_NAME
     LINKER_LANGUAGE C
     NUM_MPI_PROCS numProcs
@@ -4216,7 +4217,7 @@ function(unittest_tribits_add_executable_and_test)
     )
   unittest_compare_const(
     TRIBITS_ADD_TEST_CAPTURE_ARGS
-    "execName;COMM;serial;mpi;CATEGORIES;category1;category2;HOST;host1;host2;XHOST;host1;host2;HOSTTYPE;hosttype1;hosttype2;XHOSTTYPE;hosttype1;hosttype2;EXCLUDE_IF_NOT_TRUE;var1;var2;NOEXEPREFIX;NOEXESUFFIX;NAME;testName;NAME_POSTFIX;testNamePostfix;DIRECTORY;dir;KEYWORDS;keyword1;keyword2;NUM_MPI_PROCS;numProcs;PASS_REGULAR_EXPRESSION;regex1;regex2;FAIL_REGULAR_EXPRESSION;regex1;regex2;ENVIRONMENT;env1=envval1;env2=envval2;DISABLED;Disable this test because I said;STANDARD_PASS_OUTPUT;WILL_FAIL;TIMEOUT;11.5;LIST_SEPARATOR;<semicolon>;ADD_DIR_TO_NAME;ADDED_TESTS_NAMES_OUT;ADDED_TESTS_NAMES_OUT;ADDED_TESTS_NAMES"
+    "execName;COMM;serial;mpi;CATEGORIES;category1;category2;HOST;host1;host2;XHOST;host1;host2;HOSTTYPE;hosttype1;hosttype2;XHOSTTYPE;hosttype1;hosttype2;EXCLUDE_IF_NOT_TRUE;var1;var2;NOEXEPREFIX;NOEXESUFFIX;NAME;testName;NAME_POSTFIX;testNamePostfix;DIRECTORY;dir;KEYWORDS;keyword1;keyword2;NUM_MPI_PROCS;numProcs;PASS_REGULAR_EXPRESSION;regex1;regex2;FAIL_REGULAR_EXPRESSION;regex1;regex2;ENVIRONMENT;env1=envval1;env2=envval2;DISABLED;Disable this test because I said;RUN_SERIAL;STANDARD_PASS_OUTPUT;WILL_FAIL;TIMEOUT;11.5;LIST_SEPARATOR;<semicolon>;ADD_DIR_TO_NAME;ADDED_TESTS_NAMES_OUT;ADDED_TESTS_NAMES_OUT;ADDED_TESTS_NAMES"
     )
   # NOTE: Above, we input the list in reverse order to prove that the
   # arguments are handled correctly internally.

--- a/tribits/core/package_arch/TribitsAddExecutableAndTest.cmake
+++ b/tribits/core/package_arch/TribitsAddExecutableAndTest.cmake
@@ -106,6 +106,7 @@ endmacro()
 #     [COMM [serial] [mpi]]
 #     [ARGS "<arg0> <arg1> ..." "<arg2> <arg3> ..." ...]
 #     [NUM_MPI_PROCS <numProcs>]
+#     [RUN_SERIAL]
 #     [LINKER_LANGUAGE (C|CXX|Fortran)]
 #     [STANDARD_PASS_OUTPUT
 #       | PASS_REGULAR_EXPRESSION "<regex0>;<regex1>;..."]
@@ -167,7 +168,7 @@ function(tribits_add_executable_and_test EXE_NAME)
      #prefix
      PARSE
      #options
-     "STANDARD_PASS_OUTPUT;WILL_FAIL;ADD_DIR_TO_NAME;INSTALLABLE;NOEXEPREFIX;NOEXESUFFIX"
+     "RUN_SERIAL;STANDARD_PASS_OUTPUT;WILL_FAIL;ADD_DIR_TO_NAME;INSTALLABLE;NOEXEPREFIX;NOEXESUFFIX"
      #one_value_keywords
      "DISABLED"
      #mulit_value_keywords
@@ -249,6 +250,7 @@ function(tribits_add_executable_and_test EXE_NAME)
   tribits_fwd_parse_arg(CALL_ARGS FAIL_REGULAR_EXPRESSION)
   tribits_fwd_parse_arg(CALL_ARGS ENVIRONMENT)
   tribits_fwd_parse_arg(CALL_ARGS DISABLED)
+  tribits_fwd_parse_opt(CALL_ARGS RUN_SERIAL)
   tribits_fwd_parse_opt(CALL_ARGS STANDARD_PASS_OUTPUT)
   tribits_fwd_parse_opt(CALL_ARGS WILL_FAIL)
   tribits_fwd_parse_arg(CALL_ARGS TIMEOUT)


### PR DESCRIPTION
Addresses #554.

It was an oversight that this was not added to tribits_add_executable_and_test() when it was added to tribits_add_test().

I tested this against Trilinos and the warning reported in https://github.com/trilinos/Trilinos/issues/11411 went away.

