### PR TITLE
Bring back deprecated <Project>_ASSERT_MISSING_PACKAGES (trilinos/Trilinos#11429)

### DIFF
--- a/test/core/DependencyUnitTests/CMakeLists.txt
+++ b/test/core/DependencyUnitTests/CMakeLists.txt
@@ -1479,6 +1479,24 @@ create_dependency_handling_test_case(
 
 
 create_dependency_handling_test_case(
+  preCopyrightTrilinos_ShowInvalidPackageNameAndTplNameError_AssertMissingPackagesOn
+  ARGS
+    -DSHOW_INVALID_PACKAGE_NAME_ERROR=ON
+    -DSHOW_INVALID_TPL_NAME_ERROR=ON
+    -DTrilinos_ASSERT_MISSING_PACKAGES=ON
+  PASS_REGULAR_EXPRESSION_ALL
+    "CMake Deprecation Warning at .*/MessageWrapper.cmake:.+ [(]message[)]:"
+    "  Warning, Trilinos_ASSERT_MISSING_PACKAGES='ON' is set and is no longer"
+    "  supported! Please set Trilinos_ASSERT_DEFINED_DEPENDENCIES instead [(]see"
+    "  build ref[)]!"
+    "CMake Error at .*/TribitsReadDepsFilesCreateDepsGraph.cmake:.+ [(]message[)]:"
+    "Error, the package 'Zlib' is listed as a dependency of the package 'Zoltan'"
+    "ignore/disable the undefined package 'Zlib', set the cache variable"
+    "Trilinos_ASSERT_DEFINED_DEPENDENCIES=IGNORE[.]"
+  )
+
+
+create_dependency_handling_test_case(
   preCopyrightTrilinos_ShowInvalidPackageSelfDependency
   ARGS -DTrilinos_EXTRA_REPOSITORIES=preCopyrightTrilinos
     -DSHOW_SELF_PACKAGE_DEPENDENCY_ERROR=ON

--- a/tribits/CHANGELOG.md
+++ b/tribits/CHANGELOG.md
@@ -2,6 +2,15 @@
 ChangeLog for TriBITS
 ----------------------------------------
 
+## 2023-01-10:
+
+* **Added:** Added back support for deprecated variable
+  `<Project>_ASSERT_MISSING_PACKAGES` that was removed
+  [2022-10-11](#2022-10-11).  When `<Project>_ASSERT_MISSING_PACKAGES` is set
+  to a non-null value, it overrides the default value for
+  `<Project>_ASSERT_DEFINED_DEPENDENCIES` (but setting
+  `<Project>_ASSERT_DEFINED_DEPENDENCIES` in the cache takes precedence).
+
 ## 2023-01-06:
 
 * **Changed:** Changed all TPL dependencies back to 'Optional' so that

--- a/tribits/core/package_arch/TribitsGlobalMacros.cmake
+++ b/tribits/core/package_arch/TribitsGlobalMacros.cmake
@@ -720,6 +720,18 @@ macro(tribits_define_global_options_and_define_extra_repos)
     "Determines if a variety of development mode checks are turned on by default or not."
     )
 
+  if (NOT "${${PROJECT_NAME}_ASSERT_MISSING_PACKAGES}" STREQUAL "")
+    tribits_deprecated("Warning, ${PROJECT_NAME}_ASSERT_MISSING_PACKAGES="
+      "'${${PROJECT_NAME}_ASSERT_MISSING_PACKAGES}' is set and is no"
+      " longer supported!  Please set"
+      " ${PROJECT_NAME}_ASSERT_DEFINED_DEPENDENCIES instead (see build ref)!" )
+    if (${PROJECT_NAME}_ASSERT_MISSING_PACKAGES)
+      set(${PROJECT_NAME}_ASSERT_DEFINED_DEPENDENCIES_DEFAULT  FATAL_ERROR)
+    else()
+     set(${PROJECT_NAME}_ASSERT_DEFINED_DEPENDENCIES_DEFAULT  IGNORE)
+    endif()
+  endif()
+
   if ("${${PROJECT_NAME}_ASSERT_DEFINED_DEPENDENCIES_DEFAULT}" STREQUAL "")
     if (${PROJECT_NAME}_ENABLE_DEVELOPMENT_MODE)
       set(${PROJECT_NAME}_ASSERT_DEFINED_DEPENDENCIES_DEFAULT  FATAL_ERROR)
@@ -727,6 +739,7 @@ macro(tribits_define_global_options_and_define_extra_repos)
       set(${PROJECT_NAME}_ASSERT_DEFINED_DEPENDENCIES_DEFAULT  IGNORE)
     endif()
   endif()
+
   set(${PROJECT_NAME}_ASSERT_DEFINED_DEPENDENCIES_ERROR_VALUES_LIST
     "FATAL_ERROR" "SEND_ERROR" )
   set(${PROJECT_NAME}_ASSERT_DEFINED_DEPENDENCIES_VALUES_LIST
@@ -739,13 +752,6 @@ macro(tribits_define_global_options_and_define_extra_repos)
     ALLOWED_STRINGS_LIST
       ${${PROJECT_NAME}_ASSERT_DEFINED_DEPENDENCIES_VALUES_LIST}
     IS_ADVANCED )
-
-  if (NOT "${${PROJECT_NAME}_ASSERT_MISSING_PACKAGES}" STREQUAL "")
-    message(FATAL_ERROR "Error, ${PROJECT_NAME}_ASSERT_MISSING_PACKAGES="
-      " '${${PROJECT_NAME}_ASSERT_MISSING_PACKAGES}' is set and is no"
-      " longer supported!  Please set"
-      " ${PROJECT_NAME}_ASSERT_DEFINED_DEPENDENCIES=FATAL_ERROR instead!" )
-  endif()
 
   if ("${${PROJECT_NAME}_ASSERT_CORRECT_TRIBITS_USAGE_DEFAULT}" STREQUAL "")
     if (${PROJECT_NAME}_ENABLE_DEVELOPMENT_MODE)


### PR DESCRIPTION
See new CHANGLOG entry and git commit message.

Addresses part of trilinos/Trilinos#11429
