### PR TITLE
Implement URL normalization in cdash_analyze_and_report.py (#577)

### DIFF
--- a/tribits/ci_support/CDashQueryAnalyzeReport.py
+++ b/tribits/ci_support/CDashQueryAnalyzeReport.py
@@ -40,9 +40,11 @@
 try:
   # Python 2
   from urllib2 import urlopen
+  from urllib2 import quote as urlquote
 except ImportError:
   # Python 3
   from urllib.request import urlopen
+  from urllib.parse import quote as urlquote
 
 import sys
 import hashlib
@@ -716,41 +718,45 @@ def getAndCacheCDashQueryDataOrReadFromCache(
   return cdashQueryData
 
 
+def normalizeUrlStrings(*args):
+  return [urlquote(x) for x in args]
+
+
 # Construct full cdash/api/v1/index.php query URL to pull data down given the
 # pieces
 def getCDashIndexQueryUrl(cdashUrl, projectName, date, filterFields):
+  # for legacy reasons, this function assumes we normalized projectName
+  projectName, = normalizeUrlStrings(projectName,)
   if date: dateArg = "&date="+date
   else: dateArg = ""
   return cdashUrl+"/api/v1/index.php?project="+projectName+dateArg \
-    + "&"+filterFields
+      + "&"+filterFields
 
 
 # Construct full cdash/index.php browser URL given the pieces
 def getCDashIndexBrowserUrl(cdashUrl, projectName, date, filterFields):
+  # for legacy reasons, this function assumes we normalized projectName
+  projectName, = normalizeUrlStrings(projectName,)
   if date: dateArg = "&date="+date
   else: dateArg = ""
   return cdashUrl+"/index.php?project="+projectName+dateArg \
-    + "&"+filterFields
+      + "&"+filterFields
 
 
 # Construct full cdash/api/v1/queryTests.php query URL given the pieces
 def getCDashQueryTestsQueryUrl(cdashUrl, projectName, date, filterFields):
+  # for legacy reasons, this function assumes we normalized projectName
+  projectName, = normalizeUrlStrings(projectName,)
   if date: dateArg = "&date="+date
   else: dateArg = ""
   cdashTestUrl = cdashUrl+"/api/v1/queryTests.php?project="+projectName+dateArg+"&"+filterFields
-  return replaceNonUrlCharsInUrl(cdashTestUrl)
-
-
-# Replace non-URL chars and return new URL string
-def replaceNonUrlCharsInUrl(url):
-  urlNew = url
-  urlNew = urlNew.replace(' ', '%20')
-  # ToDo: Replace other chars as needed
-  return urlNew
+  return cdashTestUrl
 
 
 # Construct full cdash/queryTests.php browser URL given the pieces
 def getCDashQueryTestsBrowserUrl(cdashUrl, projectName, date, filterFields):
+  # for legacy reasons, this function assumes we normalized projectName
+  projectName, = normalizeUrlStrings(projectName,)
   if date: dateArg = "&date="+date
   else: dateArg = ""
   return cdashUrl+"/queryTests.php?project="+projectName+dateArg+"&"+filterFields
@@ -1701,29 +1707,33 @@ class AddTestHistoryToTestDictFunctor(object):
     dateRangeEndDateStr = self.__date
     beginEndUrlFields = "begin="+dateRangeBeginDateStr+"&end="+dateRangeEndDateStr
 
+    # normalize names for query
+    projectName_url, buildName_url, testname_url, site_url = normalizeUrlStrings(
+      projectName, buildName, testname, site)
+
     # Define queryTests.php query filters for test history
     testHistoryQueryFilters = \
       beginEndUrlFields+"&"+\
       "filtercombine=and&filtercombine=&filtercount=3&showfilters=1&filtercombine=and"+\
-      "&field1=buildname&compare1=61&value1="+buildName+\
-      "&field2=testname&compare2=61&value2="+testname+\
-      "&field3=site&compare3=61&value3="+site
+      "&field1=buildname&compare1=61&value1="+buildName_url+\
+      "&field2=testname&compare2=61&value2="+testname_url+\
+      "&field3=site&compare3=61&value3="+site_url
 
     # URL used to get the history of the test in JSON form
     testHistoryQueryUrl = \
-      getCDashQueryTestsQueryUrl(cdashUrl, projectName, None, testHistoryQueryFilters)
+      getCDashQueryTestsQueryUrl(cdashUrl, projectName_url, None, testHistoryQueryFilters)
 
     # URL to embed in email to show the history of the test to humans
     testHistoryBrowserUrl = \
-      getCDashQueryTestsBrowserUrl(cdashUrl, projectName, None, testHistoryQueryFilters)
+      getCDashQueryTestsBrowserUrl(cdashUrl, projectName_url, None, testHistoryQueryFilters)
 
     # URL for to the build summary on index.php page
     buildHistoryEmailUrl = getCDashIndexBrowserUrl(
-      cdashUrl, projectName, None,
+      cdashUrl, projectName_url, None,
       beginEndUrlFields+"&"+\
       "filtercombine=and&filtercombine=&filtercount=2&showfilters=1&filtercombine=and"+\
-      "&field1=buildname&compare1=61&value1="+buildName+\
-      "&field2=site&compare2=61&value2="+site
+      "&field1=buildname&compare1=61&value1="+buildName_url+\
+      "&field2=site&compare2=61&value2="+site_url
       )
     # ToDo: Replace this with the the URL to just this one build the index.php
     # page.  To do that, get the build stamp from the list of builds on CDash

--- a/tribits/ci_support/cdash_analyze_and_report.py
+++ b/tribits/ci_support/cdash_analyze_and_report.py
@@ -542,6 +542,10 @@ if __name__ == '__main__':
     # D.2.a) Get list of dicts of builds off cdash/index.phpp
     #
 
+    # @arghdos: note, we do not have to normalize the URLs from the input
+    # options because they are currently taken from the cdash site already
+    # (i.e., they are already in normalized form).
+
     cdashIndexBuildsBrowserUrl = CDQAR.getCDashIndexBrowserUrl(
       inOptions.cdashSiteUrl, inOptions.cdashProjectName, inOptions.date,
       inOptions.cdashBuildsFilters)


### PR DESCRIPTION
This commit:

1. Moves all URL normalization to use `urllib.parse.quote` from the [standard library](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote).  Note: I did add a python2 fallback, which I believe _should_ work, but I have not tested, nor do I know if that's a target at this time.
2. Adds project name URL normalization to all URL Query creator methods (and adds appropriate tests, see: `*_project_name_ampersand`).  Previously this was only applied in `getCDashQueryTestsQueryUrl`, but I felt it was best to be consistent.
3. Selectively applies URL normalization to the project, site, build and test ids (not 100% sure the last is necessary, but doesn't hurt) to the values used in `getCDashQueryTestsBrowserUrl` to construct the query URLs.  The quote function cannot be applied to the entire URL (which would be vastly more convenient) because, from the docs:

>By default, this function is intended for quoting the path section of a URL. The optional safe parameter specifies additional ASCII characters that should not be quoted — its default value is '/'.

That is, if you apply it to the full URL it will escape things you don't want it to (e.g., the '&' in the php queries).  Since we are manually constructing these, it is simple enough to apply.

4. Adds a note about why we _don't_ have to escape the queries coming from the input options (they are assumed to be normalized, as they're generated by CDash), and
5. Adds a corresponding test  (e.g., build name 'build++', site name with a space) 