### PR TITLE
Fix: gitdist: dist-repo-status: Display tag or SHA1 instead of 'HEAD'

### DIFF
--- a/test/python_utils/gitdist_UnitTests.py
+++ b/test/python_utils/gitdist_UnitTests.py
@@ -499,20 +499,21 @@ class test_gitdist_getRepoStats(unittest.TestCase):
   def test_no_change(self):
     try:
       testDir = createAndMoveIntoTestDir("gitdist_getRepoStats_no_change")
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: origin_repo/remote_branch\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo/remote_branch\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: origin_repo/remote_branch\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo/remote_branch\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          )
       options = GitDistOptions(mockGitPath)
       repoStats = getRepoStats(options, showMoreHeadDetails="")
       repoStats_expected = "{branch='local_branch'," \
@@ -527,21 +528,22 @@ class test_gitdist_getRepoStats(unittest.TestCase):
     try:
       testDir = createAndMoveIntoTestDir(
         "gitdist_getRepoStats_all_changed_no_tracking_branch")
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 55\n" \
-        "MOCK_PROGRAM_OUTPUT: error: blah blahh blah\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-        " T file2\n" \
-        " D file3\n" \
-        "?? file4\n" \
-        "?? file5\n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 55\n" \
+          "MOCK_PROGRAM_OUTPUT: error: blah blahh blah\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+          " T file2\n" \
+          " D file3\n" \
+          "?? file4\n" \
+          "?? file5\n" \
+          )
       options = GitDistOptions(mockGitPath)
       repoStats = getRepoStats(options, showMoreHeadDetails="")
       repoStats_expected = "{branch='local_branch'," \
@@ -556,30 +558,31 @@ class test_gitdist_getRepoStats(unittest.TestCase):
     try:
       testDir = createAndMoveIntoTestDir(
         "gitdist_getRepoStats_all_changed_no_tracking_branch")
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 55\n" \
-        "MOCK_PROGRAM_OUTPUT: error: blah blahh blah\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-        "MM file1b\n" \
-        " T file2\n" \
-        "MT file2b\n" \
-        " D file3\n" \
-        "MD file3\n" \
-        "?? file4\n" \
-        "?? file5\n" \
-        "?? file5b\n" \
-        " A file6\n" \
-        "A  file6b\n" \
-        " U file7\n" \
-        "U  file7b\n" \
-        "R  file8\n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 55\n" \
+          "MOCK_PROGRAM_OUTPUT: error: blah blahh blah\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+          "MM file1b\n" \
+          " T file2\n" \
+          "MT file2b\n" \
+          " D file3\n" \
+          "MD file3\n" \
+          "?? file4\n" \
+          "?? file5\n" \
+          "?? file5b\n" \
+          " A file6\n" \
+          "A  file6b\n" \
+          " U file7\n" \
+          "U  file7b\n" \
+          "R  file8\n" \
+          )
       options = GitDistOptions(mockGitPath)
       repoStats = getRepoStats(options, showMoreHeadDetails="SHOW_MORE_HEAD_DETAILS")
       repoStats_expected = "{branch='local_branch'," \
@@ -593,24 +596,25 @@ class test_gitdist_getRepoStats(unittest.TestCase):
   def test_all_changed_detached_head_tag(self):
     try:
       testDir = createAndMoveIntoTestDir("gitdist_getRepoStats_all_changed_detached_head_tag")
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: HEAD\n" \
-        "MOCK_PROGRAM_INPUT: tag --points-at\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: 1.2.3\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 128\n" \
-        "MOCK_PROGRAM_OUTPUT: fatal: blah blahh blah\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-        " M file2\n" \
-        "?? file3\n" \
-        "?? file4\n" \
-        "?? file5\n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: HEAD\n" \
+          "MOCK_PROGRAM_INPUT: tag --points-at\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: 1.2.3\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 128\n" \
+          "MOCK_PROGRAM_OUTPUT: fatal: blah blahh blah\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+          " M file2\n" \
+          "?? file3\n" \
+          "?? file4\n" \
+          "?? file5\n" \
+          )
       options = GitDistOptions(mockGitPath)
       repoStats = getRepoStats(options, showMoreHeadDetails="SHOW_MORE_HEAD_DETAILS")
       repoStats_expected = "{branch='1.2.3'," \
@@ -624,27 +628,28 @@ class test_gitdist_getRepoStats(unittest.TestCase):
   def test_all_changed_detached_head(self):
     try:
       testDir = createAndMoveIntoTestDir("gitdist_getRepoStats_all_changed_detached_head")
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: HEAD\n" \
-        "MOCK_PROGRAM_INPUT: tag --points-at\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        "MOCK_PROGRAM_INPUT: log --pretty=%h -1\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: 1235abcd\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 128\n" \
-        "MOCK_PROGRAM_OUTPUT: fatal: blah blahh blah\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-        " M file2\n" \
-        "?? file3\n" \
-        "?? file4\n" \
-        "?? file5\n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: HEAD\n" \
+          "MOCK_PROGRAM_INPUT: tag --points-at\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          "MOCK_PROGRAM_INPUT: log --pretty=%h -1\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: 1235abcd\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 128\n" \
+          "MOCK_PROGRAM_OUTPUT: fatal: blah blahh blah\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+          " M file2\n" \
+          "?? file3\n" \
+          "?? file4\n" \
+          "?? file5\n" \
+          )
       options = GitDistOptions(mockGitPath)
       repoStats = getRepoStats(options, showMoreHeadDetails="SHOW_MORE_HEAD_DETAILS")
       repoStats_expected = "{branch='1235abcd'," \
@@ -658,25 +663,26 @@ class test_gitdist_getRepoStats(unittest.TestCase):
   def test_all_ambiguous_head(self):
     try:
       testDir = createAndMoveIntoTestDir("gitdist_getRepoStats_all_changed_detached_head")
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: warning: refname 'HEAD' is ambiguous.\n" \
-        "error: refname 'HEAD' is ambiguous\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: remoterepo/trackingbranch\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^remoterepo/trackingbranch\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: 7\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-        " M file2\n" \
-        "?? file3\n" \
-        "?? file4\n" \
-        "?? file5\n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: warning: refname 'HEAD' is ambiguous.\n" \
+          "error: refname 'HEAD' is ambiguous\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: remoterepo/trackingbranch\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^remoterepo/trackingbranch\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: 7\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+          " M file2\n" \
+          "?? file3\n" \
+          "?? file4\n" \
+          "?? file5\n" \
+          )
       options = GitDistOptions(mockGitPath)
       repoStats = getRepoStats(options, showMoreHeadDetails="SHOW_MORE_HEAD_DETAILS")
       repoStats_expected = "{branch='<AMBIGUOUS-HEAD>'," \
@@ -695,24 +701,25 @@ class test_gitdist_getRepoStats(unittest.TestCase):
   def test_all_changed_1_author(self):
     try:
       testDir = createAndMoveIntoTestDir("gitdist_getRepoStats_all_changed_1_author")
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: origin_repo/remote_branch\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo/remote_branch\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: 1\tsome author\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-        " M file2\n" \
-        "?? file3\n" \
-        "?? file4\n" \
-        "?? file5\n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: origin_repo/remote_branch\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo/remote_branch\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: 1\tsome author\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+          " M file2\n" \
+          "?? file3\n" \
+          "?? file4\n" \
+          "?? file5\n" \
+          )
       options = GitDistOptions(mockGitPath)
       repoStats = getRepoStats(options, showMoreHeadDetails="SHOW_MORE_HEAD_DETAILS")
       repoStats_expected = "{branch='local_branch'," \
@@ -726,26 +733,27 @@ class test_gitdist_getRepoStats(unittest.TestCase):
   def test_all_changed_3_authors(self):
     try:
       testDir = createAndMoveIntoTestDir("gitdist_getRepoStats_all_changed_3_authors")
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: origin_repo/remote_branch\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo/remote_branch\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: 1 some author1\n" \
-        "2 some author2\n" \
-        "3 some author2\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-        " M file2\n" \
-        "?? file3\n" \
-        "?? file4\n" \
-        "?? file5\n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: origin_repo/remote_branch\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo/remote_branch\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: 1 some author1\n" \
+          "2 some author2\n" \
+          "3 some author2\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+          " M file2\n" \
+          "?? file3\n" \
+          "?? file4\n" \
+          "?? file5\n" \
+          )
       options = GitDistOptions(mockGitPath)
       repoStats = getRepoStats(options, showMoreHeadDetails="SHOW_MORE_HEAD_DETAILS")
       repoStats_expected = "{branch='local_branch'," \
@@ -778,60 +786,63 @@ sha1_3 [Thu Dec 1 23:34:06 2011 -0500] <author_3@ornl.gov>
 
 def writeGitMockProgram_base_3_2_1_repo1_22_0_2_repo2_0_0_0():
 
-  open(".mockprogram_inout.txt", "w").write(
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
-    "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: 3 some author\n" \
-    "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-    " M file2\n" \
-    "?? file2\n" \
-    "MOCK_PROGRAM_INPUT: status\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: On branch local_branch0\n" \
-    "Your branch is ahead of 'origin_repo0/remote_branch0' by 3 commits.\n" \
-    )
+  with open(".mockprogram_inout.txt", "w") as fileHandle:
+    fileHandle.write(
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
+      "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: 3 some author\n" \
+      "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+      " M file2\n" \
+      "?? file2\n" \
+      "MOCK_PROGRAM_INPUT: status\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: On branch local_branch0\n" \
+      "Your branch is ahead of 'origin_repo0/remote_branch0' by 3 commits.\n" \
+      )
 
-  open("ExtraRepo1/.mockprogram_inout.txt", "w").write(
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: origin_repo1/remote_branch1\n" \
-    "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo1/remote_branch1\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: 22 some author\n" \
-    "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: ?? file1\n" \
-    "MOCK_PROGRAM_INPUT: status\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: On branch local_branch1\n" \
-    "Your branch is ahead of 'origin_repo1/remote_branch1' by 22 commits.\n" \
-    )
+  with open("ExtraRepo1/.mockprogram_inout.txt", "w") as fileHandle:
+    fileHandle.write(
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: origin_repo1/remote_branch1\n" \
+      "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo1/remote_branch1\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: 22 some author\n" \
+      "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: ?? file1\n" \
+      "MOCK_PROGRAM_INPUT: status\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: On branch local_branch1\n" \
+      "Your branch is ahead of 'origin_repo1/remote_branch1' by 22 commits.\n" \
+      )
 
-  open("ExtraRepo2/.mockprogram_inout.txt", "w").write(
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: local_branch2\n" \
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: origin_repo2/remote_branch2\n" \
-    "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo2/remote_branch2\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: \n" \
-    "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: \n" \
-    )
+  with open("ExtraRepo2/.mockprogram_inout.txt", "w") as fileHandle:
+    fileHandle.write(
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: local_branch2\n" \
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: origin_repo2/remote_branch2\n" \
+      "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo2/remote_branch2\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: \n" \
+      "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: \n" \
+      )
 
 
 def writeGitMockProgram_dist_repo_versions_table():
@@ -950,62 +961,65 @@ def writeGitMockProgram_dist_repo_versions_table_1_change_base():
 
 def writeGitMockProgram_base_3_2_1_repo1_0_0_0_repo2_4_0_2():
 
-  open(".mockprogram_inout.txt", "w").write(
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
-    "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: 3 some author\n" \
-    "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-    " M file2\n" \
-    "?? file3\n" \
-    "MOCK_PROGRAM_INPUT: status\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: On branch local_branch0\n" \
-    "Your branch is ahead of 'origin_repo0/remote_branch0' by 3 commits.\n" \
-    )
+  with open(".mockprogram_inout.txt", "w") as fileHandle:
+    fileHandle.write(
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
+      "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: 3 some author\n" \
+      "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+      " M file2\n" \
+      "?? file3\n" \
+      "MOCK_PROGRAM_INPUT: status\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: On branch local_branch0\n" \
+      "Your branch is ahead of 'origin_repo0/remote_branch0' by 3 commits.\n" \
+      )
 
-  open("ExtraRepo1/.mockprogram_inout.txt", "w").write(
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: origin_repo1/remote_branch1\n" \
-    "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo1/remote_branch1\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: \n" \
-    "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: \n" \
-    )
+  with open("ExtraRepo1/.mockprogram_inout.txt", "w") as fileHandle:
+    fileHandle.write(
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: origin_repo1/remote_branch1\n" \
+      "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo1/remote_branch1\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: \n" \
+      "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: \n" \
+      )
 
-  open("ExtraRepo2/.mockprogram_inout.txt", "w").write(
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: local_branch2\n" \
-    "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: origin_repo2/remote_branch2\n" \
-    "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo2/remote_branch2\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: 3 some author\n" \
-    "1 some other author\n" \
-    "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: ??  file1\n" \
-    "?? file3\n" \
-    "MOCK_PROGRAM_INPUT: status\n" \
-    "MOCK_PROGRAM_RETURN: 0\n" \
-    "MOCK_PROGRAM_OUTPUT: On branch local_branch2\n" \
-    "Your branch is ahead of 'origin_repo2/remote_branch2' by 4 commits.\n" \
-    )
+  with open("ExtraRepo2/.mockprogram_inout.txt", "w") as fileHandle:
+    fileHandle.write(
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: local_branch2\n" \
+      "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: origin_repo2/remote_branch2\n" \
+      "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo2/remote_branch2\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: 3 some author\n" \
+      "1 some other author\n" \
+      "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: ??  file1\n" \
+      "?? file3\n" \
+      "MOCK_PROGRAM_INPUT: status\n" \
+      "MOCK_PROGRAM_RETURN: 0\n" \
+      "MOCK_PROGRAM_OUTPUT: On branch local_branch2\n" \
+      "Your branch is ahead of 'origin_repo2/remote_branch2' by 4 commits.\n" \
+      )
 
 
 class test_gitdist_getRepoVersionDictFromRepoVersionFileString(unittest.TestCase):
@@ -1235,13 +1249,14 @@ class test_gitdist(unittest.TestCase):
       os.mkdir("ExtraRepo3")
 
       # Make sure .gitdist.default is found and read correctly
-      open(".gitdist.default", "w").write(
-        ".\n" \
-        "ExtraRepo1\n" \
-        "Path/To/ExtraRepo2\n" \
-        "MissingExtraRep\n" \
-        "ExtraRepo3\n"
-        )
+      with open(".gitdist.default", "w") as fileHandle:
+        fileHandle.write(
+          ".\n" \
+          "ExtraRepo1\n" \
+          "Path/To/ExtraRepo2\n" \
+          "MissingExtraRep\n" \
+          "ExtraRepo3\n"
+          )
       cmndOut = GeneralScriptSupport.getCmndOutput(gitdistPathMock+" status",
         workingDir=testDir)
       cmndOut_expected = \
@@ -1258,14 +1273,15 @@ class test_gitdist(unittest.TestCase):
       # missing paths (MissingExtraRepo) are ignored.
 
       # Make sure that .gitdist overrides .gitdist.default
-      open(".gitdist", "w").write(
-        ".\n" \
-        "ExtraRepo1\n" \
-        "\n" \
-        "   \n" \
-        "ExtraRepo3\n" \
-        "\n"
-        )
+      with open(".gitdist", "w") as fileHandle:
+        fileHandle.write(
+          ".\n" \
+          "ExtraRepo1\n" \
+          "\n" \
+          "   \n" \
+          "ExtraRepo3\n" \
+          "\n"
+          )
       cmndOut = GeneralScriptSupport.getCmndOutput(gitdistPathMock+" status",
         workingDir=testDir)
       cmndOut_expected = \
@@ -1359,54 +1375,57 @@ class test_gitdist(unittest.TestCase):
       os.mkdir("ExtraRepo1")
       os.mkdir("ExtraRepo2")
 
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: 3 some author\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-        "MOCK_PROGRAM_INPUT: status\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: On branch local_branch0\n" \
-        "Your branch is ahead of 'origin_repo0/remote_branch0' by 3 commits.\n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: 3 some author\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+          "MOCK_PROGRAM_INPUT: status\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: On branch local_branch0\n" \
+          "Your branch is ahead of 'origin_repo0/remote_branch0' by 3 commits.\n" \
+          )
 
-      open("ExtraRepo1/.mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: origin_repo1/remote_branch1\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo1/remote_branch1\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        )
+      with open("ExtraRepo1/.mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: origin_repo1/remote_branch1\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo1/remote_branch1\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          )
 
-      open("ExtraRepo2/.mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch2\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: origin_repo2/remote_branch2\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo2/remote_branch2\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        )
+      with open("ExtraRepo2/.mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch2\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: origin_repo2/remote_branch2\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo2/remote_branch2\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          )
 
       cmndOut = GeneralScriptSupport.getCmndOutput(
         gitdistPath + " --dist-no-color --dist-use-git="+mockGitPath \
@@ -1433,54 +1452,57 @@ class test_gitdist(unittest.TestCase):
       os.mkdir("ExtraRepo1")
       os.mkdir("ExtraRepo2")
 
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          )
 
-      open("ExtraRepo1/.mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: origin_repo1/remote_branch1\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo1/remote_branch1\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: 1 some author\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        "MOCK_PROGRAM_INPUT: status\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: On branch local_branch1\n" \
-        "Your branch is ahead of 'origin_repo1/remote_branch1' by 1 commits.\n" \
-        )
+      with open("ExtraRepo1/.mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: origin_repo1/remote_branch1\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo1/remote_branch1\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: 1 some author\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          "MOCK_PROGRAM_INPUT: status\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: On branch local_branch1\n" \
+          "Your branch is ahead of 'origin_repo1/remote_branch1' by 1 commits.\n" \
+          )
 
-      open("ExtraRepo2/.mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch2\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: origin_repo2/remote_branch2\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo2/remote_branch2\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        )
+      with open("ExtraRepo2/.mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch2\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: origin_repo2/remote_branch2\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo2/remote_branch2\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          )
 
       cmndOut = GeneralScriptSupport.getCmndOutput(
         gitdistPath + " --dist-no-color --dist-use-git="+mockGitPath \
@@ -1505,36 +1527,38 @@ class test_gitdist(unittest.TestCase):
 
       os.mkdir("ExtraRepo1")
 
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: 3 some author\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-        "MOCK_PROGRAM_INPUT: status\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: On branch local_branch0\n" \
-        "Your branch is ahead of 'origin_repo0/remote_branch0' by 3 commits.\n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: 3 some author\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+          "MOCK_PROGRAM_INPUT: status\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: On branch local_branch0\n" \
+          "Your branch is ahead of 'origin_repo0/remote_branch0' by 3 commits.\n" \
+          )
 
-      open("ExtraRepo1/.mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 128\n" \
-        "MOCK_PROGRAM_OUTPUT: error: No upstream branch found for ''\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        )
+      with open("ExtraRepo1/.mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 128\n" \
+          "MOCK_PROGRAM_OUTPUT: error: No upstream branch found for ''\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          )
 
       cmndOut = GeneralScriptSupport.getCmndOutput(
         gitdistPath + " --dist-no-color --dist-use-git="+mockGitPath \
@@ -1560,36 +1584,38 @@ class test_gitdist(unittest.TestCase):
 
       os.mkdir("ExtraRepo1")
 
-      open(".mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
-        "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: \n" \
-        )
+      with open(".mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch0\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: origin_repo0/remote_branch0\n" \
+          "MOCK_PROGRAM_INPUT: shortlog -s HEAD ^origin_repo0/remote_branch0\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: \n" \
+          )
 
-      open("ExtraRepo1/.mockprogram_inout.txt", "w").write(
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
-        "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
-        "MOCK_PROGRAM_RETURN: 128\n" \
-        "MOCK_PROGRAM_OUTPUT: error: No upstream branch found for ''\n" \
-        "MOCK_PROGRAM_INPUT: status --porcelain\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: M  file1\n" \
-        "MOCK_PROGRAM_INPUT: status\n" \
-        "MOCK_PROGRAM_RETURN: 0\n" \
-        "MOCK_PROGRAM_OUTPUT: On branch local_branch1\n" \
-        "Your branch is ahead of 'origin_repo1/remote_branch1' by 1 commits.\n" \
-        )
+      with open("ExtraRepo1/.mockprogram_inout.txt", "w") as fileHandle:
+        fileHandle.write(
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: local_branch1\n" \
+          "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref --symbolic-full-name @{u}\n" \
+          "MOCK_PROGRAM_RETURN: 128\n" \
+          "MOCK_PROGRAM_OUTPUT: error: No upstream branch found for ''\n" \
+          "MOCK_PROGRAM_INPUT: status --porcelain\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: M  file1\n" \
+          "MOCK_PROGRAM_INPUT: status\n" \
+          "MOCK_PROGRAM_RETURN: 0\n" \
+          "MOCK_PROGRAM_OUTPUT: On branch local_branch1\n" \
+          "Your branch is ahead of 'origin_repo1/remote_branch1' by 1 commits.\n" \
+          )
 
       # Make sure that --dist-repos overrides all files
       cmndOut = GeneralScriptSupport.getCmndOutput(
@@ -2157,13 +2183,14 @@ class test_gitdist(unittest.TestCase):
       os.mkdir("ExtraRepo3")
 
       # Make sure .gitdist.default is found and read correctly
-      open(".gitdist.default", "w").write(
-        ". master\n" \
-        "ExtraRepo1 develop\n" \
-        "Path/To/ExtraRepo2 app-devel\n" \
-        "MissingExtraRepo\n" \
-        "ExtraRepo3\n"
-        )
+      with open(".gitdist.default", "w") as fileHandle:
+        fileHandle.write(
+          ". master\n" \
+          "ExtraRepo1 develop\n" \
+          "Path/To/ExtraRepo2 app-devel\n" \
+          "MissingExtraRepo\n" \
+          "ExtraRepo3\n"
+          )
       cmndOut = GeneralScriptSupport.getCmndOutput(
         gitdistPathMock+" checkout _DEFAULT_BRANCH_", workingDir=testDir)
       cmndOut_expected = \
@@ -2180,11 +2207,12 @@ class test_gitdist(unittest.TestCase):
       # missing paths (MissingExtraRepo) are ignored.
 
       # Make sure that .gitdist overrides .gitdist.default
-      open(".gitdist", "w").write(
-        ". develop\n" \
-        "ExtraRepo1 develop\n" \
-        "ExtraRepo3 develop\n"
-        )
+      with open(".gitdist", "w") as fileHandle:
+        fileHandle.write(
+          ". develop\n" \
+          "ExtraRepo1 develop\n" \
+          "ExtraRepo3 develop\n"
+          )
       cmndOut = GeneralScriptSupport.getCmndOutput(
         gitdistPathMock+" checkout _DEFAULT_BRANCH_", workingDir=testDir)
       cmndOut_expected = \
@@ -2230,13 +2258,15 @@ class test_gitdist(unittest.TestCase):
       # Create a mock git meta-project.
       testDir = createAndMoveIntoTestDir("gitdist_move_to_base_dir")
       os.makedirs("ExtraRepo/path/to/somewhere")
-      open(".gitdist", "w").write(
-        ".\n" \
-        "ExtraRepo\n"
-        )
-      open("ExtraRepo/.gitdist", "w").write(
-        ".\n"
-        )
+      with open(".gitdist", "w") as fileHandle:
+        fileHandle.write(
+          ".\n" \
+          "ExtraRepo\n"
+          )
+      with open("ExtraRepo/.gitdist", "w") as fileHandle:
+        fileHandle.write(
+          ".\n"
+          )
       os.chdir("ExtraRepo/path/to/somewhere")
 
       # Test with the default setting.

--- a/test/python_utils/gitdist_UnitTests.py
+++ b/test/python_utils/gitdist_UnitTests.py
@@ -2098,11 +2098,12 @@ class test_gitdist(unittest.TestCase):
         "Legend:\n" \
         "* ID: Repository ID, zero based (order git commands are run)\n" \
         "* Repo Dir: Relative to base repo (base repo shown first with '(Base)')\n" \
-        "* Branch: Current branch (or detached HEAD)\n" \
+        "* Branch: Current branch, or (if detached HEAD) tag name or SHA1\n" \
         "* Tracking Branch: Tracking branch (or empty if no tracking branch exists)\n" \
         "* C: Number local commits w.r.t. tracking branch (empty if zero or no TB)\n" \
         "* M: Number of tracked modified (uncommitted) files (empty if zero)\n" \
         "* ?: Number of untracked, non-ignored files (empty if zero)\n\n"
+      self.maxDiff = None
       self.assertEqual(s(cmndOut), s(cmndOut_expected))
 
     finally:
@@ -2141,11 +2142,12 @@ class test_gitdist(unittest.TestCase):
           "Legend:\n" \
           "* ID: Repository ID, zero based (order git commands are run)\n" \
           "* Repo Dir: Relative to base repo (base repo shown first with '(Base)')\n" \
-          "* Branch: Current branch (or detached HEAD)\n" \
+          "* Branch: Current branch, or (if detached HEAD) tag name or SHA1\n" \
           "* Tracking Branch: Tracking branch (or empty if no tracking branch exists)\n" \
           "* C: Number local commits w.r.t. tracking branch (empty if zero or no TB)\n" \
           "* M: Number of tracked modified (uncommitted) files (empty if zero)\n" \
           "* ?: Number of untracked, non-ignored files (empty if zero)\n\n"
+        self.maxDiff = None
         self.assertEqual(s(cmndOut), s(cmndOut_expected))
 
       finally:

--- a/test/python_utils/gitdist_UnitTests.py
+++ b/test/python_utils/gitdist_UnitTests.py
@@ -808,6 +808,8 @@ def writeGitMockProgram_base_3_2_1_repo1_22_0_2_repo2_0_0_0():
       "Your branch is ahead of 'origin_repo0/remote_branch0' by 3 commits.\n" \
       )
 
+  os.mkdir("ExtraRepo1")
+
   with open("ExtraRepo1/.mockprogram_inout.txt", "w") as fileHandle:
     fileHandle.write(
       "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
@@ -827,6 +829,8 @@ def writeGitMockProgram_base_3_2_1_repo1_22_0_2_repo2_0_0_0():
       "MOCK_PROGRAM_OUTPUT: On branch local_branch1\n" \
       "Your branch is ahead of 'origin_repo1/remote_branch1' by 22 commits.\n" \
       )
+
+  os.mkdir("ExtraRepo2")
 
   with open("ExtraRepo2/.mockprogram_inout.txt", "w") as fileHandle:
     fileHandle.write(
@@ -863,6 +867,8 @@ def writeGitMockProgram_dist_repo_versions_table():
       "MOCK_PROGRAM_OUTPUT: Merge Pull Request #1234 from user/repo/branch\n" \
     )
 
+  os.mkdir("ExtraRepo1")
+
   with open("ExtraRepo1/.mockprogram_inout.txt", "w") as f:
     f.write(
       "MOCK_PROGRAM_INPUT: rev-parse --short HEAD\n" \
@@ -878,6 +884,8 @@ def writeGitMockProgram_dist_repo_versions_table():
       "MOCK_PROGRAM_RETURN: 0\n" \
       "MOCK_PROGRAM_OUTPUT: Fixed a Bug\n" \
     )
+
+  os.mkdir("ExtraRepo2")
 
   with open("ExtraRepo2/.mockprogram_inout.txt", "w") as f:
     f.write(
@@ -926,6 +934,8 @@ def writeGitMockProgram_dist_repo_versions_table_1_change_base():
       "MOCK_PROGRAM_OUTPUT: Merge Pull Request #1234 from user/repo/branch\n" \
     )
 
+  os.mkdir("ExtraRepo1")
+
   with open("ExtraRepo1/.mockprogram_inout.txt", "w") as f:
     f.write(
       "MOCK_PROGRAM_INPUT: rev-parse --short HEAD\n" \
@@ -941,6 +951,8 @@ def writeGitMockProgram_dist_repo_versions_table_1_change_base():
       "MOCK_PROGRAM_RETURN: 0\n" \
       "MOCK_PROGRAM_OUTPUT: Fixed a Bug\n" \
     )
+
+  os.mkdir("ExtraRepo2")
 
   with open("ExtraRepo2/.mockprogram_inout.txt", "w") as f:
     f.write(
@@ -983,6 +995,8 @@ def writeGitMockProgram_base_3_2_1_repo1_0_0_0_repo2_4_0_2():
       "Your branch is ahead of 'origin_repo0/remote_branch0' by 3 commits.\n" \
       )
 
+  os.mkdir("ExtraRepo1")
+
   with open("ExtraRepo1/.mockprogram_inout.txt", "w") as fileHandle:
     fileHandle.write(
       "MOCK_PROGRAM_INPUT: rev-parse --abbrev-ref HEAD\n" \
@@ -998,6 +1012,8 @@ def writeGitMockProgram_base_3_2_1_repo1_0_0_0_repo2_4_0_2():
       "MOCK_PROGRAM_RETURN: 0\n" \
       "MOCK_PROGRAM_OUTPUT: \n" \
       )
+
+  os.mkdir("ExtraRepo2")
 
   with open("ExtraRepo2/.mockprogram_inout.txt", "w") as fileHandle:
     fileHandle.write(
@@ -1744,9 +1760,6 @@ class test_gitdist(unittest.TestCase):
 
       testDir = createAndMoveIntoTestDir("gitdist_dist_repo_status_all")
 
-      os.mkdir("ExtraRepo1")
-      os.mkdir("ExtraRepo2")
-
       writeGitMockProgram_base_3_2_1_repo1_22_0_2_repo2_0_0_0()
 
       cmndOut = GeneralScriptSupport.getCmndOutput(
@@ -1778,9 +1791,6 @@ class test_gitdist(unittest.TestCase):
 
       testDir = createAndMoveIntoTestDir("gitdist_dist_repo_versions_table")
 
-      os.mkdir("ExtraRepo1")
-      os.mkdir("ExtraRepo2")
-
       writeGitMockProgram_dist_repo_versions_table()
 
       cmndOut = GeneralScriptSupport.getCmndOutput(
@@ -1809,9 +1819,6 @@ class test_gitdist(unittest.TestCase):
       testDir = createAndMoveIntoTestDir(
         "gitdist_dist_repo_versions_table_1_change_base")
 
-      os.mkdir("ExtraRepo1")
-      os.mkdir("ExtraRepo2")
-
       writeGitMockProgram_dist_repo_versions_table_1_change_base()
 
       cmndOut = GeneralScriptSupport.getCmndOutput(
@@ -1837,9 +1844,6 @@ class test_gitdist(unittest.TestCase):
       # Create a mock git meta-project
 
       testDir = createAndMoveIntoTestDir("gitdist_dist_repo_versions_short_table")
-
-      os.mkdir("ExtraRepo1")
-      os.mkdir("ExtraRepo2")
 
       writeGitMockProgram_dist_repo_versions_table()
 
@@ -1872,9 +1876,6 @@ class test_gitdist(unittest.TestCase):
 
         testDir = createAndMoveIntoTestDir("gitdist_dist_repo_status_all")
 
-        os.mkdir("ExtraRepo1")
-        os.mkdir("ExtraRepo2")
-
         writeGitMockProgram_base_3_2_1_repo1_22_0_2_repo2_0_0_0()
 
         cmndOut = GeneralScriptSupport.getCmndOutput(
@@ -1906,9 +1907,6 @@ class test_gitdist(unittest.TestCase):
       # Create a mock git meta-project
 
       testDir = createAndMoveIntoTestDir("gitdist_dist_repo_status_mod_only_first")
-
-      os.mkdir("ExtraRepo1")
-      os.mkdir("ExtraRepo2")
 
       writeGitMockProgram_base_3_2_1_repo1_22_0_2_repo2_0_0_0()
 
@@ -1943,9 +1941,6 @@ class test_gitdist(unittest.TestCase):
 
         testDir = createAndMoveIntoTestDir("gitdist_dist_repo_status_mod_only_first")
 
-        os.mkdir("ExtraRepo1")
-        os.mkdir("ExtraRepo2")
-
         writeGitMockProgram_base_3_2_1_repo1_22_0_2_repo2_0_0_0()
 
         cmndOut = GeneralScriptSupport.getCmndOutput(
@@ -1976,9 +1971,6 @@ class test_gitdist(unittest.TestCase):
       # Create a mock git meta-project
 
       testDir = createAndMoveIntoTestDir("gitdist_dist_repo_status_mod_only_first_legend")
-
-      os.mkdir("ExtraRepo1")
-      os.mkdir("ExtraRepo2")
 
       writeGitMockProgram_base_3_2_1_repo1_22_0_2_repo2_0_0_0()
 
@@ -2019,10 +2011,8 @@ class test_gitdist(unittest.TestCase):
 
         # Create a mock git meta-project
 
-        testDir = createAndMoveIntoTestDir("gitdist_dist_repo_status_mod_only_first_legend")
-
-        os.mkdir("ExtraRepo1")
-        os.mkdir("ExtraRepo2")
+        testDir = \
+          createAndMoveIntoTestDir("gitdist_dist_repo_status_mod_only_first_legend")
 
         writeGitMockProgram_base_3_2_1_repo1_22_0_2_repo2_0_0_0()
 
@@ -2063,9 +2053,6 @@ class test_gitdist(unittest.TestCase):
 
       testDir = createAndMoveIntoTestDir("gitdist_dist_repo_status_mod_only_first_last")
 
-      os.mkdir("ExtraRepo1")
-      os.mkdir("ExtraRepo2")
-
       writeGitMockProgram_base_3_2_1_repo1_0_0_0_repo2_4_0_2()
 
       cmndOut = GeneralScriptSupport.getCmndOutput(
@@ -2098,9 +2085,6 @@ class test_gitdist(unittest.TestCase):
         # Create a mock git meta-project
 
         testDir = createAndMoveIntoTestDir("gitdist_dist_repo_status_mod_only_first_last")
-
-        os.mkdir("ExtraRepo1")
-        os.mkdir("ExtraRepo2")
 
         writeGitMockProgram_base_3_2_1_repo1_0_0_0_repo2_4_0_2()
 

--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -36,7 +36,7 @@ else:
 distRepoStatusLegend = r"""Legend:
 * ID: Repository ID, zero based (order git commands are run)
 * Repo Dir: Relative to base repo (base repo shown first with '(Base)')
-* Branch: Current branch (or detached HEAD)
+* Branch: Current branch, or (if detached HEAD) tag name or SHA1
 * Tracking Branch: Tracking branch (or empty if no tracking branch exists)
 * C: Number local commits w.r.t. tracking branch (empty if zero or no TB)
 * M: Number of tracked modified (uncommitted) files (empty if zero)
@@ -333,7 +333,7 @@ outputs a table like:
   |----|-----------------------|--------|-----------------|---|----|---|
   |  0 | BaseRepo (Base)       | dummy  |                 |   |    |   |
   |  1 | ExtraRepo1            | master | origin/master   | 1 |  2 |   |
-  |  2 | ExtraRepo1/ExtraRepo2 | HEAD   |                 |   | 25 | 4 |
+  |  2 | ExtraRepo1/ExtraRepo2 | abc123 |                 |   | 25 | 4 |
   |  3 | ExtraRepo3            | master | origin/master   |   |    |   |
   ----------------------------------------------------------------------
 
@@ -341,6 +341,13 @@ If the option --dist-legend is also passed in, the output will include:
 
 """+distRepoStatusLegend+\
 r"""
+
+In the case of a detached head state, as shown above with the repo
+'ExtraRepo3', the SHA1 (e.g. 'abc123') was printed instead of 'HEAD'.
+However, if the repo is in the detached head state but a tag happens to point
+to the current commit (e.g. 'git tag --points-at' returns non-empy), then the
+tag name (e.g. 'v1.2.3') is printed instead of the SHA1 of the commit.
+
 One can also show the status of only changed repos with the command:
 
   $ gitdist dist-repo-status --dist-mod-only  # alias 'gitdist-mod-status'
@@ -351,7 +358,7 @@ which produces a table like:
   | ID | Repo Dir              | Branch | Tracking Branch | C | M  | ? |
   |----|-----------------------|--------|-----------------|---|----|---|
   |  1 | ExtraRepo1            | master | origin/master   | 1 |  2 |   |
-  |  2 | ExtraRepo1/ExtraRepo2 | HEAD   |                 |   | 25 | 4 |
+  |  2 | ExtraRepo1/ExtraRepo2 | abc123 |                 |   | 25 | 4 |
   ----------------------------------------------------------------------
 
 (see the alias 'gitdist-mod-status' in --dist-help=aliases).

--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -1906,7 +1906,7 @@ if __name__ == '__main__':
       # Get repo stats
       repoStats = None
       if options.modifiedOnly or distRepoStatus:
-        repoStats = getRepoStats(options)
+        repoStats = getRepoStats(options, showMoreHeadDetails="SHOW_MORE_HEAD_DETAILS")
       repoVersions = None
       if distRepoVersionTable:
         repoVersions = getRepoVersions(options)

--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -844,7 +844,8 @@ def createTable(tableData, utf8=False):
       if mockSttySize:
         sttySize = mockSttySize
       else:
-        sttySize = os.popen("stty size", "r").read()
+        with os.popen("stty size", "r") as subprocess:
+          sttySize = subprocess.read()
       rows, columns = sttySize.split()
     except:
       shrink = False
@@ -1071,7 +1072,7 @@ def getCmndOutput(cmnd, rtnCode=False):
   child = subprocess.Popen(cmnd, shell=True, stdout=subprocess.PIPE,
     stderr = subprocess.STDOUT)
   output = child.stdout.read()
-  child.wait()
+  child.communicate()
   if rtnCode:
     return (s(output), child.returncode)
   return s(output)


### PR DESCRIPTION
There was a bug is the previous PR #587.  See commit messages for details.

This replaces the following PR that seems to show a GitHub defect described in https://github.com/TriBITSPub/TriBITS/pull/589#issuecomment-1615052483:

* #589 

I was afraid that the GitHub defect would cause the merge of the wrong commits.
