### PR TITLE
Fix broken build docs tests run with GitHub Actions

### DIFF
--- a/.github/workflows/tribits_testing.yml
+++ b/.github/workflows/tribits_testing.yml
@@ -74,6 +74,12 @@ jobs:
           which ${{ matrix.config.cxx }}
           ${{ matrix.config.cxx }} --version
           if [ "${{ matrix.config.fc }}" = "" ]; then echo "No fortran compiler"; else echo "Checking gfortran path and version" && which ${{ matrix.config.fc }} && ${{ matrix.config.fc }} --version; fi
+      - name: Fetch repo tags
+        run: |
+          echo "Running: git fetch origin 'refs/tags/*:refs/tags/*'"
+          git fetch origin 'refs/tags/*:refs/tags/*'
+          echo "Running: git tag"
+          git tag
       - name: Run configure, build, test, and submit to CDash
         run: |
           cd ..

--- a/tribits/doc/utils/gen_doc_utils.sh
+++ b/tribits/doc/utils/gen_doc_utils.sh
@@ -51,7 +51,7 @@ function generate_git_version_file {
     echo
     echo "Generating git version"
     echo
-    git describe --match="$_TRIBITS_TAG_PREFIX*" > TribitsGitVersion.txt || \
+    git describe --always --match="$_TRIBITS_TAG_PREFIX*" > TribitsGitVersion.txt || \
       echo "$_TRIBITS_TAG_PREFIX.{Unknown version}" > TribitsGitVersion.txt
   else
     echo "$_TRIBITS_TAG_PREFIX.{Unknown version}" > TribitsGitVersion.txt

--- a/tribits/doc/utils/gen_doc_utils.sh
+++ b/tribits/doc/utils/gen_doc_utils.sh
@@ -51,7 +51,8 @@ function generate_git_version_file {
     echo
     echo "Generating git version"
     echo
-    echo `git describe --match="$_TRIBITS_TAG_PREFIX*"` > TribitsGitVersion.txt
+    git describe --match="$_TRIBITS_TAG_PREFIX*" > TribitsGitVersion.txt || \
+      echo "$_TRIBITS_TAG_PREFIX.{Unknown version}" > TribitsGitVersion.txt
   else
     echo "$_TRIBITS_TAG_PREFIX.{Unknown version}" > TribitsGitVersion.txt
   fi


### PR DESCRIPTION
While working on PR #591, I ran into the failing GitHub Actions run tests `TriBITS_build_docs` and `TriBITS_build_sphinx_docs` as shown [here](https://github.com/TriBITSPub/TriBITS/actions/runs/5659746893) for example.  Looking at the failed tests [here](https://my.cdash.org/queryTests.php?project=TriBITS&filtercount=2&showfilters=1&filtercombine=and&field1=revision&compare1=61&value1=70b146b00560a9fa75ceda21b9d4fa3a8d8ea340&field2=status&compare2=62&value2=passed) you see:

```
Generating git version

fatal: No names found, cannot describe anything.
```

and that leads to the failure of all of the documents:

```
Generating TribitsUsersGuide.html ...
TribitsUsersGuide.rst:7: (WARNING/2) Cannot extract empty bibliographic field "Version".
Cleaning intermediate files ...
/home/runner/work/TriBITS/TriBITS/tribits/doc/guides
```

and

```
Generating TribitsBuildReference.html ...
TribitsBuildReference.rst:8: (WARNING/2) Cannot extract empty bibliographic field "Version".
```

We see similar errors in nightly testing like [here](https://my.cdash.org/test/86581526) showing:

```
Generating TribitsUsersGuide.html ...
TribitsUsersGuide.rst:7: (WARNING/2) Cannot extract empty bibliographic field "Version".
Cleaning intermediate files ...
```

but somehow the tests still pass.

In any case, the changes in this PR makes those tests pass, but git describe is still not creating the correct version info and seems to be missing the tags.  But at least the repo SHA1 will be provided in the generated document.

