### PR TITLE
CDash Random failure tool patch 2024-02-15 (#600)

### DIFF
--- a/test/ci_support/cdash_analyze_and_report_random_failures_UnitTests.py
+++ b/test/ci_support/cdash_analyze_and_report_random_failures_UnitTests.py
@@ -180,8 +180,9 @@ class test_cdash_analyze_and_report_random_failures(unittest.TestCase):
         self.test_dir.remove()
 
 
-    # Test the random failure case of a single initial test containing
-    # one passing and one failing test in its test history, both with the same SHA1 pairs
+    # Test the random failure case starting from two initial failing tests (ift)
+    # in which one of the initial failing test contains a history of two tests
+    # with the same sha1 pair, but one is a passing case and the other nonpassing.
     #
     def test_random_failure(self):
 
@@ -226,6 +227,10 @@ class test_cdash_analyze_and_report_random_failures(unittest.TestCase):
         )
 
 
+    # Test to no random failure case starting from two initial failing tests (ift).
+    # Each ift has a test history containing multiple tests with passing and nonpassing results,
+    # but non share the same sha1 pair.
+    #
     def test_no_random_failure(self):
 
         testCaseName = "rft_0_ift_2"

--- a/tribits/ci_support/CDashAnalyzeReportRandomFailures.py
+++ b/tribits/ci_support/CDashAnalyzeReportRandomFailures.py
@@ -307,7 +307,6 @@ class CDashAnalyzeReportRandomFailuresDriver:
     useCachedCDashData=False, alwaysUseCacheFileIfExists=False,
     verbose='False'
   ):
-    print("\n BUILD CACHE FILE "+buildSummaryCacheFile)
     verbose = verbose == 'all'
     buildSummaryJson = CDQAR.getAndCacheCDashQueryDataOrReadFromCache(
         cdashBuildSummaryQueryUrl, buildSummaryCacheFile, useCachedCDashData,


### PR DESCRIPTION
## Related issues
- #600 

## Description
These are requested changes to the [Trilinos production version](https://github.com/achauphan/TriBITS/pull/2) that are being implemented. I've packaged them as a patch here for the TriBITS version. 

Let me know if there is a better way to going about these patches going forward. I figured it would be a good idea to include the changes in the production Trilinos version of the script here as well.

## Changes

- Added optional `--email-subject-prefix` argument to add a prefix string to html page title and email subject line
- Change test history URL output in `singleSummaryReporter` to use a hyperlink to clean up output




