### PR TITLE
Provide better error message for tribits_asesrt_minimum_cmake_version() (#612)

### DIFF
--- a/tribits/core/common/TribitsConstants.cmake
+++ b/tribits/core/common/TribitsConstants.cmake
@@ -14,8 +14,9 @@ set(TRIBITS_CMAKE_MINIMUM_REQUIRED 3.23.0)
 macro(tribits_asesrt_minimum_cmake_version)
 
   if (CMAKE_VERSION VERSION_LESS ${TRIBITS_CMAKE_MINIMUM_REQUIRED})
-    message(FATAL_ERROR "Error, TriBiTS must have version"
-        " ${TRIBITS_CMAKE_MINIMUM_REQUIRED} or higher!")
+    message(FATAL_ERROR "Error, this TriBITS project ${PROJECT_NAME} must have a"
+      " version of CMake ${TRIBITS_CMAKE_MINIMUM_REQUIRED} or higher but was"
+      " only provided CMake version ${CMAKE_VERSION}!" )
   endif()
   
 endmacro()


### PR DESCRIPTION
Addresses #612

The current error messages seemed to suggest that the TriBITS version was too low.  But this is an error message about the version of CMake being too long.