### PR TITLE
Fix up git pre-push hook that checks for signed off commits 

### DIFF
--- a/common_tools/git/hooks/client-side/pre-push
+++ b/common_tools/git/hooks/client-side/pre-push
@@ -49,7 +49,27 @@ def getVersionInfoFromStdinStr(stdinStr):
     remoteCommit = None
   #
   return (localCommit, remoteCommit)
- 
+
+
+def getUpstreamRemoteBranch():
+  upstreamRemoteBranchPropName = "user.upstreamremotebranch"
+  upstreamRemoteBranch = getCmndOutput(["git", "config", "--get",
+    upstreamRemoteBranchPropName], allowToFail=True).strip()
+  if not upstreamRemoteBranch:
+    print("Error: The git repo config var '"+upstreamRemoteBranchPropName+"'"\
+      +" is not set!\n\n"\
+      +"Please set it in your local repo with:\n\n"\
+      +"  git config "+upstreamRemoteBranchPropName+" <remoteName>/<branchName>")
+    exit(1)
+  return upstreamRemoteBranch
+
+
+def getAdjustedReferenceVersion(remoteCommit):
+  if remoteCommit == "0000000000000000000000000000000000000000":
+    #print("Adjusted remote ref for remote commit: "+remoteCommit)
+    return getUpstreamRemoteBranch()
+  return remoteCommit
+
 
 #
 # Main
@@ -66,10 +86,12 @@ remoteURL = cmndLineArgs[1]
 # Read in data from STDIIN
 stdinStr = sys.stdin.read().strip()
 (localCommit, remoteCommit) = getVersionInfoFromStdinStr(stdinStr)
+remoteReferenceVersion = getAdjustedReferenceVersion(remoteCommit)
 
 # Get the commits
 if remoteCommit:
-  gitCommits = getCmndOutput(["git", "rev-list", remoteCommit+".."+localCommit]).strip()
+  gitCommits = getCmndOutput(["git", "rev-list",
+    remoteReferenceVersion+".."+localCommit]).strip()
   #print("gitCommits = '"+gitCommits+"'")
 else:
   gitCommits = None

--- a/common_tools/git/hooks/client-side/pre-push
+++ b/common_tools/git/hooks/client-side/pre-push
@@ -71,6 +71,12 @@ def getAdjustedReferenceVersion(remoteCommit):
   return remoteCommit
 
 
+def getVersionRangeInfoFromStdinStr(stdinStr):
+  (localCommit, remoteCommit) = getVersionInfoFromStdinStr(stdinStr)
+  remoteReferenceVersion = getAdjustedReferenceVersion(remoteCommit)
+  return (localCommit, remoteReferenceVersion)
+
+
 #
 # Main
 #
@@ -83,13 +89,12 @@ remoteURL = cmndLineArgs[1]
 #print("remoteName = "+str(remoteName))
 #print("remoteURL = "+str(remoteURL))
 
-# Read in data from STDIIN
 stdinStr = sys.stdin.read().strip()
-(localCommit, remoteCommit) = getVersionInfoFromStdinStr(stdinStr)
-remoteReferenceVersion = getAdjustedReferenceVersion(remoteCommit)
+
+(localCommit, remoteReferenceVersion) = getVersionRangeInfoFromStdinStr(stdinStr)
 
 # Get the commits
-if remoteCommit:
+if remoteReferenceVersion:
   gitCommits = getCmndOutput(["git", "rev-list",
     remoteReferenceVersion+".."+localCommit]).strip()
   #print("gitCommits = '"+gitCommits+"'")

--- a/common_tools/git/hooks/client-side/pre-push
+++ b/common_tools/git/hooks/client-side/pre-push
@@ -99,6 +99,14 @@ def getCommitsListToBeTested(localCommit, remoteReferenceVersion):
   return []
 
 
+def checkCommitOkay(commit):
+  commitMsg = getCmndOutput(["git", "log", "-1", "--pretty=format:\"%B\"", commit])
+  if not "Signed-off-by:" in commitMsg:
+    print("Error: Commit "+commit+" does not have a Signed-off-by line!")
+    return False
+  return True
+
+
 #
 # Main
 #
@@ -116,9 +124,7 @@ gitCommitsList = getCommitsListToBeTested(localCommit, remoteReferenceVersion)
 foundBadCommit = False
 if gitCommitsList:
   for commit in gitCommitsList:
-    commitMsg = getCmndOutput(["git", "log", "-1", "--pretty=format:\"%B\"", commit])
-    if not "Signed-off-by:" in commitMsg:
-      print("Error: Commit "+commit+" does not have a Signed-off-by line!")
+    if not checkCommitOkay(commit):
       foundBadCommit = True
 if foundBadCommit:
   print("\nNOTE: These commits can be signed off by running:\n\n"\

--- a/common_tools/git/hooks/client-side/pre-push
+++ b/common_tools/git/hooks/client-side/pre-push
@@ -97,16 +97,15 @@ else:
   gitCommits = None
 
 # Loop over commits and check for the proper usage
+foundBadCommit = False
 if gitCommits:
-
   gitCommitsArray = str(gitCommits).split("\n")
   #print("gitCommitsArray = "+str(gitCommitsArray))
-
   for commit in gitCommitsArray:
     commitMsg = getCmndOutput(["git", "log", "-1", "--pretty=format:\"%B\"", commit])
     if not "Signed-off-by:" in commitMsg:
       print("Error: Commit "+commit+" does not have a Signed-off-by line!")
-      exit(1)
+      foundBadCommit = True
 
 # Abort if only doing testing
 prePushHookTesting = os.environ.get("PRE_PUSH_HOOK_TESTING", "0")
@@ -114,5 +113,7 @@ if prePushHookTesting == "1":
   print("Aborting pre-push because PRE_PUSH_HOOK_TESTING="+str(prePushHookTesting))
   exit(1)
 
-# If you get here, it is okay to push!
+# Final return pass/fail
+if foundBadCommit:
+  exit(1)
 exit(0)

--- a/common_tools/git/hooks/client-side/pre-push
+++ b/common_tools/git/hooks/client-side/pre-push
@@ -30,6 +30,27 @@ def getCmndOutput(cmnd):
   return output
 
 
+def getVersionInfoFromStdinStr(stdinStr):
+  if stdinStr:
+    stdinArray = stdinStr.split(" ")
+    #print("stdinArray = "+str(stdinArray))
+    localRef = stdinArray[0]
+    localObjectName = stdinArray[1]
+    remoteRef = stdinArray[2]
+    remoteObjectName = stdinArray[3]
+    #print("localRef = "+localRef)
+    #print("localObjectName = "+localObjectName)
+    #print("remoteRef = "+remoteRef)
+    #print("remoteObjectName = "+remoteObjectName)
+    localCommit = localObjectName
+    remoteCommit = remoteObjectName
+  else:
+    localCommit = None
+    remoteCommit = None
+  #
+  return (localCommit, remoteCommit)
+ 
+
 #
 # Main
 #
@@ -44,22 +65,11 @@ remoteURL = cmndLineArgs[1]
 
 # Read in data from STDIIN
 stdinStr = sys.stdin.read().strip()
-if stdinStr:
-  stdinArray = stdinStr.split(" ")
-  #print("stdinArray = "+str(stdinArray))
-  localRef = stdinArray[0]
-  localObjectName = stdinArray[1]
-  remoteRef = stdinArray[2]
-  remoteObjectName = stdinArray[3]
-  #print("localRef = "+localRef)
-  #print("localObjectName = "+localObjectName)
-  #print("remoteRef = "+remoteRef)
-  #print("remoteObjectName = "+remoteObjectName)
+(localCommit, remoteCommit) = getVersionInfoFromStdinStr(stdinStr)
 
 # Get the commits
-if stdinStr:
-  gitCommits = getCmndOutput(["git", "rev-list",
-    remoteObjectName+".."+localObjectName]).strip()
+if remoteCommit:
+  gitCommits = getCmndOutput(["git", "rev-list", remoteCommit+".."+localCommit]).strip()
   #print("gitCommits = '"+gitCommits+"'")
 else:
   gitCommits = None

--- a/common_tools/git/hooks/client-side/pre-push
+++ b/common_tools/git/hooks/client-side/pre-push
@@ -81,6 +81,8 @@ def getVersionRangeInfoFromStdinStr(stdinStr):
 # Main
 #
 
+# Get the branch name at the top in case it is not set!
+upstreamRemoteBranch = getUpstreamRemoteBranch()
 
 # Read in command-line args
 cmndLineArgs = sys.argv[1:]
@@ -111,6 +113,9 @@ if gitCommits:
     if not "Signed-off-by:" in commitMsg:
       print("Error: Commit "+commit+" does not have a Signed-off-by line!")
       foundBadCommit = True
+if foundBadCommit:
+  print("\nNOTE: These commits can be signed off by running:\n\n"\
+    "  git rebase --signoff "+upstreamRemoteBranch+"\n")
 
 # Abort if only doing testing
 prePushHookTesting = os.environ.get("PRE_PUSH_HOOK_TESTING", "0")

--- a/common_tools/git/hooks/client-side/pre-push
+++ b/common_tools/git/hooks/client-side/pre-push
@@ -107,6 +107,18 @@ def checkCommitOkay(commit):
   return True
 
 
+def checkCommitsAreOkay(gitCommitsList, upstreamRemoteBranch):
+  foundBadCommit = False
+  if gitCommitsList:
+    for commit in gitCommitsList:
+      if not checkCommitOkay(commit):
+        foundBadCommit = True
+  if foundBadCommit:
+    print("\nNOTE: These commits can be signed off by running:\n\n"\
+      "  git rebase --signoff "+upstreamRemoteBranch+"\n")
+    return False
+  return True
+
 #
 # Main
 #
@@ -114,21 +126,13 @@ def checkCommitOkay(commit):
 # Get the branch name at the top in case it is not set!
 upstreamRemoteBranch = getUpstreamRemoteBranch()
 
-# Get input and set of commits to check
 (remoteName, remoteURL) = getCmndLineArgsFrmSysArgv(sys.argv)
+
 stdinStr = sys.stdin.read().strip()
 (localCommit, remoteReferenceVersion) = getVersionRangeInfoFromStdinStr(stdinStr)
 gitCommitsList = getCommitsListToBeTested(localCommit, remoteReferenceVersion)
 
-# Loop over commits and check for the proper usage
-foundBadCommit = False
-if gitCommitsList:
-  for commit in gitCommitsList:
-    if not checkCommitOkay(commit):
-      foundBadCommit = True
-if foundBadCommit:
-  print("\nNOTE: These commits can be signed off by running:\n\n"\
-    "  git rebase --signoff "+upstreamRemoteBranch+"\n")
+allCommitsAreOkay = checkCommitsAreOkay(gitCommitsList, upstreamRemoteBranch)
 
 # Abort if only doing testing
 prePushHookTesting = os.environ.get("PRE_PUSH_HOOK_TESTING", "0")
@@ -137,6 +141,6 @@ if prePushHookTesting == "1":
   exit(1)
 
 # Final return pass/fail
-if foundBadCommit:
+if not allCommitsAreOkay:
   exit(1)
 exit(0)

--- a/common_tools/git/hooks/client-side/pre-push
+++ b/common_tools/git/hooks/client-side/pre-push
@@ -119,6 +119,14 @@ def checkCommitsAreOkay(gitCommitsList, upstreamRemoteBranch):
     return False
   return True
 
+
+def abortIfOnlyDoingTesting():
+  prePushHookTesting = os.environ.get("PRE_PUSH_HOOK_TESTING", "0")
+  if prePushHookTesting == "1":
+    print("Aborting pre-push because PRE_PUSH_HOOK_TESTING="+str(prePushHookTesting))
+    exit(1)
+
+
 #
 # Main
 #
@@ -134,13 +142,8 @@ gitCommitsList = getCommitsListToBeTested(localCommit, remoteReferenceVersion)
 
 allCommitsAreOkay = checkCommitsAreOkay(gitCommitsList, upstreamRemoteBranch)
 
-# Abort if only doing testing
-prePushHookTesting = os.environ.get("PRE_PUSH_HOOK_TESTING", "0")
-if prePushHookTesting == "1":
-  print("Aborting pre-push because PRE_PUSH_HOOK_TESTING="+str(prePushHookTesting))
-  exit(1)
+abortIfOnlyDoingTesting()
 
 # Final return pass/fail
-if not allCommitsAreOkay:
-  exit(1)
+if not allCommitsAreOkay: exit(1)
 exit(0)

--- a/common_tools/git/hooks/client-side/pre-push
+++ b/common_tools/git/hooks/client-side/pre-push
@@ -30,6 +30,15 @@ def getCmndOutput(cmnd, allowToFail=False):
   return output
 
 
+def getCmndLineArgsFrmSysArgv(sysArgv):
+  cmndLineArgs = sysArgv[1:]
+  remoteName = cmndLineArgs[0]
+  remoteURL = cmndLineArgs[1]
+  #print("remoteName = "+str(remoteName))
+  #print("remoteURL = "+str(remoteURL))
+  return (remoteName, remoteURL)
+
+
 def getVersionInfoFromStdinStr(stdinStr):
   if stdinStr:
     stdinArray = stdinStr.split(" ")
@@ -97,13 +106,8 @@ def getCommitsListToBeTested(localCommit, remoteReferenceVersion):
 # Get the branch name at the top in case it is not set!
 upstreamRemoteBranch = getUpstreamRemoteBranch()
 
-# Read in command-line args
-cmndLineArgs = sys.argv[1:]
-remoteName = cmndLineArgs[0] 
-remoteURL = cmndLineArgs[1]
-#print("remoteName = "+str(remoteName))
-#print("remoteURL = "+str(remoteURL))
-
+# Get input and set of commits to check
+(remoteName, remoteURL) = getCmndLineArgsFrmSysArgv(sys.argv)
 stdinStr = sys.stdin.read().strip()
 (localCommit, remoteReferenceVersion) = getVersionRangeInfoFromStdinStr(stdinStr)
 gitCommitsList = getCommitsListToBeTested(localCommit, remoteReferenceVersion)

--- a/common_tools/git/hooks/client-side/pre-push
+++ b/common_tools/git/hooks/client-side/pre-push
@@ -18,11 +18,11 @@ def s(x):
     return x
 
 
-def getCmndOutput(cmnd):
+def getCmndOutput(cmnd, allowToFail=False):
   result = subprocess.run(cmnd, stdout=subprocess.PIPE,
     stderr = subprocess.STDOUT)
   output = s(result.stdout)
-  if result.returncode != 0:
+  if result.returncode != 0 and not allowToFail:
     print("Error, the command "+str(cmnd)+" returned error code "+str(result.returncode)\
       +" with the stderr message:\n\n"+str(result.stderr)\
       +"\n\nReturned output was:\n\n"+output)

--- a/common_tools/git/hooks/client-side/pre-push
+++ b/common_tools/git/hooks/client-side/pre-push
@@ -77,6 +77,19 @@ def getVersionRangeInfoFromStdinStr(stdinStr):
   return (localCommit, remoteReferenceVersion)
 
 
+def getCommitsListToBeTested(localCommit, remoteReferenceVersion):
+  if remoteReferenceVersion:
+    gitCommitsStr = getCmndOutput(["git", "rev-list",
+      remoteReferenceVersion+".."+localCommit]).strip()
+    #print("gitCommits = '"+gitCommits+"'")
+  else:
+    gitCommitsStr = None
+  # Return an array of the commits
+  if gitCommitsStr:
+    return str(gitCommitsStr).split("\n")
+  return []
+
+
 #
 # Main
 #
@@ -92,23 +105,13 @@ remoteURL = cmndLineArgs[1]
 #print("remoteURL = "+str(remoteURL))
 
 stdinStr = sys.stdin.read().strip()
-
 (localCommit, remoteReferenceVersion) = getVersionRangeInfoFromStdinStr(stdinStr)
-
-# Get the commits
-if remoteReferenceVersion:
-  gitCommits = getCmndOutput(["git", "rev-list",
-    remoteReferenceVersion+".."+localCommit]).strip()
-  #print("gitCommits = '"+gitCommits+"'")
-else:
-  gitCommits = None
+gitCommitsList = getCommitsListToBeTested(localCommit, remoteReferenceVersion)
 
 # Loop over commits and check for the proper usage
 foundBadCommit = False
-if gitCommits:
-  gitCommitsArray = str(gitCommits).split("\n")
-  #print("gitCommitsArray = "+str(gitCommitsArray))
-  for commit in gitCommitsArray:
+if gitCommitsList:
+  for commit in gitCommitsList:
     commitMsg = getCmndOutput(["git", "log", "-1", "--pretty=format:\"%B\"", commit])
     if not "Signed-off-by:" in commitMsg:
       print("Error: Commit "+commit+" does not have a Signed-off-by line!")


### PR DESCRIPTION
This commit checks for commits that are not signed off and correct them.  The usage is pretty self documenting so I don't think much documentation is needed beyond this.

This turned out to be much more complicated that I would have imaged.   (Much harder than a pre-commit hook, for example.)

This script really needs to have automated tests (like we have for gitdist).
