### PR TITLE
Update for CMake 4.0.0-rc4

### DIFF
--- a/.github/workflows/tribits_testing.yml
+++ b/.github/workflows/tribits_testing.yml
@@ -22,7 +22,7 @@ jobs:
           - { os: ubuntu-latest, cmake: "3.23.1", generator: "makefiles", python: "3.8", cc: gcc-9, cxx: g++-9, fc: gfortran-9 }
           - { os: ubuntu-latest, cmake: "3.24.3", generator: "makefiles", python: "3.8", cc: gcc-10, cxx: g++-10 }
           - { os: ubuntu-latest, cmake: "3.24.3", generator: "makefiles", python: "3.8", cc: gcc-11,  cxx: g++-11, fc: gfortran-11, no_have_ninja: no-ninja }
-          - { os: ubuntu-latest, cmake: "3.25.2", generator: "makefiles", python: "3.8", cc: gcc-11,  cxx: g++-11,  fc: gfortran-11  }
+          - { os: ubuntu-latest, cmake: "4.0.0-rc4", generator: "makefiles", python: "3.8", cc: gcc-11,  cxx: g++-11,  fc: gfortran-11  }
 
     runs-on: ${{ matrix.config.os }}
 

--- a/test/core/ExamplesUnitTests/find_package_two_dirs/CMakeLists.txt
+++ b/test/core/ExamplesUnitTests/find_package_two_dirs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(FindPackageTwoDirs NONE)
 

--- a/tribits/examples/RawHelloWorld/CMakeLists.txt
+++ b/tribits/examples/RawHelloWorld/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Example of a simple project that uses raw CMake
-cmake_minimum_required(VERSION 2.8.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(RawHelloWorld)
 enable_testing()
 add_subdirectory(hello_world)


### PR DESCRIPTION
This passed local testing and I submitted results to [here](https://my.cdash.org/index.php?project=TriBITS&filtercount=3&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=cee-build030&field2=buildname&compare2=61&value2=Linux-TRIBITS_SERIAL&field3=buildstamp&compare3=61&value3=20250316-1906-Experimental) showing:

```
-- CMAKE_VERSION='4.0.0-rc4'
```

and all passing (non-disabled) tests.
