### PR TITLE
Set CMake policy CMP0144 to new to use <PACKAGENAME>_ROOT env vars

### DIFF
--- a/tribits/CHANGELOG.md
+++ b/tribits/CHANGELOG.md
@@ -2,6 +2,15 @@
 ChangeLog for TriBITS
 ----------------------------------------
 
+## 2025-03-22:
+
+* **Changed:** Set CMake policy
+  [CMP0144](https://cmake.org/cmake/help/latest/policy/CMP0144.html) to `NEW`
+  (for versions of CMake 3.27+) so that `find_package(<PackageName> ...)` will
+  use upper case env var `<PACKAGENAME>_ROOT`.  Now, systems that are setting
+  uppercase env var names for standard packages will get picked in CMake
+  configures.
+
 ## 2025-02-17:
 
 * **Added:** Added support for header-only libraries with

--- a/tribits/core/common/TribitsCMakePolicies.cmake
+++ b/tribits/core/common/TribitsCMakePolicies.cmake
@@ -7,11 +7,17 @@
 # *****************************************************************************
 # @HEADER
 
+macro(tribits_set_cmake_policy_if_exists  policyName  oldOrNew)
+  if (POLICY ${policyName})
+    cmake_policy(SET ${policyName} ${oldOrNew})
+  endif()
+endmacro()
+
 # Define policies for CMake
-# It is assumed that the project has already called CMAKE_MINIMUM_REQUIRED.
-cmake_policy(SET CMP0003 NEW) # Don't split up full lib paths to linker args
-cmake_policy(SET CMP0007 NEW) # Don't ignore empty list items
-cmake_policy(SET CMP0053 NEW) # Make var references much faster
-cmake_policy(SET CMP0054 NEW) # Avoid quoted strings lookup variables
-cmake_policy(SET CMP0057 NEW) # Support if ( ... IN_LIST ... )
-cmake_policy(SET CMP0082 NEW) # Install rules follow order install() called in subdirs
+tribits_set_cmake_policy_if_exists(CMP0003 NEW) # Don't split up full lib paths to linker args
+tribits_set_cmake_policy_if_exists(CMP0007 NEW) # Don't ignore empty list items
+tribits_set_cmake_policy_if_exists(CMP0053 NEW) # Make var references much faster
+tribits_set_cmake_policy_if_exists(CMP0054 NEW) # Avoid quoted strings lookup variables
+tribits_set_cmake_policy_if_exists(CMP0057 NEW) # Support if ( ... IN_LIST ... )
+tribits_set_cmake_policy_if_exists(CMP0082 NEW) # Install rules follow order install() called in subdirs
+tribits_set_cmake_policy_if_exists(CMP0144 NEW) # find_package() use <PACKAGENAME>_ROOT env var


### PR DESCRIPTION
This eliminates warnings like:

```
CMake Warning (dev) at cmake/tribits/core/package_arch/TribitsProjectImpl.cmake:80 (find_package):
  Policy CMP0144 is not set: find_package uses upper-case <PACKAGENAME>_ROOT
  variables.  Run "cmake --help-policy CMP0144" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  Environment variable GIT_ROOT is set to:

    /projects/sems/install/rhel8-x86_64/sems/utility/git/2.37.0/gcc/8.3.0/base/vmjqb3w

  For compatibility, find_package is ignoring the variable, but code in a
  .cmake module might still use it.
Call Stack (most recent call first):
  cmake/tribits/core/package_arch/TribitsProject.cmake:62 (tribits_project_impl)
  CMakeLists.txt:53 (TRIBITS_PROJECT)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This is part of:

* https://github.com/trilinos/Trilinos/issues/13731
