### PR TITLE
Make -h go to gitdist help, not git help

### DIFF
--- a/test/python_utils/gitdist_UnitTests.py
+++ b/test/python_utils/gitdist_UnitTests.py
@@ -1220,6 +1220,13 @@ class test_gitdist(unittest.TestCase):
       GeneralScriptSupport.extractLinesMatchingRegex(cmndOut,"^OVERVIEW:$"), "")
     self.assertEqual(
       GeneralScriptSupport.extractLinesMatchingRegex(cmndOut,"^REPO SELECTION AND SETUP:$"), "")
+  def test_short_help(self):
+    cmndOut = getCmndOutput(gitdistPath+" -h")
+    assertContainsGitdistHelpHeader(self, cmndOut)
+    self.assertEqual(
+      GeneralScriptSupport.extractLinesMatchingRegex(cmndOut,"^OVERVIEW:$"), "")
+    self.assertEqual(
+      GeneralScriptSupport.extractLinesMatchingRegex(cmndOut,"^REPO SELECTION AND SETUP:$"), "")
 
 
   # Make sure --dist-help= does not print OVERVIEW section

--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -1152,6 +1152,7 @@ def getCommandlineOps():
 
   distHelpArgName = "--dist-help" # Must match --dist-help before --help!
   helpArgName = "--help"
+  shortHelpArgName = "-h"
   withGitArgName = "--dist-use-git"
   reposArgName = "--dist-repos"
   notReposArgName = "--dist-not-repos"
@@ -1164,7 +1165,7 @@ def getCommandlineOps():
   legendName = "--dist-legend"
   shortName = "--dist-short"
 
-  nativeArgNames = [ distHelpArgName, helpArgName, withGitArgName, \
+  nativeArgNames = [ distHelpArgName, helpArgName, shortHelpArgName, withGitArgName, \
     reposArgName, notReposArgName, \
     versionFileName, versionFile2Name, noColorArgName, debugArgName, noOptName, \
     modifiedOnlyName, legendName, shortName ]


### PR DESCRIPTION
The --help option was going to gitdist help, not git help, so this should be consistent.