### PR TITLE
Add --exclude option

### DIFF
--- a/tribits/python_utils/tree.py
+++ b/tribits/python_utils/tree.py
@@ -103,7 +103,7 @@ def main():
 
   clp.add_option(
     "--exclude", dest="exclude", type="string", default=None,
-    help="Exclude directories or files that match this exclude (e.g. '.git').")
+    help="Exclude matching directory or file (e.g. '.git').")
 
   (options, args) = clp.parse_args()
 


### PR DESCRIPTION
Allows ignoring .git directory.

I will extend this to a list of exclude regexes later.

I tested this manually. (There are no automated tests for this little utility yet.)
