### PR TITLE
Correctly splitting the --extra-cmake-options input.

### DIFF
--- a/tribits/ci_support/CheckinTest.py
+++ b/tribits/ci_support/CheckinTest.py
@@ -1448,7 +1448,7 @@ def runBuildTestCase(inOptions, tribitsGitRepos, buildTestCase, timings):
     if inOptions.useNinja:
       cmakeBaseOptions.append("-GNinja")
     if inOptions.extraCmakeOptions:
-      cmakeBaseOptions.extend(commandLineOptionsToList(inOptions.extraCmakeOptions))
+      cmakeBaseOptions.extend(inOptions.extraCmakeOptions.split(','))
     cmakeBaseOptions.append(cmakeScopedDefine(projectName,
     "TRIBITS_DIR:PATH", inOptions.tribitsDir))
     cmakeBaseOptions.append(cmakeScopedDefine(projectName,


### PR DESCRIPTION
Description:
The use of commandLineOptionsToList wraps the default .split() command which splits on whitespace, not commas.
Fixes issue #640.