### PR TITLE
Fix Python 3.9.25 and gitdist GITDIST_MOVE_TO_BASE_DIR behavior

### DIFF
--- a/test/python_utils/gitdist_UnitTests.py
+++ b/test/python_utils/gitdist_UnitTests.py
@@ -106,6 +106,7 @@ class test_createTable(unittest.TestCase):
   def setUp(self):
     self.gitdistMoveToBaseDir = os.environ.get("GITDIST_MOVE_TO_BASE_DIR", "")
     os.environ["GITDIST_MOVE_TO_BASE_DIR"] = ""
+    self.pwd = os.environ.get("PWD", "")
     self.gitdistUnitTestSttySize = os.environ.get(
       "GITDIST_UNIT_TEST_STTY_SIZE", ""
     )
@@ -113,6 +114,7 @@ class test_createTable(unittest.TestCase):
 
   def tearDown(self):
     os.environ["GITDIST_MOVE_TO_BASE_DIR"] = self.gitdistMoveToBaseDir
+    os.environ["PWD"] = self.pwd
     os.environ["GITDIST_UNIT_TEST_STTY_SIZE"] = self.gitdistUnitTestSttySize
 
 
@@ -2426,6 +2428,130 @@ class test_gitdist(unittest.TestCase):
         "['mockgit', '-c', 'color.status=never', 'status']\n\n"
       self.assertEqual(s(cmndOut), s(cmndOut_expected))
       
+    finally:
+      os.chdir(testBaseDir)
+
+
+  def test_gitdist_move_to_base_dir_nested_subrepo(self):
+    os.chdir(testBaseDir)
+    try:
+
+      # Create a mock git meta-project with a nested git repo that is listed
+      # by both the immediate and the outer-most .gitdist files.
+      testDir = createAndMoveIntoTestDir("gitdist_move_to_base_dir_nested_subrepo")
+      os.makedirs("ExtraRepo/NestedRepo/doc")
+      os.makedirs("ExtraRepo/NestedRepo/.git")
+      with open(".gitdist", "w") as fileHandle:
+        fileHandle.write(
+          ".\n" \
+          "ExtraRepo\n" \
+          "ExtraRepo/NestedRepo\n"
+          )
+      with open("ExtraRepo/.gitdist.default", "w") as fileHandle:
+        fileHandle.write(
+          ".\n" \
+          "NestedRepo\n"
+          )
+      os.chdir("ExtraRepo/NestedRepo/doc")
+
+      os.environ["GITDIST_MOVE_TO_BASE_DIR"] = "IMMEDIATE_BASE"
+      cmndOut = GeneralScriptSupport.getCmndOutput(gitdistPathMock+" status")
+      cmndOut_expected = \
+        "\n*** Base Git Repo: ExtraRepo\n" \
+        "['mockgit', '-c', 'color.status=never', 'status']\n\n" \
+        "*** Git Repo: NestedRepo\n" \
+        "['mockgit', '-c', 'color.status=never', 'status']\n\n"
+      self.assertEqual(s(cmndOut), s(cmndOut_expected))
+
+      os.environ["GITDIST_MOVE_TO_BASE_DIR"] = "EXTREME_BASE"
+      cmndOut = GeneralScriptSupport.getCmndOutput(gitdistPathMock+" status")
+      cmndOut_expected = \
+        "\n*** Base Git Repo: MockProjectDir\n" \
+        "['mockgit', '-c', 'color.status=never', 'status']\n\n" \
+        "*** Git Repo: ExtraRepo\n" \
+        "['mockgit', '-c', 'color.status=never', 'status']\n\n" \
+        "*** Git Repo: ExtraRepo/NestedRepo\n" \
+        "['mockgit', '-c', 'color.status=never', 'status']\n\n"
+      self.assertEqual(s(cmndOut), s(cmndOut_expected))
+
+    finally:
+      os.chdir(testBaseDir)
+
+
+  def test_gitdist_move_to_base_dir_nested_subrepo_logical_pwd(self):
+    os.chdir(testBaseDir)
+    try:
+
+      # Create a mock meta-project where the current subrepo is reached through
+      # a symlink.  This covers the case where os.getcwd() returns the physical
+      # path but PWD contains the logical path with the outer .gitdist file.
+      testDir = createAndMoveIntoTestDir(
+        "gitdist_move_to_base_dir_nested_subrepo_logical_pwd")
+      os.makedirs("../RealExtraRepo/NestedRepo/doc")
+      os.makedirs("../RealExtraRepo/NestedRepo/.git")
+      os.symlink("../RealExtraRepo", "ExtraRepo")
+      with open(".gitdist", "w") as fileHandle:
+        fileHandle.write(
+          ".\n" \
+          "ExtraRepo\n" \
+          "ExtraRepo/NestedRepo\n"
+          )
+      with open("ExtraRepo/.gitdist.default", "w") as fileHandle:
+        fileHandle.write(
+          ".\n" \
+          "NestedRepo\n"
+          )
+      logicalCwd = os.path.join(testDir, "ExtraRepo", "NestedRepo", "doc")
+      os.chdir(logicalCwd)
+      os.environ["PWD"] = logicalCwd
+
+      os.environ["GITDIST_MOVE_TO_BASE_DIR"] = "EXTREME_BASE"
+      cmndOut = GeneralScriptSupport.getCmndOutput(gitdistPathMock+" status")
+      cmndOut_expected = \
+        "\n*** Base Git Repo: MockProjectDir\n" \
+        "['mockgit', '-c', 'color.status=never', 'status']\n\n" \
+        "*** Git Repo: ExtraRepo\n" \
+        "['mockgit', '-c', 'color.status=never', 'status']\n\n" \
+        "*** Git Repo: ExtraRepo/NestedRepo\n" \
+        "['mockgit', '-c', 'color.status=never', 'status']\n\n"
+      self.assertEqual(s(cmndOut), s(cmndOut_expected))
+
+    finally:
+      os.chdir(testBaseDir)
+
+
+  def test_gitdist_move_to_base_dir_inside_git_repo_below_nonbase_gitdist(self):
+    os.chdir(testBaseDir)
+    try:
+
+      # Create a mock git repo with an intermediate .gitdist that does not
+      # describe the current base repo.  IMMEDIATE_BASE should keep walking up
+      # to the git repo root and use the .gitdist file there.
+      testDir = createAndMoveIntoTestDir(
+        "gitdist_move_to_base_dir_inside_git_repo_below_nonbase_gitdist")
+      os.makedirs(".git")
+      os.makedirs("ExtraRepo")
+      os.makedirs("path/to/intermediate/working/dir")
+      with open(".gitdist", "w") as fileHandle:
+        fileHandle.write(
+          ".\n" \
+          "ExtraRepo\n"
+          )
+      with open("path/to/intermediate/.gitdist", "w") as fileHandle:
+        fileHandle.write(
+          "SomeOtherRepo\n"
+          )
+      os.chdir("path/to/intermediate/working/dir")
+
+      os.environ["GITDIST_MOVE_TO_BASE_DIR"] = "IMMEDIATE_BASE"
+      cmndOut = GeneralScriptSupport.getCmndOutput(gitdistPathMock+" status")
+      cmndOut_expected = \
+        "\n*** Base Git Repo: MockProjectDir\n" \
+        "['mockgit', '-c', 'color.status=never', 'status']\n\n" \
+        "*** Git Repo: ExtraRepo\n" \
+        "['mockgit', '-c', 'color.status=never', 'status']\n\n"
+      self.assertEqual(s(cmndOut), s(cmndOut_expected))
+
     finally:
       os.chdir(testBaseDir)
 

--- a/tribits/devtools_install/install-cmake.py
+++ b/tribits/devtools_install/install-cmake.py
@@ -155,7 +155,7 @@ argument '--cmake-version=master'.
     createDir(self.cmakeBuildBaseDir, True, True)
 
     # Look for an already installed CMake
-    if self.inOptions.cmakeNativeConfig is not "off":
+    if self.inOptions.cmakeNativeConfig != "off":
       cmakeCmd = self.which("cmake")
     else:
       # Configuring NOT with CMake was explicitly requested
@@ -176,7 +176,7 @@ argument '--cmake-version=master'.
         " -DCMAKE_INSTALL_PREFIX="+self.inOptions.installDir
         )
 
-    elif self.inOptions.cmakeNativeConfig is "on":
+    elif self.inOptions.cmakeNativeConfig == "on":
       # Configuring CMake with CMake was explicitly requested but
       # the CMake executable was not found in PATH
       raise Exception("Could not find 'cmake' in PATH and --use-native-cmake-config=on!")

--- a/tribits/python_utils/gitdist.py
+++ b/tribits/python_utils/gitdist.py
@@ -583,25 +583,28 @@ treat the current directory as the base git repository (as if there was a
 usual.  You have the ability to change this behavior by setting the
 GITDIST_MOVE_TO_BASE_DIR environment variable.
 
-To describe the behavior for the differ net options, consider the following set
+To describe the behavior for the different options, consider the following set
 of nested git repositories and directories:
 
     BaseRepo/
       .git
-      .gitdist
+      .gitdist   # contains ".", "ExtraRepo", and "ExtraRepo/NestedRepo"
       ...
       ExtraRepo/
         .git
-        .gitdist
+        .gitdist # contains "." and "NestedRepo"
         ...
-        path/
+        NestedRepo/
+          .git
           ...
-          to/
+          path/
             ...
-            some/
+            to/
               ...
-              directory/
+              some/
                 ...
+                directory/
+                  ...
 
 
 The valid settings for GITDIST_MOVE_TO_BASE_DIR include:
@@ -615,17 +618,23 @@ The valid settings for GITDIST_MOVE_TO_BASE_DIR include:
 
     In this case, gitdist will start moving up the directory tree until it
     finds a .gitdist[.default] file, and then run in the directory where it
-    finds it.  In the above example, if you are in
-    BaseRepo/ExtraRepo/path/to/some/directory/ when you run gitdist, it will
-    move up to ExtraRepo to execute the command you give it from there.
+    finds it.  If you are under a nested git repo before gitdist finds that
+    file, then the .gitdist[.default] file must list that nested git repo.
+    In the above example, if you are in
+    BaseRepo/ExtraRepo/NestedRepo/path/to/some/directory/ when you run
+    gitdist, it will move up to ExtraRepo to execute the command you give it
+    from there because ExtraRepo/.gitdist lists "NestedRepo".
 
   EXTREME_BASE:
 
     In this case, gitdist will continue moving up the directory tree until it
-    finds the outer-most repository containing a .gitdist[.default] file, and
-    then run in that directory.  Given the directory tree above, if you were
-    in BaseRepo/ExtraRepo/path/to/some/directory, it will move up to BaseRepo
-    to execute the command you give it.
+    finds the upstream-most .gitdist[.default] file that lists the nested git
+    repo you are currently under.  Given the directory tree above, if you were
+    in BaseRepo/ExtraRepo/NestedRepo/path/to/some/directory, gitdist would
+    move up to BaseRepo because BaseRepo/.gitdist lists
+    "ExtraRepo/NestedRepo".  If an outer directory has a .gitdist[.default]
+    file but that file does not list the nested git repo path, gitdist ignores
+    that outer file instead of crossing into an unrelated outer meta-project.
 
 With either of the settings above, when gitdist is finished running, it will
 leave you in the same directory you were in when you executed command in the
@@ -1143,6 +1152,85 @@ def parseGitdistFile(gitdistfile):
   return (reposFullList, defaultBranchDict)
 
 
+def getGitdistFileForDir(dirPath):
+  gitdistFile = os.path.join(dirPath, ".gitdist")
+  if os.path.isfile(gitdistFile):
+    return gitdistFile
+  gitdistDefaultFile = os.path.join(dirPath, ".gitdist.default")
+  if os.path.isfile(gitdistDefaultFile):
+    return gitdistDefaultFile
+  return None
+
+
+def dirContainsGitRepo(dirPath):
+  return os.path.exists(os.path.join(dirPath, ".git"))
+
+
+def gitdistFileListsRepo(gitdistFile, repoPath):
+  reposFullList, defaultBranchDict = parseGitdistFile(gitdistFile)
+  return repoPath in reposFullList
+
+
+def getLogicalCurrentWorkingDir():
+  pwd = os.environ.get("PWD")
+  if pwd:
+    try:
+      if os.path.samefile(pwd, os.getcwd()):
+        return pwd
+    except OSError:
+      pass
+  return os.getcwd()
+
+
+def getEnclosingGitRepoDirFromPath(currentPath):
+  while 1:
+    if dirContainsGitRepo(currentPath):
+      return currentPath
+    gitdistFile = getGitdistFileForDir(currentPath)
+    if gitdistFile and gitdistFileListsRepo(gitdistFile, "."):
+      return None
+    parentPath, currentDir = os.path.split(currentPath)
+    if currentDir == "":
+      return None
+    currentPath = parentPath
+
+
+def gitdistFileAppliesToRepo(gitdistFile, gitdistDir, enclosingGitRepoDir):
+  if not enclosingGitRepoDir:
+    return True
+  repoPath = os.path.relpath(enclosingGitRepoDir, gitdistDir)
+  return gitdistFileListsRepo(gitdistFile, repoPath)
+
+
+def getBaseDirFromPath(currentPath, findExtremeBase):
+  enclosingGitRepoDir = getEnclosingGitRepoDirFromPath(currentPath)
+  foundBaseDir = None
+
+  while 1:
+    gitdistFile = getGitdistFileForDir(currentPath)
+    if gitdistFile and gitdistFileAppliesToRepo(gitdistFile, currentPath,
+      enclosingGitRepoDir):
+      foundBaseDir = currentPath
+      if not enclosingGitRepoDir:
+        enclosingGitRepoDir = currentPath
+      if not findExtremeBase:
+        break
+    parentPath, currentDir = os.path.split(currentPath)
+    if currentDir == "":
+      break
+    currentPath = parentPath
+
+  return foundBaseDir
+
+
+def getImmediateBaseDirFromPath(currentPath):
+  return getBaseDirFromPath(currentPath, False)
+
+
+def getExtremeBaseDirFromPath(currentPath):
+  return getBaseDirFromPath(currentPath, True)
+
+
 # Get the commandline options
 def getCommandlineOps():
 
@@ -1371,38 +1459,14 @@ def getCommandlineOps():
     None
   elif moveToBaseDir == "EXTREME_BASE":
     # Run gitdist in the most base dir where .gitdist[.default] exists
-    drive, currentPath = os.path.splitdrive(os.getcwd())
-    pathList = []
-    while 1:
-      currentPath, currentDir = os.path.split(currentPath)
-      if currentDir != "":
-        pathList.append(currentDir)
-      else:
-        if currentPath != "":
-          pathList.append(currentPath)
-        break
-    pathList.reverse()
-    newPath = drive+pathList[0]
-    for directory in pathList:
-      newPath = os.path.join(newPath, directory)
-      if ((os.path.isfile(os.path.join(newPath, ".gitdist"))) or
-        (os.path.isfile(os.path.join(newPath, ".gitdist.default")))):
-        break
-    os.chdir(newPath)
+    newPath = getExtremeBaseDirFromPath(getLogicalCurrentWorkingDir())
+    if newPath:
+      os.chdir(newPath)
   elif moveToBaseDir == "IMMEDIATE_BASE":
     # Run gitdist in the immediate base dir where .gitdist[.default] exists
-    currentPath = os.getcwd()
-    foundIt = False
-    while 1:
-      if ((os.path.isfile(os.path.join(currentPath, ".gitdist"))) or
-        (os.path.isfile(os.path.join(currentPath, ".gitdist.default")))):
-        foundIt = True
-        break
-      currentPath, currentDir = os.path.split(currentPath)
-      if currentDir == "":
-        break
-    if foundIt:
-      os.chdir(currentPath)
+    newPath = getImmediateBaseDirFromPath(getLogicalCurrentWorkingDir())
+    if newPath:
+      os.chdir(newPath)
   else:
     print(
       "Error, env var GITDIST_MOVE_TO_BASE_DIR='"+moveToBaseDir+"' is invalid!"


### PR DESCRIPTION
Was getting warning about unsupported operations

And I was getting local failures of the gitdist unit tests due to bad logic related to GITDIST_MOVE_TO_BASE_DIR.