### PR TITLE
Add support for setting LLVM_PROFILE_FILE unique for each test

### DIFF
--- a/dev_testing/clang/mpi_debug/do-configure
+++ b/dev_testing/clang/mpi_debug/do-configure
@@ -1,0 +1,22 @@
+#!/bin/bash
+if [[ -e CMakeCache.txt ]] ; then
+  rm  CMakeCache.txt
+fi
+if [[ -d CMakeFiles ]] ; then
+  rm -r CMakeFiles
+fi  
+cmake \
+-G Ninja \
+-D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+-D CTEST_BUILD_NAME=clang-$(clang++ --version | head -1 | cut -d ' ' -f 3)-mpich-$(mpirun --version | head -1 | cut -d ' ' -f 4)-$(git branch --show-current) \
+-D TriBITS_ENABLE_Fortran=OFF \
+-D CMAKE_C_COMPILER=$(which mpicc) \
+-D CMAKE_CXX_COMPILER=$(which mpicxx) \
+-D CTEST_BUILD_FLAGS=-j$(nproc) \
+-D CTEST_PARALLEL_LEVEL=$(nproc) \
+"$@" \
+../..
+
+
+#-D CMAKE_Fortran_COMPILER=$(which mpif90) \
+#-D CMAKE_Fortran_FLAGS="-fPIE" \

--- a/dev_testing/clang/mpi_debug/do-configure-mycdash
+++ b/dev_testing/clang/mpi_debug/do-configure-mycdash
@@ -1,0 +1,8 @@
+#!/bin/bash
+./do-configure \
+-DCTEST_SITE=$(cat /etc/hostname) \
+-DCTEST_DROP_SITE="my.cdash.org" \
+-DCTEST_PROJECT_NAME="TriBITS" \
+-DCTEST_DROP_LOCATION="/submit.php?project=TriBITS" \
+-DTRIBITS_2ND_CTEST_DROP_SITE="" \
+"$@"

--- a/dev_testing/clang/mpi_debug/load-env.sh
+++ b/dev_testing/clang/mpi_debug/load-env.sh
@@ -1,0 +1,8 @@
+# Simple build and test with no coverage or anything
+# Make sure that the clang env is loaded if not already
+if [[ -e /home/runner/.bashrc ]] ; then
+  source /home/runner/.bashrc
+fi
+export OMPI_CC=$(which clang)
+export OMPI_CXX=$(which clang++)
+#export OMPI_FC=$(which gfortran)

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -49,7 +49,7 @@ tribits_add_advanced_test( TestingFunctionMacro_UnitTests
       -D${PROJECT_NAME}_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
       -P "${CMAKE_CURRENT_SOURCE_DIR}/TestingFunctionMacro_UnitTests.cmake"
     PASS_REGULAR_EXPRESSION_ALL
-      "Final UnitTests Result: num_run = 724"
+      "Final UnitTests Result: num_run = 726"
       "Final UnitTests Result: PASSED"
   )
 
@@ -62,7 +62,7 @@ tribits_add_advanced_test( CompilerOptions_UnitTests
       -D${PROJECT_NAME}_TRIBITS_DIR=${${PROJECT_NAME}_TRIBITS_DIR}
       -P "${CMAKE_CURRENT_SOURCE_DIR}/CompilerOptions_UnitTests.cmake"
     PASS_REGULAR_EXPRESSION_ALL
-      "Final UnitTests Result: num_run = 207"
+      "Final UnitTests Result: num_run = 208"
       "Final UnitTests Result: PASSED"
   )
 

--- a/test/core/CompilerOptions_UnitTests.cmake
+++ b/test/core/CompilerOptions_UnitTests.cmake
@@ -374,6 +374,26 @@ function(unitest_gcc_with_coverage_options)
 endfunction()
 
 
+function(unitest_enable_coverage_and_llvm_coverage_error)
+
+  message("\n***")
+  message("*** Testing error for enabling GCov and LLVM coverage together")
+  message("***\n")
+
+  tribits_set_all_compiler_id(GNU)
+  set(${PROJECT_NAME}_ENABLE_COVERAGE_TESTING ON)
+  set(${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING ON)
+  set(MESSAGE_WRAPPER_UNIT_TEST_MODE TRUE)
+  global_set(MESSAGE_WRAPPER_INPUT)
+
+  tribits_setup_basic_compile_link_flags()
+
+  unittest_compare_const(MESSAGE_WRAPPER_INPUT
+    "FATAL_ERROR;Error, ${PROJECT_NAME}_ENABLE_COVERAGE_TESTING=ON and; ${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING=ON are not allowed; at the same time.  Enable only one coverage testing mode.")
+
+endfunction()
+
+
 function(unitest_gcc_with_checked_stl_options)
 
   message("\n***")
@@ -821,6 +841,7 @@ set(${PROJECT_NAME}_ENABLE_STRONG_Fortran_COMPILE_WARNINGS TRUE)
 set(${PROJECT_NAME}_WARNINGS_AS_ERRORS_FLAGS "--warnings_as_errors_placeholder")
 set(${PROJECT_NAME}_ENABLE_SHADOW_WARNINGS "")
 set(${PROJECT_NAME}_ENABLE_COVERAGE_TESTING OFF)
+set(${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING OFF)
 set(${PROJECT_NAME}_ENABLE_CHECKED_STL OFF)
 set(${PROJECT_NAME}_ENABLE_DEBUG_SYMBOLS OFF)
 set(${PROJECT_NAME}_VERBOSE_CONFIGURE TRUE)
@@ -839,6 +860,7 @@ unitest_gcc_with_shadow_options()
 unitest_gcc_global_enable_shadow_options()
 unitest_gcc_global_disable_shadow_options()
 unitest_gcc_with_coverage_options()
+unitest_enable_coverage_and_llvm_coverage_error()
 unitest_gcc_with_checked_stl_options()
 unitest_gcc_with_cleaned_options()
 unitest_gcc_no_strong_warnings_options()
@@ -855,4 +877,4 @@ unitest_other_base_options()
 unitest_other_with_shadow_cleaned_checked_stl_coverage_options()
 
 # Pass in the number of expected tests that must pass!
-unittest_final_result(207)
+unittest_final_result(208)

--- a/test/core/TestingFunctionMacro_UnitTests.cmake
+++ b/test/core/TestingFunctionMacro_UnitTests.cmake
@@ -2482,6 +2482,13 @@ function(unittest_tribits_add_test_properties)
   unittest_has_substr_const(TRIBITS_SET_TEST_PROPERTIES_INPUT
     "PackageA_SomeExec;PROPERTY;ENVIRONMENT;var1=val1;var2=val2")
 
+  message("Test setting LLVM_PROFILE_FILE")
+  set(${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING ON)
+  tribits_add_test(${EXEN})
+  unittest_has_substr_const(TRIBITS_SET_TEST_PROPERTIES_INPUT
+    "PackageA_SomeExec;APPEND;PROPERTY;ENVIRONMENT;LLVM_PROFILE_FILE=${CMAKE_CURRENT_BINARY_DIR}/PackageA_SomeExec_%p.profraw")
+  set(${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING OFF)
+
   set(TRIBITS_SET_TEST_PROPERTIES_CAPTURE_INPUT OFF)
 
 endfunction()
@@ -3784,6 +3791,15 @@ function(unittest_tribits_add_advanced_test_properties)
   unittest_has_substr_const(TRIBITS_SET_TEST_PROPERTIES_INPUT
     "PackageA_TAAT_basic_cmnd_1_args_0;PROPERTY;ENVIRONMENT;var1=val1;var2=val2")
 
+  message("Test setting LLVM_PROFILE_FILE")
+  set(${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING ON)
+  tribits_add_advanced_test_unittest_reset()
+  tribits_add_advanced_test( TAAT_basic_cmnd_1_args_0
+    TEST_0 CMND ${CMNDN} )
+  unittest_has_substr_const(TRIBITS_SET_TEST_PROPERTIES_INPUT
+    "PackageA_TAAT_basic_cmnd_1_args_0;APPEND;PROPERTY;ENVIRONMENT;LLVM_PROFILE_FILE=${CMAKE_CURRENT_BINARY_DIR}/PackageA_TAAT_basic_cmnd_1_args_0_%p.profraw")
+  set(${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING OFF)
+
   set(TRIBITS_SET_TEST_PROPERTIES_CAPTURE_INPUT OFF)
   set(TRIBITS_ADD_ADVANCED_TEST_SKIP_SCRIPT OFF)
 
@@ -4898,4 +4914,4 @@ message("*** Determine final result of all unit tests")
 message("***\n")
 
 # Pass in the number of expected tests that must pass!
-unittest_final_result(724)
+unittest_final_result(726)

--- a/tribits/core/package_arch/TribitsGlobalMacros.cmake
+++ b/tribits/core/package_arch/TribitsGlobalMacros.cmake
@@ -771,6 +771,17 @@ macro(tribits_define_global_options_and_define_extra_repos)
   advanced_set( ${PROJECT_NAME}_ENABLE_COVERAGE_TESTING OFF
     CACHE BOOL "Enable support for coverage testing by setting needed compiler/linker options." )
 
+  if ("${${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING_DEFAULT}" STREQUAL "")
+    if ("${CTEST_TEST_COVERAGE_TOOL}" STREQUAL "LLVM-COV")
+      set(${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING_DEFAULT ON)
+    else()
+      set(${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING_DEFAULT OFF)
+    endif()
+  endif()
+  advanced_set( ${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING
+    ${${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING_DEFAULT}
+    CACHE BOOL "Set LLVM_PROFILE_FILE for every TriBITS-added CTest test to a unique per-test .profraw file.  Defaults to ON for LLVM source-based coverage builds." )
+
   advanced_set( ${PROJECT_NAME}_ENABLE_CHECKED_STL OFF
     CACHE BOOL "Turn on checked STL checking (e.g. -D_GLIBCXX_DEBUG) or not." )
 

--- a/tribits/core/package_arch/TribitsSetupBasicCompileLinkFlags.cmake
+++ b/tribits/core/package_arch/TribitsSetupBasicCompileLinkFlags.cmake
@@ -9,6 +9,7 @@
 
 include(TribitsDefineStandardCompileVars)
 include(DualScopePrependCmndlineArgs)
+include(MessageWrapper)
 include(PrintVar)
 
 #
@@ -121,6 +122,17 @@ function(tribits_setup_basic_compile_link_flags)
   #
   # Set up coverage testing options
   #
+
+  assert_defined(${PROJECT_NAME}_ENABLE_COVERAGE_TESTING)
+  assert_defined(${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING)
+  if (${PROJECT_NAME}_ENABLE_COVERAGE_TESTING
+      AND ${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING)
+    message_wrapper(FATAL_ERROR
+      "Error, ${PROJECT_NAME}_ENABLE_COVERAGE_TESTING=ON and"
+      " ${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING=ON are not allowed"
+      " at the same time.  Enable only one coverage testing mode.")
+    return()
+  endif()
 
   if (${PROJECT_NAME}_ENABLE_COVERAGE_TESTING)
     set(COVERAGE_OPTIONS "-fprofile-arcs -ftest-coverage")

--- a/tribits/core/test_support/TribitsAddAdvancedTest.cmake
+++ b/tribits/core/test_support/TribitsAddAdvancedTest.cmake
@@ -1478,6 +1478,8 @@ function(tribits_add_advanced_test TEST_NAME_IN)
 
     tribits_private_add_test_set_environment(${TEST_NAME})
 
+    tribits_private_add_test_set_llvm_profile_file_environment(${TEST_NAME})
+
     if (TPL_ENABLE_MPI AND HAS_AT_LEAST_ONE_EXEC)
       set(MAX_NUM_MPI_PROCS_USED_TO_PRINT  ${MAX_NUM_MPI_PROCS_USED})
     else()

--- a/tribits/core/test_support/TribitsAddTestHelpers.cmake
+++ b/tribits/core/test_support/TribitsAddTestHelpers.cmake
@@ -729,6 +729,19 @@ endfunction()
 
 
 #
+# Set a unique LLVM_PROFILE_FILE var for the test 
+#
+function(tribits_private_add_test_set_llvm_profile_file_environment  TEST_NAME_IN)
+
+  if (${PROJECT_NAME}_ENABLE_LLVM_COVERAGE_TESTING)
+    tribits_set_test_property(${TEST_NAME_IN} APPEND PROPERTY ENVIRONMENT
+      "LLVM_PROFILE_FILE=${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME_IN}_%p.profraw")
+  endif()
+
+endfunction()
+
+
+#
 # Set the environment for a test already added
 #
 function(tribits_private_add_test_set_environment  TEST_NAME_IN)
@@ -880,6 +893,8 @@ function(tribits_private_add_test_post_process_added_test  TEST_NAME_IN
      ${NUM_PROCS_USED_IN})
 
   tribits_private_add_test_add_label_and_keywords(${TEST_NAME_IN})
+
+  tribits_private_add_test_set_llvm_profile_file_environment(${TEST_NAME_IN})
 
   tribits_private_add_test_print_added(${TEST_NAME_IN}
     "${CATEGORIES_IN}"  "${NUM_PROCS_USED_IN}"  "${PROCESSORS_USED}"

--- a/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
+++ b/tribits/doc/build_ref/TribitsBuildReferenceBody.rst
@@ -2693,12 +2693,76 @@ NOTES:
 Enabling support for coverage testing
 -------------------------------------
 
-To turn on support for coverage testing set::
+TriBITS supports two coverage-testing workflows:
 
-  -D <Project>_ENABLE_COVERAGE_TESTING=ON 
+* Classic GCC GCov coverage, enabled with ``<Project>_ENABLE_COVERAGE_TESTING``;
+* Newer LLVM source-based coverage, supported through
+  ``<Project>_ENABLE_LLVM_COVERAGE_TESTING`` and explicit LLVM compiler flags.
 
-This will set compile and link options -fprofile-arcs -ftest-coverage for GCC.
-Use 'make dashboard' (see below) to submit coverage results to CDash
+Only one of these TriBITS coverage modes may be enabled at a time.  Configuring
+with both ``<Project>_ENABLE_COVERAGE_TESTING=ON`` and
+``<Project>_ENABLE_LLVM_COVERAGE_TESTING=ON`` is an error.
+
+
+Enabling classic GCC GCov coverage testing
+++++++++++++++++++++++++++++++++++++++++++
+
+To turn on support for classic GCC GCov coverage testing set::
+
+  -D <Project>_ENABLE_COVERAGE_TESTING=ON
+
+This will set compile and link options ``-fprofile-arcs -ftest-coverage`` for
+GCC.  Use 'make dashboard' (see below) to submit coverage results to CDash.
+
+WARNING: TriBITS support for automatically setting compiler options like this is
+deprecated.
+
+
+Enabling LLVM source-based coverage testing
++++++++++++++++++++++++++++++++++++++++++++
+
+For LLVM source-based coverage builds, the C and C++ code must be compiled
+with the LLVM instrumentation options ``-fprofile-instr-generate`` and
+``-fcoverage-mapping``.  For example, configure with::
+
+  -D CMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
+  -D CMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" \
+  -D <Project>_ENABLE_LLVM_COVERAGE_TESTING=ON
+
+Some platforms may also need to link shared libraries with the LLVM linker by
+configuring with::
+
+  -D CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld"
+
+The option ``<Project>_ENABLE_LLVM_COVERAGE_TESTING`` causes TriBITS to set a
+unique ``LLVM_PROFILE_FILE`` environment variable for every TriBITS-added CTest
+test.  This option can be set explicitly with::
+
+  -D <Project>_ENABLE_LLVM_COVERAGE_TESTING=ON
+
+This option defaults to ``ON`` when ``CTEST_TEST_COVERAGE_TOOL`` is set to
+``LLVM-COV`` and defaults to ``OFF`` otherwise.  When enabled, TriBITS sets the
+per-test environment variable to a path in that test's binary directory with
+the full test name and LLVM's ``%p`` process-id pattern in the filename, such
+as::
+
+  LLVM_PROFILE_FILE=<test-binary-dir>/<fullTestName>_%p.profraw
+
+This is useful when running LLVM-instrumented tests in parallel with commands
+like ``ctest -j<N>``.  Without a unique ``LLVM_PROFILE_FILE`` value, multiple
+tests or test processes may write to the same default raw profile file.  With
+this option enabled, each test gets distinct ``*.profraw`` files that can be
+merged into ``*.profdata`` files for later use with ``llvm-cov``.
+
+NOTE: TriBITS sets the per-test environment variable but does not clean up old
+LLVM coverage output.  Before running the tests again, manually remove any
+stale ``*.profdata`` files that would otherwise be reused or confused with
+the new coverage results.
+
+CMake/CTest are expected to eventually add native support for
+``CTEST_TEST_COVERAGE_TOOL=LLVM-COV``.  Once that support is available in a
+new-enough CMake/CTest version, TriBITS will automatically adjust to use the
+native CMake/CTest LLVM coverage support.
 
 
 Viewing configure options and documentation
@@ -4407,14 +4471,20 @@ and submit to CDash as described below.  But to take full advantage of the
 all-at-once mode and to have results displayed on CDash broken down
 package-by-package, one must be submitting to a newer CDash version 3.0+.
 
-For submitting line coverage results, configure with::
+For submitting classic GCC GCov line coverage results, configure with::
 
   -D<Project>_ENABLE_COVERAGE_TESTING=ON
 
 and the environment variable ``CTEST_DO_COVERAGE_TESTING=TRUE`` is
 automatically set by the target ``dashboard`` so you don't have to set this
 yourself.  Then, when you run the ``dashboard`` target, it will automatically
-submit coverage results to CDash as well.
+submit coverage results to CDash as well.  For more details on available
+coverage modes, see `Enabling support for coverage testing`_.
+
+NOTE: A future version of CMake/CTest/CDash will provide native support for the
+newer LLVM source-based coverage mentioned above (see
+``<Project>_ENABLE_LLVM_COVERAGE_TESTING`` above).  Until then, coverage results
+using LLVM source-based coverage cannot be submitted to a CDash project.
 
 Doing memory checking running the enabled tests with Valgrind requires that
 you set ``CTEST_DO_MEMORY_TESTING=TRUE`` with the ``env`` command when running


### PR DESCRIPTION
This will allow running the tests in parallel but be able to access per-test coverage info.  This sets the env var for each test:

```text
export LLVM_PROFILE_FILE=<test-binary-dir>/<fullTestName>_%p.profraw
```

This matches what is being done in:

* https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11891

but this works with any version of CMake/CTest.

See updated documentation.
